### PR TITLE
[OXT-19] tboot: measure all command line arguments (CVE-2014-5118)

### DIFF
--- a/xenclient/recipes/tboot/tboot-1.7.0/tboot-1.7.0-CVE-2014-5118.patch
+++ b/xenclient/recipes/tboot/tboot-1.7.0/tboot-1.7.0-CVE-2014-5118.patch
@@ -1,0 +1,24 @@
+tboot: measure all command line arguments (CVE-2014-5118)
+
+JP Blake's patch to address CVE-2014-5118.
+
+Upstream-status: This patch was submitted upstream, but tboot took a different
+approach to fixing it.  However, their fix is currently incomplete:
+http://sourceforge.net/p/tboot/mailman/message/32760688/
+
+Reported-by: James Blake <blakej@ainfosec.com>
+Signed-off-by: James Blake <blakej@ainfosec.com>
+Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>
+
+diff -rupN tboot-1.7.0/tboot/common/policy.c tboot-1.7.0-patched/tboot/common/policy.c
+--- tboot-1.7.0/tboot/common/policy.c	2012-01-15 10:21:20.000000000 -0500
++++ tboot-1.7.0-patched/tboot/common/policy.c	2014-11-07 12:11:02.966141513 -0500
+@@ -383,8 +383,6 @@ static bool hash_module(tb_hash_t *hash,
+     /* hash command line */
+     if ( cmdline == NULL )
+         cmdline = "";
+-    else
+-        cmdline = skip_filename(cmdline);
+     if ( !hash_buffer((const unsigned char *)cmdline, strlen(cmdline), hash,
+                       hash_alg) )
+         return false;

--- a/xenclient/recipes/tboot/tboot_1.7.0.bb
+++ b/xenclient/recipes/tboot/tboot_1.7.0.bb
@@ -6,7 +6,7 @@ require recipes/tboot/tboot.inc
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://tboot/include/types.h;beginline=4;endline=32;md5=5a2b57a442b97cfc3d81ba639fda3ac1"
 
-PR = "r4"
+PR = "r5"
 
 S="${WORKDIR}/tboot-1.7.0"
 
@@ -23,6 +23,7 @@ SRC_URI = "http://downloads.sourceforge.net/tboot/tboot-1.7.0.tar.gz \
            file://set-tboot-private-region-as-reserved.patch;patch=1 \
            file://configure_tboot \
            file://lcp_data.bin \
+           file://tboot-1.7.0-CVE-2014-5118.patch \
            "
 SRC_URI[md5sum] = "1913ec6170a10f16fdcc2220b6f45d4a"
 SRC_URI[sha256sum] = "01e8329c59ef0d8e06e12c1bbee007348272269ff11765aedafc5961f79567b6"


### PR DESCRIPTION
JP Blake's patch to address CVE-2014-5118.

Upstream-status: This patch was submitted upstream, but tboot took a different
approach to fixing it.  However, their fix is currently incomplete:
http://sourceforge.net/p/tboot/mailman/message/32760688/

OXT-19

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
