### PR TITLE
Remove qemu-dm recipes now that the qemu-dm repo is gone.

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-static_git.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm-static_git.bb
@@ -1,8 +1,0 @@
-require recipes-openxt/qemu-dm/qemu-dm.inc
-
-SRCREV_source = "${AUTOREV}"
-SRCREV_patchqueue = "${AUTOREV}"
-
-DEPENDS += " pciutils-static "
-
-EXTRA_OECONF += " --static --disable-syslog "

--- a/recipes-openxt/qemu-dm/qemu-dm_git.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm_git.bb
@@ -1,4 +1,0 @@
-require recipes-openxt/qemu-dm/qemu-dm.inc
-
-SRCREV_source = "${AUTOREV}"
-SRCREV_patchqueue = "${AUTOREV}"


### PR DESCRIPTION
These reference the old qemu-dm.git mirror repo. They can cause
build failures as noted in the ticket.

OXT-100

Signed-off-by: Ross Philipson ross.philipson@gmail.com
