### PR TITLE
icedtea6-native: Normalize indentation.

### DIFF
--- a/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
+++ b/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
@@ -1,11 +1,11 @@
 SRC_URI += "\
-            file://icedtea-ecj-fix-compil-gcc-4.7.patch;apply=no \
-			file://icedtea-ecj-fix-currency-data.patch;apply=no \
-           "
+    file://icedtea-ecj-fix-compil-gcc-4.7.patch;apply=no \
+    file://icedtea-ecj-fix-currency-data.patch;apply=no \
+"
 # Ask bitbake to use icedtea-native-1.8.11 to copy the patch
 FILESEXTRAPATHS := "${THISDIR}/${PN}:"
 
 export DISTRIBUTION_ECJ_PATCHES += " \
-                              patches/icedtea-ecj-fix-compil-gcc-4.7.patch \
-							  patches/icedtea-ecj-fix-currency-data.patch \
-                             "
+    patches/icedtea-ecj-fix-compil-gcc-4.7.patch \
+    patches/icedtea-ecj-fix-currency-data.patch \
+"


### PR DESCRIPTION
This replaces the odd tabs with spaces and normalizes the number of
space to 4. http://www.openembedded.org/wiki/Styleguide

Signed-off-by: Philip Tricca <flihp@twobit.us>