### PR TITLE
Add additional resolutions (back) to vgabios.

### DIFF
--- a/recipes-openxt/vgabios/vgabios-0.7a/vbe-extended-edid-modes.patch
+++ b/recipes-openxt/vgabios/vgabios-0.7a/vbe-extended-edid-modes.patch
@@ -1,0 +1,218 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+
+Adds a collection of common supported "resolution" modes for HVM guest display.
+These allow for a more natural-appearing display on many monitors.
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+
+This patch adds support for a collection of additional standard and common modes
+to the table of modes used by the VGA BIOS Extensions (VBE). These specify the
+modes that the emulated VGA device is "capable" of producing; and thus are set 
+to modes that the target adapter is likely to be able to produce. 
+
+When combined with the rest of the OpenXT VGA BIOS Extensions patches, the guest
+is informed of the maximum resolution recomended by the display multiplexer:  
+this information is retrieved via a RPC in the VBE extension patch in qemu-dm
+(vbe-xt-extensions.patch). Most guests will interpret this data and allow
+selection of any modes equal or smaller to the "maximum resolution" provided by
+the display handler.
+
+Note that the final responsibility for making the display work resides with the
+display handler, which should be able to translate any of the modes on this list
+to a visible display, whether by paneling ("adding borders"), scaling, or 
+cropping. Thus, the selection of these values results in a more optimal display,
+but is not absolutely critical for correct operation.
+
+################################################################################
+CHANGELOG
+################################################################################
+Documented: Kyle J. Temkin <temkink@ainfosec.com>, 30 Mar 2015
+Copied from the Xen VGABIOS patch queue; original author unkown.
+
+################################################################################
+REMOVAL
+################################################################################
+This patch should be removed if we remove the OpenXT VBE extensions, as our
+extensions allow us to detect when a given resolution is appropriate. Without
+those extensions, the user will be able to select a collection of inappropriate
+modes, which may not be handled correctly by the display multiplexer.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+This is an OpenXT work-around. There is no plan to upstream this patch.
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+This does not directly depend on any internal patches, but only makes sense
+with the following VGABIOS patches:
+
+- vbe-extensions.patch
+
+The QEMU patch necessary to support the patch above should also be applied:
+
+- vbe-xt-extensions.patch
+
+################################################################################
+PATCH
+################################################################################
+diff --git c/vbetables-gen.c i/vbetables-gen.c
+index b55c2d1..26bd934 100644
+--- c/vbetables-gen.c
++++ i/vbetables-gen.c
+@@ -12,79 +12,79 @@ typedef struct {
+ } ModeInfo;
+ 
+ ModeInfo modes[] = {
+-    /* standard VESA modes */
+-{ 640, 400, 8                          , 0x100},
+-{ 640, 480, 8                          , 0x101},
+-{ 800, 600, 4                          , 0x102},
+-{ 800, 600, 8                          , 0x103},
+-{ 1024, 768, 4                         , 0x104},
+-{ 1024, 768, 8                         , 0x105},
+-{ 1280, 1024, 4                        , 0x106},
+-{ 1280, 1024, 8                        , 0x107},
+-{ 320, 200, 15                       , 0x10D},
+-{ 320, 200, 16                        , 0x10E},
+-{ 320, 200, 24                        , 0x10F},
+-{ 640, 480, 15                       , 0x110},
+-{ 640, 480, 16                        , 0x111},
+-{ 640, 480, 24                        , 0x112},
+-{ 800, 600, 15                       , 0x113},
+-{ 800, 600, 16                        , 0x114},
+-{ 800, 600, 24                        , 0x115},
+-{ 1024, 768, 15                      , 0x116},
+-{ 1024, 768, 16                       , 0x117},
+-{ 1024, 768, 24                       , 0x118},
+-{ 1280, 1024, 15                     , 0x119},
+-{ 1280, 1024, 16                      , 0x11A},
+-{ 1280, 1024, 24                      , 0x11B},
+-{ 1600, 1200, 8                        , 0x11C},
+-{ 1600, 1200, 15                     , 0x11D},
+-{ 1600, 1200, 16                      , 0x11E},
+-{ 1600, 1200, 24                      , 0x11F},
++   /* standard VESA modes */
++{ 640, 400, 8, 0x100 },
++{ 640, 480, 8, 0x101 },
++{ 800, 600, 8, 0x103 },
++{ 1024, 768, 8, 0x105 },
++{ 1280, 1024, 8, 0x107 },
++{ 320, 200, 16, 0x10E },
++{ 320, 200, 24, 0x10F },
++{ 640, 480, 16, 0x111 },
++{ 640, 480, 24, 0x112 },
++{ 800, 600, 16, 0x114 },
++{ 800, 600, 24, 0x115 },
++{ 1024, 768, 16, 0x117 },
++{ 1024, 768, 24, 0x118 },
++{ 1280, 1024, 16, 0x11A },
++{ 1280, 1024, 16, 0x11B },
+ 
+       /* BOCHS/PLEX86 'own' mode numbers */
+-{ 320, 200, 32                       , 0x140},
+-{ 640, 400, 32                       , 0x141},
+-{ 640, 480, 32                       , 0x142},
+-{ 800, 600, 32                       , 0x143},
+-{ 1024, 768, 32                      , 0x144},
+-{ 1280, 1024, 32                     , 0x145},
+-{ 320, 200, 8                        , 0x146},
+-{ 1600, 1200, 32                     , 0x147},
+-{ 1152, 864, 8                       , 0x148},
+-{ 1152, 864, 15                      , 0x149},
+-{ 1152, 864, 16                      , 0x14a},
+-{ 1152, 864, 24                      , 0x14b},
+-{ 1152, 864, 32                      , 0x14c},
+-{ 1280, 768, 16                      , 0x175},
+-{ 1280, 768, 24                      , 0x176},
+-{ 1280, 768, 32                      , 0x177},
+-{ 1280, 800, 16                      , 0x178},
+-{ 1280, 800, 24                      , 0x179},
+-{ 1280, 800, 32                      , 0x17a},
+-{ 1280, 960, 16                      , 0x17b},
+-{ 1280, 960, 24                      , 0x17c},
+-{ 1280, 960, 32                      , 0x17d},
+-{ 1440, 900, 16                      , 0x17e},
+-{ 1440, 900, 24                      , 0x17f},
+-{ 1440, 900, 32                      , 0x180},
+-{ 1400, 1050, 16                     , 0x181},
+-{ 1400, 1050, 24                     , 0x182},
+-{ 1400, 1050, 32                     , 0x183},
+-{ 1680, 1050, 16                     , 0x184},
+-{ 1680, 1050, 24                     , 0x185},
+-{ 1680, 1050, 32                     , 0x186},
+-{ 1920, 1200, 16                     , 0x187},
+-{ 1920, 1200, 24                     , 0x188},
+-{ 1920, 1200, 32                     , 0x189},
+-{ 2560, 1600, 16                     , 0x18a},
+-{ 2560, 1600, 24                     , 0x18b},
+-{ 2560, 1600, 32                     , 0x18c},
+-{ 1280, 720, 16                      , 0x18d},
+-{ 1280, 720, 24                      , 0x18e},
+-{ 1280, 720, 32                      , 0x18f},
+-{ 1920, 1080, 16                     , 0x190},
+-{ 1920, 1080, 24                     , 0x191},
+-{ 1920, 1080, 32                     , 0x192},
++	/* "Common" modes (http://en.wikipedia.org/wiki/VESA_BIOS_Extensions) */
++{  640,  480, 32, 0x129 },
++{  800,  600, 32, 0x12E },
++{ 1024,  768, 32, 0x138 },
++{ 1280, 1024, 32, 0x13D },
++{ 1600, 1200, 32, 0x142 },
++{ 1152,  864, 32, 0x14c },
++
++  /* Additional modes supported by OpenXT. */
++{ 1152,  720, 32, 0x14d },
++{ 1152,  768, 32, 0x14e },
++{ 1152,  864, 32, 0x14f },
++
++{ 1280,  720, 32, 0x150 },
++{ 1280,  768, 32, 0x151 },
++{ 1280,  800, 32, 0x152 },
++{ 1280,  854, 32, 0x153 },
++{ 1280,  960, 32, 0x154 },
++
++{ 1360,  768, 32, 0x156 },
++
++{ 1400, 1050, 32, 0x158 },
++
++{ 1440,  768, 32, 0x15a },
++{ 1440,  900, 32, 0x15b },
++{ 1440,  960, 32, 0x15c },
++{ 1440, 1080, 32, 0x15f },
++
++{ 1600,  768, 32, 0x160 },
++{ 1600,  900, 32, 0x161 },
++{ 1600, 1024, 32, 0x162 },
++{ 1600, 1200, 32, 0x163 },
++
++{ 1680, 1050, 32, 0x169 },
++
++{ 1920, 1080, 32, 0x16d },
++
++  /* modes which require 16MB frame buffer */
++{ 1920, 1200, 32, 0x170 },
++{ 1920, 1400, 32, 0x170 },
++{ 1920, 1440, 32, 0x170 },
++
++{ 2048, 1107, 32, 0x171 },
++{ 2048, 1152, 32, 0x172 },
++{ 2048, 1280, 32, 0x173 },
++{ 2048, 1536, 32, 0x174 },
++
++{ 2560, 1440, 32, 0x175 },
++{ 2560, 1600, 32, 0x176 },
++
++  /* modes which require 32MB frame buffer */
++{ 2560, 2048, 32, 0x177 },
++{ 3840, 2160, 32, 0x178 },
++
++        /* end-of-list */
+ { 0, },
+ };
+ 

