### PR TITLE
ifplugd: fix SRC_URI for abandoned/unmaintained package

### DIFF
--- a/xenclient/recipes/ifplugd/ifplugd_0.28.bb
+++ b/xenclient/recipes/ifplugd/ifplugd_0.28.bb
@@ -12,7 +12,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 PR = "r1"
 
-SRC_URI = "http://0pointer.de/lennart/projects/ifplugd/ifplugd-${PV}.tar.gz \
+SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/ifplugd/ifplugd-0.28.tar.gz/df6f4bab52f46ffd6eb1f5912d4ccee3/ifplugd-0.28.tar.gz \
            file://kernel-types.patch \
            file://nobash.patch \
            file://ifplugd.conf"


### PR DESCRIPTION
Pull from pkgs.fedoraproject.org and and hardcoded the PV, since I'm guessing there will be no more updated versions...

This may be a good example of something that should be included in the OPENXT_MIRROR bits?
