### PR TITLE
[v2] refpolicy: run setfiles only if $D is not set

### DIFF
--- a/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
+++ b/xenclient/recipes/selinux/refpolicy-mcs_2.20130424.bbappend
@@ -50,19 +50,17 @@ do_install_append() {
 }
 
 sysroot_stage_all_append () {
-	sysroot_stage_dir ${D}${sysconfdir} ${SYSROOT_DESTDIR}${sysconfdir}
+    sysroot_stage_dir ${D}${sysconfdir} ${SYSROOT_DESTDIR}${sysconfdir}
 }
 
 pkg_postinst_${PN} () {
-	/sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
-}
-
-pkg_postinst_${PN}_xenclient-ndvm () {
-    if [ -z "$D" ];then
+    if [ -z "$D" ]; then
         /sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /
     fi
 }
 
 pkg_postinst_${PN}_append_xenclient-dom0 () {
-	/sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /config /storage
+    if [ -z "$D" ]; then
+        /sbin/setfiles /etc/selinux/${POL_TYPE}/contexts/files/file_contexts /config /storage
+    fi
 }


### PR DESCRIPTION
Running this setfiles command only applies for the target. Check for existence of $D,
which is only defined for the build environment. If $D is not defined, we're running
on the target, so execute setfiles.
