### PR TITLE
[linux-i915] Silence gem-foreign debug.

### DIFF
--- a/recipes-kernel/linux/files/gem-foreign-debug.patch
+++ b/recipes-kernel/linux/files/gem-foreign-debug.patch
@@ -1,0 +1,154 @@
+--- a/drivers/gpu/drm/i915/i915_gem.c
++++ b/drivers/gpu/drm/i915/i915_gem.c
+@@ -1836,6 +1836,7 @@ i915_gem_object_get_pages_gtt(struct drm
+ 	return 0;
+ 
+ err_pages:
++	DRM_DEBUG_DRIVER("shmem_read_mapping_page_gfp failed\n");
+ 	sg_mark_end(sg);
+ 	for_each_sg_page(st->sgl, &sg_iter, st->nents, 0)
+ 		page_cache_release(sg_page_iter_page(&sg_iter));
+@@ -3110,8 +3111,10 @@ i915_gem_object_bind_to_gtt(struct drm_i
+ 	}
+ 
+ 	ret = i915_gem_object_get_pages(obj);
+-	if (ret)
++	if (ret) {
++		DRM_DEBUG_DRIVER("i915_gem_object_get_pages failed\n");
+ 		return ret;
++	}
+ 
+ 	i915_gem_object_pin_pages(obj);
+ 
+@@ -3130,8 +3133,10 @@ search_free:
+ 					       obj->cache_level,
+ 					       map_and_fenceable,
+ 					       nonblocking);
+-		if (ret == 0)
++		if (ret == 0) {
++			DRM_DEBUG_DRIVER("drm_mm_insert_* failed... retrying\n");
+ 			goto search_free;
++		}
+ 
+ 		i915_gem_object_unpin_pages(obj);
+ 		kfree(node);
+@@ -3145,6 +3150,7 @@ search_free:
+ 
+ 	ret = i915_gem_gtt_prepare_object(obj);
+ 	if (ret) {
++		DRM_DEBUG_DRIVER("i915_gem_gtt_prepare_object failed\n");
+ 		i915_gem_object_unpin_pages(obj);
+ 		drm_mm_put_block(node);
+ 		return ret;
+@@ -3459,8 +3465,10 @@ i915_gem_object_pin_to_display_plane(str
+ 
+ 	if (pipelined != obj->ring) {
+ 		ret = i915_gem_object_sync(obj, pipelined);
+-		if (ret)
++		if (ret) {
++			DRM_DEBUG_DRIVER("i915_gem_object_sync failed\n");
+ 			return ret;
++		}
+ 	}
+ 
+ 	/* The display engine is not coherent with the LLC cache on gen6.  As
+@@ -3473,16 +3481,20 @@ i915_gem_object_pin_to_display_plane(str
+ 	 * with that bit in the PTE to main memory with just one PIPE_CONTROL.
+ 	 */
+ 	ret = i915_gem_object_set_cache_level(obj, I915_CACHE_NONE);
+-	if (ret)
++	if (ret) {
++		DRM_DEBUG_DRIVER("i915_gem_object_set_cache_level failed\n");
+ 		return ret;
++	}
+ 
+ 	/* As the user may map the buffer once pinned in the display plane
+ 	 * (e.g. libkms for the bootup splash), we have to ensure that we
+ 	 * always use map_and_fenceable for all scanout buffers.
+ 	 */
+ 	ret = i915_gem_object_pin(obj, alignment, true, false);
+-	if (ret)
++	if (ret) {
++		DRM_DEBUG_DRIVER("i915_gem_object_pin failed\n");
+ 		return ret;
++	}
+ 
+ 	i915_gem_object_flush_cpu_write_domain(obj);
+ 
+@@ -3654,8 +3666,10 @@ i915_gem_object_pin(struct drm_i915_gem_
+ 		ret = i915_gem_object_bind_to_gtt(obj, alignment,
+ 						  map_and_fenceable,
+ 						  nonblocking);
+-		if (ret)
++		if (ret) {
++			DRM_DEBUG_DRIVER("i915_gem_object_bind_to_gtt failed\n");
+ 			return ret;
++		}
+ 
+ 		if (!dev_priv->mm.aliasing_ppgtt)
+ 			i915_gem_gtt_bind_object(obj, obj->cache_level);
+--- a/drivers/gpu/drm/i915/i915_gem_foreign.c
++++ b/drivers/gpu/drm/i915/i915_gem_foreign.c
+@@ -65,6 +65,14 @@ i915_gem_foreign_remove_override(struct
+ 	for (i = 0; i < num_pages; i++) {
+ 		if (m2p_remove_override(vmap->pvec[i], NULL))
+ 			BUG();
++#if DRM_DEBUG_CODE
++		if (!(i % 100)) {
++			DRM_DEBUG_DRIVER("Foreign unmap(%d) pfn = %lx, kaddr = %p\n",
++					 i, page_to_pfn(vmap->pvec[i]),
++					 pfn_to_kaddr(page_to_pfn(vmap->pvec[i])));
++
++		}
++#endif
+ 	}
+ }
+ 
+@@ -76,6 +84,7 @@ i915_gem_foreign_get_pages(struct drm_i9
+ 	struct scatterlist *sg = NULL;
+ 	int i, ret;
+ 
++        DRM_DEBUG_DRIVER("Foreign get pages.\n");
+ 	vmap->pvec = kmalloc(vmap->num_pages*sizeof(struct page *),
+ 			 GFP_KERNEL | __GFP_NOWARN | __GFP_NORETRY);
+ 	if (vmap->pvec == NULL) {
+@@ -121,9 +130,22 @@ i915_gem_foreign_get_pages(struct drm_i9
+ 			i915_gem_foreign_remove_override(vmap, i - 1);
+ 			goto err1;
+ 		}
++#if DRM_DEBUG_CODE
++		if (!(i % 100)) {
++			DRM_DEBUG_DRIVER("Foreign map(%d) mfn = %llx, pfn = %lx, kaddr = %p, valid = %d\n",
++					 i, vmap->mfns[i], page_to_pfn(vmap->pvec[i]),
++					 pfn_to_kaddr(page_to_pfn(vmap->pvec[i])),
++					 virt_addr_valid(pfn_to_kaddr(page_to_pfn(vmap->pvec[i]))));
++		}
++#endif
+ 	}
+ 
+ 	for_each_sg(st->sgl, sg, vmap->num_pages, i) {
++#if DRM_DEBUG_CODE
++		if (!(i % 100)) {
++			DRM_DEBUG_DRIVER("Foreign page[%d] = %p\n", i, vmap->pvec[i]);
++		}
++#endif
+ 		sg_set_page(sg, vmap->pvec[i], PAGE_SIZE, 0);
+ 	}
+ 
+@@ -149,6 +171,7 @@ i915_gem_foreign_put_pages(struct drm_i9
+ 	struct i915_gem_foreign_object *vmap = to_foreign_object(obj);
+ 	int num_pages = obj->base.size >> PAGE_SHIFT;
+ 
++        DRM_DEBUG_DRIVER("Foreign put pages.\n");
+ 	i915_gem_foreign_remove_override(vmap, num_pages);
+ 
+ 	i915_gem_foreign_free_pages(vmap, num_pages);
+@@ -185,6 +208,8 @@ i915_gem_foreign_ioctl(struct drm_device
+ 	int ret = -ENOMEM;
+ 	u32 handle;
+ 
++	DRM_DEBUG_DRIVER("Foreign init - mfns:%p num_pages:0x%x flags: 0x%x\n",
++			 args->mfns, args->num_pages, args->flags);
+ 	if ((args->num_pages * PAGE_SIZE) > dev_priv->gtt.total)
+ 		return -E2BIG;
+ 

--- a/recipes-kernel/linux/files/gem-foreign.patch
+++ b/recipes-kernel/linux/files/gem-foreign.patch
@@ -1,8 +1,6 @@
-diff --git a/drivers/gpu/drm/i915/Makefile b/drivers/gpu/drm/i915/Makefile
-index bdcf1e4..848f09d 100644
 --- a/drivers/gpu/drm/i915/Makefile
 +++ b/drivers/gpu/drm/i915/Makefile
-@@ -14,6 +14,7 @@ i915-y := i915_drv.o i915_dma.o i915_irq.o \
+@@ -14,6 +14,7 @@ i915-y := i915_drv.o i915_dma.o i915_irq
  	  i915_gem_gtt.o \
  	  i915_gem_stolen.o \
  	  i915_gem_tiling.o \
@@ -10,11 +8,9 @@ index bdcf1e4..848f09d 100644
  	  i915_gem_userptr.o \
  	  i915_sysfs.o \
  	  i915_trace_points.o \
-diff --git a/drivers/gpu/drm/i915/i915_dma.c b/drivers/gpu/drm/i915/i915_dma.c
-index 3453254..0f9acaf 100644
 --- a/drivers/gpu/drm/i915/i915_dma.c
 +++ b/drivers/gpu/drm/i915/i915_dma.c
-@@ -1891,6 +1891,7 @@ struct drm_ioctl_desc i915_ioctls[] = {
+@@ -1902,6 +1902,7 @@ struct drm_ioctl_desc i915_ioctls[] = {
  	DRM_IOCTL_DEF_DRV(I915_GEM_CONTEXT_CREATE, i915_gem_context_create_ioctl, DRM_UNLOCKED),
  	DRM_IOCTL_DEF_DRV(I915_GEM_CONTEXT_DESTROY, i915_gem_context_destroy_ioctl, DRM_UNLOCKED),
  	DRM_IOCTL_DEF_DRV(I915_REG_READ, i915_reg_read_ioctl, DRM_UNLOCKED),
@@ -22,8 +18,6 @@ index 3453254..0f9acaf 100644
  	DRM_IOCTL_DEF_DRV(I915_GEM_USERPTR, i915_gem_userptr_ioctl, DRM_UNLOCKED),
  };
  
-diff --git a/drivers/gpu/drm/i915/i915_drv.h b/drivers/gpu/drm/i915/i915_drv.h
-index 8c24b0d..692f81f 100644
 --- a/drivers/gpu/drm/i915/i915_drv.h
 +++ b/drivers/gpu/drm/i915/i915_drv.h
 @@ -1311,6 +1311,7 @@ struct drm_i915_gem_object {
@@ -57,7 +51,7 @@ index 8c24b0d..692f81f 100644
  	};
  };
  
-@@ -1669,6 +1679,8 @@ int i915_gem_entervt_ioctl(struct drm_device *dev, void *data,
+@@ -1669,6 +1679,8 @@ int i915_gem_entervt_ioctl(struct drm_de
  			   struct drm_file *file_priv);
  int i915_gem_leavevt_ioctl(struct drm_device *dev, void *data,
  			   struct drm_file *file_priv);
@@ -66,7 +60,7 @@ index 8c24b0d..692f81f 100644
  int i915_gem_userptr_ioctl(struct drm_device *dev, void *data,
  			   struct drm_file *file);
  int i915_gem_set_tiling(struct drm_device *dev, void *data,
-@@ -1687,6 +1699,8 @@ void i915_gem_object_init(struct drm_i915_gem_object *obj,
+@@ -1687,6 +1699,8 @@ void i915_gem_object_init(struct drm_i91
  			 const struct drm_i915_gem_object_ops *ops);
  struct drm_i915_gem_object *i915_gem_alloc_object(struct drm_device *dev,
  						  size_t size);
@@ -75,11 +69,9 @@ index 8c24b0d..692f81f 100644
  void i915_gem_free_object(struct drm_gem_object *obj);
  
  int __must_check i915_gem_object_pin(struct drm_i915_gem_object *obj,
-diff --git a/drivers/gpu/drm/i915/i915_gem.c b/drivers/gpu/drm/i915/i915_gem.c
-index 06b6900..ad4ed7b 100644
 --- a/drivers/gpu/drm/i915/i915_gem.c
 +++ b/drivers/gpu/drm/i915/i915_gem.c
-@@ -79,8 +79,8 @@ static void i915_gem_info_add_obj(struct drm_i915_private *dev_priv,
+@@ -79,8 +79,8 @@ static void i915_gem_info_add_obj(struct
  	dev_priv->mm.object_memory += size;
  }
  
@@ -90,101 +82,9 @@ index 06b6900..ad4ed7b 100644
  {
  	dev_priv->mm.object_count--;
  	dev_priv->mm.object_memory -= size;
-@@ -1836,6 +1836,7 @@ i915_gem_object_get_pages_gtt(struct drm_i915_gem_object *obj)
- 	return 0;
- 
- err_pages:
-+	DRM_ERROR("shmem_read_mapping_page_gfp failed\n");
- 	sg_mark_end(sg);
- 	for_each_sg_page(st->sgl, &sg_iter, st->nents, 0)
- 		page_cache_release(sg_page_iter_page(&sg_iter));
-@@ -3110,8 +3111,10 @@ i915_gem_object_bind_to_gtt(struct drm_i915_gem_object *obj,
- 	}
- 
- 	ret = i915_gem_object_get_pages(obj);
--	if (ret)
-+	if (ret) {
-+		DRM_ERROR("i915_gem_object_get_pages failed");
- 		return ret;
-+	}
- 
- 	i915_gem_object_pin_pages(obj);
- 
-@@ -3130,9 +3133,12 @@ search_free:
- 					       obj->cache_level,
- 					       map_and_fenceable,
- 					       nonblocking);
--		if (ret == 0)
-+		if (ret == 0) {
-+			DRM_ERROR("drm_mm_insert_* failed... retrying\n");
- 			goto search_free;
-+		}
- 
-+		DRM_ERROR("drm_mm_insert_* failed... aborting\n");
- 		i915_gem_object_unpin_pages(obj);
- 		kfree(node);
- 		return ret;
-@@ -3145,6 +3151,7 @@ search_free:
- 
- 	ret = i915_gem_gtt_prepare_object(obj);
- 	if (ret) {
-+		DRM_ERROR("i915_gem_gtt_prepare_object failed\n");
- 		i915_gem_object_unpin_pages(obj);
- 		drm_mm_put_block(node);
- 		return ret;
-@@ -3459,8 +3466,10 @@ i915_gem_object_pin_to_display_plane(struct drm_i915_gem_object *obj,
- 
- 	if (pipelined != obj->ring) {
- 		ret = i915_gem_object_sync(obj, pipelined);
--		if (ret)
-+		if (ret) {
-+			DRM_ERROR("i915_gem_object_sync failed\n");
- 			return ret;
-+		}
- 	}
- 
- 	/* The display engine is not coherent with the LLC cache on gen6.  As
-@@ -3473,16 +3482,20 @@ i915_gem_object_pin_to_display_plane(struct drm_i915_gem_object *obj,
- 	 * with that bit in the PTE to main memory with just one PIPE_CONTROL.
- 	 */
- 	ret = i915_gem_object_set_cache_level(obj, I915_CACHE_NONE);
--	if (ret)
-+	if (ret) {
-+		DRM_ERROR("i915_gem_object_set_cache_level failed\n");
- 		return ret;
-+	}
- 
- 	/* As the user may map the buffer once pinned in the display plane
- 	 * (e.g. libkms for the bootup splash), we have to ensure that we
- 	 * always use map_and_fenceable for all scanout buffers.
- 	 */
- 	ret = i915_gem_object_pin(obj, alignment, true, false);
--	if (ret)
-+	if (ret) {
-+		DRM_ERROR("i915_gem_object_pin failed\n");
- 		return ret;
-+	}
- 
- 	i915_gem_object_flush_cpu_write_domain(obj);
- 
-@@ -3654,8 +3667,10 @@ i915_gem_object_pin(struct drm_i915_gem_object *obj,
- 		ret = i915_gem_object_bind_to_gtt(obj, alignment,
- 						  map_and_fenceable,
- 						  nonblocking);
--		if (ret)
-+		if (ret) {
-+			DRM_ERROR("i915_gem_object_bind_to_gtt failed\n");
- 			return ret;
-+		}
- 
- 		if (!dev_priv->mm.aliasing_ppgtt)
- 			i915_gem_gtt_bind_object(obj, obj->cache_level);
-diff --git a/drivers/gpu/drm/i915/i915_gem_foreign.c b/drivers/gpu/drm/i915/i915_gem_foreign.c
-new file mode 100644
-index 0000000..2066222
 --- /dev/null
 +++ b/drivers/gpu/drm/i915/i915_gem_foreign.c
-@@ -0,0 +1,261 @@
+@@ -0,0 +1,235 @@
 +/*
 + * Copyright © 2013 Citrix Systems, Inc.
 + *
@@ -223,10 +123,6 @@ index 0000000..2066222
 +#include <xen/balloon.h>
 +#include <xen/interface/memory.h>
 +
-+/* TODO can't get DRM logging working, hack for now, remove later */
-+#undef DRM_DEBUG_DRIVER
-+#define DRM_DEBUG_DRIVER DRM_INFO
-+
 +static struct i915_gem_foreign_object *to_foreign_object(struct drm_i915_gem_object *obj)
 +{
 +	return container_of(obj, struct i915_gem_foreign_object, gem);
@@ -256,11 +152,6 @@ index 0000000..2066222
 +	for (i = 0; i < num_pages; i++) {
 +		if (m2p_remove_override(vmap->pvec[i], NULL))
 +			BUG();
-+		if (!(i % 100)) {
-+			DRM_DEBUG_DRIVER("Foreign unmap(%d) pfn = %lx, kaddr = %p\n",
-+			 i, page_to_pfn(vmap->pvec[i]),
-+			 pfn_to_kaddr(page_to_pfn(vmap->pvec[i])));
-+		}
 +	}
 +}
 +
@@ -271,8 +162,6 @@ index 0000000..2066222
 +	struct sg_table *st = NULL;
 +	struct scatterlist *sg = NULL;
 +	int i, ret;
-+
-+	DRM_DEBUG_DRIVER("**Foreign get pages.\n");
 +
 +	vmap->pvec = kmalloc(vmap->num_pages*sizeof(struct page *),
 +			 GFP_KERNEL | __GFP_NOWARN | __GFP_NORETRY);
@@ -319,19 +208,9 @@ index 0000000..2066222
 +			i915_gem_foreign_remove_override(vmap, i - 1);
 +			goto err1;
 +		}
-+		if (!(i % 100)) {
-+			DRM_DEBUG_DRIVER("Foreign map(%d) mfn = %llx, pfn = %lx, kaddr = %p, valid = %d\n",
-+			 i, vmap->mfns[i], page_to_pfn(vmap->pvec[i]),
-+			 pfn_to_kaddr(page_to_pfn(vmap->pvec[i])),
-+			 virt_addr_valid(pfn_to_kaddr(page_to_pfn(vmap->pvec[i]))));
-+		}
 +	}
 +
 +	for_each_sg(st->sgl, sg, vmap->num_pages, i) {
-+		if (!(i % 100)) {
-+			DRM_DEBUG_DRIVER("Foreign page[%d] = %p\n",
-+			 i, vmap->pvec[i]);
-+		}
 +		sg_set_page(sg, vmap->pvec[i], PAGE_SIZE, 0);
 +	}
 +
@@ -356,8 +235,6 @@ index 0000000..2066222
 +{
 +	struct i915_gem_foreign_object *vmap = to_foreign_object(obj);
 +	int num_pages = obj->base.size >> PAGE_SHIFT;
-+
-+	DRM_DEBUG_DRIVER("**Foreign put pages.\n");
 +
 +	i915_gem_foreign_remove_override(vmap, num_pages);
 +
@@ -394,9 +271,6 @@ index 0000000..2066222
 +	uint32_t size;
 +	int ret = -ENOMEM;
 +	u32 handle;
-+
-+	DRM_DEBUG_DRIVER("**Foreign init - mfns: %p num_pages: 0x%x flags: 0x%x\n",
-+			args->mfns, args->num_pages, args->flags);
 +
 +	if ((args->num_pages * PAGE_SIZE) > dev_priv->gtt.total)
 +		return -E2BIG;
@@ -446,45 +320,6 @@ index 0000000..2066222
 +	kfree(obj);
 +	return ret;
 +}
-diff --git a/drivers/gpu/drm/i915/intel_display.c b/drivers/gpu/drm/i915/intel_display.c
-index 90a7c17..df064a1 100644
---- a/drivers/gpu/drm/i915/intel_display.c
-+++ b/drivers/gpu/drm/i915/intel_display.c
-@@ -1801,8 +1801,10 @@ intel_pin_and_fence_fb_obj(struct drm_device *dev,
- 
- 	dev_priv->mm.interruptible = false;
- 	ret = i915_gem_object_pin_to_display_plane(obj, alignment, pipelined);
--	if (ret)
-+	if (ret) {
-+                DRM_ERROR("pin_to_display_plane failed\n");
- 		goto err_interruptible;
-+        }
- 
- 	/* Install a fence for tiled scan-out. Pre-i965 always needs a
- 	 * fence, whereas 965+ only requires a fence if using
-@@ -1810,8 +1812,10 @@ intel_pin_and_fence_fb_obj(struct drm_device *dev,
- 	 * a fence as the cost is not that onerous.
- 	 */
- 	ret = i915_gem_object_get_fence(obj);
--	if (ret)
-+	if (ret){
-+                DRM_ERROR("object_get_fence failed\n");
- 		goto err_unpin;
-+        }
- 
- 	i915_gem_object_pin_fence(obj);
- 
-@@ -2179,7 +2183,7 @@ intel_pipe_set_base(struct drm_crtc *crtc, int x, int y,
- 					 NULL);
- 	if (ret != 0) {
- 		mutex_unlock(&dev->struct_mutex);
--		DRM_ERROR("pin & fence failed\n");
-+		DRM_ERROR("pin & fence failed: %d\n", ret);
- 		return ret;
- 	}
- 
-diff --git a/include/uapi/drm/i915_drm.h b/include/uapi/drm/i915_drm.h
-index 489e892..5c7e09f 100644
 --- a/include/uapi/drm/i915_drm.h
 +++ b/include/uapi/drm/i915_drm.h
 @@ -199,6 +199,8 @@ typedef struct _drm_i915_sarea {

--- a/recipes-kernel/linux/linux-xenclient-3.11.inc
+++ b/recipes-kernel/linux/linux-xenclient-3.11.inc
@@ -41,6 +41,7 @@ SRC_URI = "http://mirror.openxt.org/linux-3.11.10.4.tar.gz;name=kernel \
     file://stubdom-allow-foreign-lowmem-map.patch;patch=1 \
     file://gem-userptr.patch;patch=1 \
     file://gem-foreign.patch;patch=1 \
+    file://gem-foreign-debug.patch;patch=1 \
     file://atmel-tpm-timeouts.patch;patch=1 \
     file://fbcon-do-not-drag-detect-primary-option.patch;patch=1 \
     file://usbback-base.patch;patch=1 \


### PR DESCRIPTION
As some debug calls went into other i915 files, split the debug code
from the original functionality.

Use DRM print methods.