### PR TITLE
[alsa-lib] use /etc/asound/asound.conf instead of /etc/asound.conf

### DIFF
--- a/xenclient/recipes/alsa-lib/alsa-lib-1.0.25/move-asound_conf.patch
+++ b/xenclient/recipes/alsa-lib/alsa-lib-1.0.25/move-asound_conf.patch
@@ -1,0 +1,46 @@
+diff -ru alsa-lib-1.0.25.orig//NOTES alsa-lib-1.0.25/NOTES
+--- alsa-lib-1.0.25.orig//NOTES	2014-11-20 11:17:40.229842102 -0500
++++ alsa-lib-1.0.25/NOTES	2014-11-20 11:18:28.792344108 -0500
+@@ -52,5 +52,5 @@
+ 
+ 	defaults.pcm.nonblock 0
+ 
+-in /etc/asound.conf or ~/.asoundrc file.
++in /etc/asound/asound.conf or ~/.asoundrc file.
+ 
+diff -ru alsa-lib-1.0.25.orig//src/conf/alsa.conf alsa-lib-1.0.25/src/conf/alsa.conf
+--- alsa-lib-1.0.25.orig//src/conf/alsa.conf	2014-11-20 11:17:40.205840293 -0500
++++ alsa-lib-1.0.25/src/conf/alsa.conf	2014-11-20 11:18:47.772107173 -0500
+@@ -15,7 +15,7 @@
+ 					"/alsa.conf.d/"
+ 				]
+ 			}
+-			"/etc/asound.conf"
++			"/etc/asound/asound.conf"
+ 			"~/.asoundrc"
+ 		]
+ 		errors false
+diff -ru alsa-lib-1.0.25.orig//src/conf/cards/USB-Audio.conf alsa-lib-1.0.25/src/conf/cards/USB-Audio.conf
+--- alsa-lib-1.0.25.orig//src/conf/cards/USB-Audio.conf	2014-11-20 11:17:40.205840293 -0500
++++ alsa-lib-1.0.25/src/conf/cards/USB-Audio.conf	2014-11-20 11:19:10.604106851 -0500
+@@ -3,7 +3,7 @@
+ #
+ #
+ #  DO NO EDIT; this is an internal ALSA file.
+-#  If you want to add your own definitions, put them into /etc/asound.conf or
++#  If you want to add your own definitions, put them into /etc/asound/asound.conf or
+ #  ~/.asoundrc, with "cards." before the "USB-Audio", e.g.:
+ #
+ #  cards.USB-Audio.pcm.use_dmix."NoiseBlaster 3000" no
+diff -ru alsa-lib-1.0.25.orig//src/conf.c alsa-lib-1.0.25/src/conf.c
+--- alsa-lib-1.0.25.orig//src/conf.c	2014-11-20 11:17:40.141692110 -0500
++++ alsa-lib-1.0.25/src/conf.c	2014-11-20 11:18:08.924372865 -0500
+@@ -392,7 +392,7 @@
+ 	{
+ 		func load
+ 		files [
+-			"/etc/asound.conf"
++			"/etc/asound/asound.conf"
+ 			"~/.asoundrc"
+ 		]
+ 		errors false

--- a/xenclient/recipes/alsa-lib/alsa-lib_1.0.25.bbappend
+++ b/xenclient/recipes/alsa-lib/alsa-lib_1.0.25.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS := "${THISDIR}/${PN}-${PV}"
+SRC_URI += " \
+    file://move-asound_conf.patch \
+    "


### PR DESCRIPTION
All of OpenXT uses /etc/asound/asound.conf as the main alsa config file, instead of /etc/asound.conf.
I think it is mainly due to the fact that this is the default path in the SELinux refpolicy.
The alsa deamon was not aware of that...
This should fix a lot of sound issues.
