### PR TITLE
Location of selinux packages changed

### DIFF
--- a/xenclient/recipes/selinux/checkpolicy_2.1.12.bbappend
+++ b/xenclient/recipes/selinux/checkpolicy_2.1.12.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/${SELINUX_RELEASE}/${BPN}-${PV}.tar.gz"

--- a/xenclient/recipes/selinux/libselinux_2.1.13.bbappend
+++ b/xenclient/recipes/selinux/libselinux_2.1.13.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/${SELINUX_RELEASE}/${BPN}-${PV}.tar.gz"

--- a/xenclient/recipes/selinux/libsemanage_2.1.10.bbappend
+++ b/xenclient/recipes/selinux/libsemanage_2.1.10.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/${SELINUX_RELEASE}/${BPN}-${PV}.tar.gz"

--- a/xenclient/recipes/selinux/libsepol_2.1.9.bbappend
+++ b/xenclient/recipes/selinux/libsepol_2.1.9.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/${SELINUX_RELEASE}/${BPN}-${PV}.tar.gz"

--- a/xenclient/recipes/selinux/policycoreutils_2.1.14.bbappend
+++ b/xenclient/recipes/selinux/policycoreutils_2.1.14.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/${SELINUX_RELEASE}/${BPN}-${PV}.tar.gz"

--- a/xenclient/recipes/selinux/sepolgen_1.1.9.bbappend
+++ b/xenclient/recipes/selinux/sepolgen_1.1.9.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/${SELINUX_RELEASE}/${BPN}-${PV}.tar.gz"


### PR DESCRIPTION
Userland packages moved from:
http://userspace.selinuxproject.org/releases/
to:
https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/
