### PR TITLE
Add policycoreutils-native to DEPENDS for all images inheriting from the...

### DIFF
--- a/xenclient/classes/selinux-image.bbclass
+++ b/xenclient/classes/selinux-image.bbclass
@@ -1,3 +1,4 @@
+DEPENDS += "policycoreutils-native"
 IMAGE_INSTALL += " \
     libselinux-bin \
     policycoreutils-loadpolicy \


### PR DESCRIPTION
... selinux-image class.

The refpolicy package already causes this to be built and installed
in in the build sysroot. The selinux-image class depends on semodule
and setfiles though so best to have an explicit dependency.
