### PR TITLE
ghc: fix SRC_URI with new hackage.haskell.org package url format

### DIFF
--- a/xenclient/recipes/ghc-libs/ghc-lib-common.inc
+++ b/xenclient/recipes/ghc-libs/ghc-lib-common.inc
@@ -1,7 +1,7 @@
 require recipes/ghc/ghc-pkg.inc
 
 GHC_PN  = "${PN}"
-SRC_URI = "http://hackage.haskell.org/packages/archive/${GHC_PN}/${PV}/${GHC_PN}-${PV}.tar.gz"
+SRC_URI = "http://hackage.haskell.org/package/${GHC_PN}-${PV}/${GHC_PN}-${PV}.tar.gz"
 S       = "${WORKDIR}/${GHC_PN}-${PV}"
 PR      = "r6"
 


### PR DESCRIPTION
Hackage seems to have re-organized their source URLs, and the fetch process does not appear to follow the 301 (at least on my build system).