--- a/recipes-openxt/vgabios/vgabios_0.7a.bb
+++ b/recipes-openxt/vgabios/vgabios_0.7a.bb
@@ -15,11 +15,12 @@ SRC_URI += "file://xen-fix-vbe-size-computation-overflow.patch;patch=1  \
             file://vga-spinlock.patch;patch=1                           \
             file://vga-shadow-bda.patch;patch=1                         \
             file://xen-log-to-ioport-0xe9.patch;patch=1                 \
+            file://vbe-extended-edid-modes.patch                        \
             "
 SRC_URI[tarball.md5sum] = "2c0fe5c0ca08082a9293e3a7b23dc900"
 SRC_URI[tarball.sha256sum] = "9d24c33d4bfb7831e2069cf3644936a53ef3de21d467872b54ce2ea30881b865"
 
-PR = "r0"
+PR = "r1"
 
 FILES_${PN} = "/usr/share/firmware/${PN}-${PV}*.bin"
 FILES_${PN}-dbg = "/usr/share/firmware/${PN}-${PV}*.debug.bin"


### PR DESCRIPTION
Adds a collection of common supported "resolution" modes for HVM guest display.
These allow for a more natural-appearing display on many monitors. See
added patch for additional information.

Signed-off-by: Kyle Temkin <temkink@ainfosec.com>