### PR TITLE
ca-certificates: Fix broken SRC_URI

### DIFF
--- a/recipes-support/ca-certificates/ca-certificates_20120212.bbappend
+++ b/recipes-support/ca-certificates/ca-certificates_20120212.bbappend
@@ -1,0 +1,3 @@
+PRINC = "1"
+SRC_URI = "http://snapshot.debian.org/archive/debian/20120229T213309Z/pool/main/c/ca-certificates/ca-certificates_${PV}.tar.gz \
+           file://0001-update-ca-certificates-remove-c-rehash.patch"


### PR DESCRIPTION
Update SRC_URI to snapshots.debian.org. Apparently they removed
the 20120212 version from the main repo.

Signed-off-by: Justin Bennett <bennettj@ainfosec.com>