### PR TITLE
acpid warning

### DIFF
--- a/recipes-bsp/acpid/acpid/ac_actions
+++ b/recipes-bsp/acpid/acpid/ac_actions
@@ -2,5 +2,5 @@
 
 ac=`cat /sys/class/power_supply/AC/online`
 for i in /etc/acpi/actions/ac*; do
-        $i "$ac"
+	[ -f "$i" -a -x "$i" ] && "$i" "$ac"
 done


### PR DESCRIPTION
Petty change to silence acpid warning (no /etc/acpi/actions/ac* matching script).