### PR TITLE
OXT-102

### DIFF
--- a/recipes-core/icedtea/icedtea6-native/icedtea-ecj-fix-currency-data.patch
+++ b/recipes-core/icedtea/icedtea6-native/icedtea-ecj-fix-currency-data.patch
@@ -1,0 +1,11 @@
+--- openjdk-ecj.orig/jdk/src/share/classes/java/util/CurrencyData.properties	2011-06-27 13:30:33.000000000 -0400
++++ openjdk-ecj/jdk/src/share/classes/java/util/CurrencyData.properties	2014-12-30 16:28:44.802805865 -0500
+@@ -526,7 +526,7 @@
+ # TUNISIA
+ TN=TND
+ # TURKEY
+-TR=TRL;2004-12-31-22-00-00;TRY
++TR=TRY
+ # TURKMENISTAN
+ TM=TMM
+ # TURKS AND CAICOS ISLANDS

--- a/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
+++ b/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
@@ -1,9 +1,11 @@
 SRC_URI += "\
             file://icedtea-ecj-fix-compil-gcc-4.7.patch;apply=no \
+			file://icedtea-ecj-fix-currency-data.patch;apply=no \
            "
 # Ask bitbake to use icedtea-native-1.8.11 to copy the patch
 FILESEXTRAPATHS := "${THISDIR}/${PN}:"
 
 export DISTRIBUTION_ECJ_PATCHES += " \
                               patches/icedtea-ecj-fix-compil-gcc-4.7.patch \
+							  patches/icedtea-ecj-fix-currency-data.patch \
                              "


### PR DESCRIPTION
OXT-102

Added patch to remove old Turkey currency code and timestamp from
CurrencyData.properties in the jdk inside icedtea6.  Modified the bbappend
file to apply the patch.
