### PR TITLE
[ioemu] Handle the audio-recording policy flag in hda audio

### DIFF
--- a/xenclient/recipes/ioemu/files/intel-hda-disable-audio-recording
+++ b/xenclient/recipes/ioemu/files/intel-hda-disable-audio-recording
@@ -1,0 +1,31 @@
+diff --git a/hw/hda-audio.c b/hw/hda-audio.c
+index 8966bf5..fdfc972 100644
+--- a/hw/hda-audio.c
++++ b/hw/hda-audio.c
+@@ -27,6 +27,8 @@
+ 
+ /* -------------------------------------------------------------------------- */
+ 
++extern int disable_audio_recording;
++
+ typedef struct desc_param {
+     uint32_t id;
+     uint32_t val;
+@@ -491,10 +493,13 @@ static void hda_audio_input_cb(void *opaque, int avail)
+                 break;
+             }
+         }
+-        rc = hda_codec_xfer(&st->state->hda, st->stream, false,
+-                            st->buf, sizeof(st->buf));
+-        if (!rc) {
+-            break;
++        /* Only transfer input if allowed by the policy */
++        if (!disable_audio_recording) {
++          rc = hda_codec_xfer(&st->state->hda, st->stream, false,
++                              st->buf, sizeof(st->buf));
++          if (!rc) {
++             break;
++          }
+         }
+         st->bpos = 0;
+     }

--- a/xenclient/recipes/ioemu/ioemu.inc
+++ b/xenclient/recipes/ioemu/ioemu.inc
@@ -51,6 +51,7 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/ioemu.git;protocol=${OPENXT_GIT_PROTOCOL};
     file://disable-blktap.patch;patch=1 \
     file://atapi-pt-exclusive-access.patch;patch=1 \
     file://intel-hda.patch;patch=1 \
+    file://intel-hda-disable-audio-recording;patch=1 \
     file://cdrom-fix-cdrom-media-change-detection.patch;patch=1 \
     file://lpc.patch;patch=1 \
     file://applesmc.patch;patch=1 \


### PR DESCRIPTION
This could probably be done a better way.
This doesn't fix other audio issues like hda breaking when attempting to do input and output at the same time.

OXT-42

Singed-off-by: Jed Lejosne jed.openxt@gmail.com
