### PR TITLE
[OXT-6] pseudo-xattr-support: remove invalid UNIQUE constraint

### DIFF
--- a/xenclient/recipes/pseudo/pseudo/pseudo-xattr-support.patch
+++ b/xenclient/recipes/pseudo/pseudo/pseudo-xattr-support.patch
@@ -676,10 +676,10 @@ index 4a30420..5385fca 100644
  		break;
  	default:
 diff --git a/pseudo_db.c b/pseudo_db.c
-index 540a3c2..83a9cde 100644
+index 540a3c2..f17c827 100644
 --- a/pseudo_db.c
 +++ b/pseudo_db.c
-@@ -81,6 +81,18 @@ static struct sql_table {
+@@ -81,6 +81,17 @@ static struct sql_table {
  	    "rdev INTEGER",
  	  NULL,
  	  NULL },
@@ -690,15 +690,14 @@ index 540a3c2..83a9cde 100644
 +	     "dev INTEGER, "
 +		 "xattrname VARCHAR, "
 +		 "xattrvalue VARCHAR, "
-+		 "UNIQUE (ino, dev, xattrname), "
-+		 "UNIQUE (path, xattrname)",
++		 "UNIQUE (ino, dev, xattrname)",
 +	   NULL,
 +	   NULL },
 +
  	{ NULL, NULL, NULL, NULL },
  }, log_tables[] = {
  	{ "logs",
-@@ -1250,6 +1262,209 @@ log_entry_free(log_entry *e) {
+@@ -1250,6 +1261,209 @@ log_entry_free(log_entry *e) {
  	free(e);
  }
  


### PR DESCRIPTION
This addresses an issue where an incremental rebuild of the dom0 or
ndvm images will create an image with incorrect/missing selinux labels.

When rebuilding an image, the method used in the pseudo-xattr-support
patch tracks via dev+inode+xattrname.  But there is a UNIQUE constraint
"UNIQUE (path, xattrname)", which is invalid when a file is overwritten
because the inode changes. The other constraint,
"UNIQUE (ino, dev, xattrname)" is sufficient.

OXT-6

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
