### PR TITLE
[xenclient-boot-sound] fix config before adjusting the volumes

### DIFF
--- a/recipes-openxt/xenclient/xenclient-boot-sound/xenclient-boot-sound.initscript
+++ b/recipes-openxt/xenclient/xenclient-boot-sound/xenclient-boot-sound.initscript
@@ -21,6 +21,7 @@ case "$1" in
 start)
 	udevadm settle
 	alsactl init
+	update-pcm-config
 	amixer set "Master" 100%
 	amixer set "Headphone" 100%
 	amixer set "Mic" 100%
@@ -33,7 +34,6 @@ start)
 	amixer set "Internal Mic" 100%
 	amixer set "Front" 100%
 	amixer set "Line" 100%
-	update-pcm-config
         ;;
 stop)
         ;;


### PR DESCRIPTION
update-pcm-config fixes the alsa config, which is needed to be able to access the volumes.