### PR TITLE
RT3572: Move license before attempting configure

### DIFF
--- a/xenclient/recipes/ralink/rt3572_2.5.0.0.bb
+++ b/xenclient/recipes/ralink/rt3572_2.5.0.0.bb
@@ -19,7 +19,7 @@ S = "${WORKDIR}/2011_0427_RT3572_Linux_STA_v2.5.0.0.DPO"
 DEPENDS = "virtual/kernel"
 inherit module-base
 
-addtask move_lic before do_populate_lic after do_unpack
+addtask move_lic before do_populate_lic before do_configure after do_unpack
 
 do_move_lic () {
     cp ${S}/LICENSE\ ralink-GPL.txt ${S}/LICENSE-ralink-GPL.txt


### PR DESCRIPTION
Added a task dependency to address a concurrency issue regarding the license file name, since it has a space in the actual file name.

Signed-off-by: Kevin M. Pearson kevin.pearson.4@us.af.mil
