### PR TITLE
xenclient-installer-image: add network device support

### DIFF
--- a/xenclient/recipes/images/xenclient-installer-image.bb
+++ b/xenclient/recipes/images/xenclient-installer-image.bb
@@ -37,6 +37,10 @@ IMAGE_INSTALL = "\
     task-base \
     task-xenclient-common \
     task-xenclient-installer \
+    intel-e1000e \
+    intel-e1000e-conf \
+    linux-firmware \
+    rt2870-firmware \
     ${ANGSTROM_EXTRA_INSTALL}"
 
 IMAGE_FSTYPES = "cpio.gz"


### PR DESCRIPTION
Pulled a few packages listed in the ndvm image to support
network devices and copied them into the installer image.

OXT-56

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
