### PR TITLE
refpolicy-mcs: fix path for file_contexts to point to image staging dir

### DIFF
--- a/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
+++ b/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
@@ -49,19 +49,13 @@ sysroot_stage_all_append () {
 }
 
 pkg_postinst_${PN} () {
-	if [ -n  "$D" ]; then
-		/sbin/setfiles ${D}/etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
-	else
+    if [ -z "$D" ]; then
 		/sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
-	fi
-}
-
-pkg_postinst_${PN}_xenclient-ndvm () {
-    if [ -z "$D" ];then
-        /sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
     fi
 }
 
 pkg_postinst_${PN}_append_xenclient-dom0 () {
-	/sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /config /storage
+    if [ -z "$D" ]; then
+		/sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /config /storage
+	fi
 }


### PR DESCRIPTION
file_contexts was referenced as an absolute path on the build machine, rather than pointing to the image staging directory
