### PR TITLE
Refpolicy fix

### DIFF
--- a/xenclient/recipes/curl/curl_7.24.0.bbappend
+++ b/xenclient/recipes/curl/curl_7.24.0.bbappend
@@ -1,0 +1,2 @@
+DEPENDS_virtclass-native += "gnutls"
+CURLGNUTLS_virtclass-native = ""

--- a/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
+++ b/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
@@ -49,7 +49,7 @@ sysroot_stage_all_append () {
 }
 
 pkg_postinst_${PN} () {
-	/sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
+	/sbin/setfiles ${STAGING_DIR_HOST}/etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
 }
 
 pkg_postinst_${PN}_xenclient-ndvm () {


### PR DESCRIPTION
2 fixes:

Added gnutls to CURL native for https git URLs.

Fixed path in refpolicy-mcs postinst script for setfiles command.  file_contexts resides in /etc/selinux/xc_policy/contexts/files in the image staging directory, not on the build machine filesystem.
