### PR TITLE
[sysroot] remove dependence on (empty) task-xenclient-dom0-extra

### DIFF
--- a/xenclient/recipes/images/xenclient-sysroot-image.bb
+++ b/xenclient/recipes/images/xenclient-sysroot-image.bb
@@ -18,7 +18,7 @@ ANGSTROM_EXTRA_INSTALL += " \
 export IMAGE_BASENAME = "xenclient-sysroot-image"
 export STAGING_KERNEL_DIR
 
-DEPENDS = "task-base task-xenclient-dom0 task-xenclient-dom0-extra"
+DEPENDS = "task-base task-xenclient-dom0"
 IMAGE_INSTALL = "\
     ${ROOTFS_PKGMANAGE} \
     ${IMAGE_INITSCRIPTS} \


### PR DESCRIPTION
This dependence is useless, as dom0 doesn't have it and task-xenclient-dom0-extra is empty anyway.

Singed-off-by: Jed Lejosne jed.openxt@gmail.com
