### PR TITLE
refpolicy: explicitly use .git extension for repository

### DIFF
--- a/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
+++ b/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
@@ -2,7 +2,7 @@ FILESEXTRA := "${THISDIR}/${PN}"
 FILESEXTRAPATHS_prepend := "${FILESEXTRA}:"
 
 SRC_URI += " \
-	   ${OPENXT_GIT_MIRROR}/refpolicy-xt-pq;protocol=git;tag=${OPENXT_TAG} \
+	   ${OPENXT_GIT_MIRROR}/refpolicy-xt-pq.git;protocol=git;tag=${OPENXT_TAG} \
 	   ${OPENXT_GIT_MIRROR}/selinux-policy.git;protocol=git;tag=${OPENXT_TAG} \
 	   file://config \
 "


### PR DESCRIPTION
Make the SRC_URI format consistent for all OpenXT git repos:  refpolicy-xt-pq should be refpolicy-xt-pq.git.
