### PR TITLE
[uim] disable multi-threaded compilation, as it fails sometimes...

### DIFF
--- a/recipes-connectivity/uim/uim.inc
+++ b/recipes-connectivity/uim/uim.inc
@@ -18,3 +18,6 @@ SRC_URI = "http://uim.googlecode.com/files/uim-${PV}.tar.bz2"
 
 FILES_${PN}-dbg += "${libdir}/*/*/*/.debug ${libdir}/*/*/.debug"
 FILES_${PN}-dev += "${libdir}/uim/plugin/*.la"
+
+# https://github.com/uim/uim/issues/44
+PARALLEL_MAKE = ""


### PR DESCRIPTION
This about doubles the build time of the package, from less than 30 seconds to less than a minute.

Singed-off-by: Jed Lejosne <jed.openxt@gmail.com>