### PR TITLE
ifplugd: Use OPENXT_MIRROR instead of fedora.org.

### DIFF
--- a/xenclient/recipes/ifplugd/ifplugd_0.28.bb
+++ b/xenclient/recipes/ifplugd/ifplugd_0.28.bb
@@ -12,7 +12,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 PR = "r1"
 
-SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/ifplugd/ifplugd-0.28.tar.gz/df6f4bab52f46ffd6eb1f5912d4ccee3/ifplugd-0.28.tar.gz \
+SRC_URI = "${OPENXT_MIRROR}/ifplugd-0.28.tar.gz \
            file://kernel-types.patch \
            file://nobash.patch \
            file://ifplugd.conf"


### PR DESCRIPTION
Consensus from https://github.com/OpenXT/xenclient-oe/pull/12
seems to be that using our own mirror is the right thing to do here.
