### PR TITLE
curl-native: add https support to curl-native

### DIFF
--- a/xenclient/recipes/curl/curl_7.24.0.bbappend
+++ b/xenclient/recipes/curl/curl_7.24.0.bbappend
@@ -1,0 +1,2 @@
+DEPENDS_virtclass-native += "gnutls-native"
+CURLGNUTLS_virtclass-native = " --with-gnutls=${STAGING_LIBDIR}/"


### PR DESCRIPTION
Add dependency to gnutls-native and added libdir for gnutls to build for curl-native to allow https fetch urls.
