### PR TITLE
[OXT-250] Update Xen from 4.3.3 to 4.3.4, rolling back some hand rolled XSA patche...

### DIFF
--- a/recipes-extended/xen/files/xc-xt-interrupt-debug-info.patch
+++ b/recipes-extended/xen/files/xc-xt-interrupt-debug-info.patch
@@ -2,7 +2,7 @@ diff --git a/xen/arch/x86/irq.c b/xen/arch/x86/irq.c
 index b0b0c65..47d3e4f 100644
 --- a/xen/arch/x86/irq.c
 +++ b/xen/arch/x86/irq.c
-@@ -2100,9 +2100,102 @@ void free_domain_pirqs(struct domain *d)
+@@ -2100,9 +2100,97 @@ void free_domain_pirqs(struct domain *d)
      spin_unlock(&pcidevs_lock);
  }
  
@@ -22,11 +22,6 @@ index b0b0c65..47d3e4f 100644
 +        printk("%04x:", apic_read(APIC_TMR + i*0x10));
 +    printk("\n");
 +}
-+
-+#define vlapic_test_vector(vec, bitmap)                         \
-+    test_bit(VEC_POS(vec),                                      \
-+                     (unsigned long *)((bitmap) + REG_POS(vec)))
-+
 +
 +static void dump_lapic_register(struct vlapic *l,char *name,int base)
 +{

--- a/recipes-extended/xen/files/xc-xt-v4v.patch
+++ b/recipes-extended/xen/files/xc-xt-v4v.patch
@@ -6,9 +6,9 @@ index ba57e5a..f2073e9 100644
      HYPERCALL(hvm_op),
      HYPERCALL(sysctl),
      HYPERCALL(domctl),
--    HYPERCALL(tmem_op)
-+    HYPERCALL(tmem_op),
-+    HYPERCALL(v4v_op)
+     HYPERCALL(tmem_op),
++    HYPERCALL(v4v_op),
+     [ __HYPERVISOR_arch_1 ] = (hvm_hypercall_t *)paging_domctl_continuation
  };
  
  #define COMPAT_CALL(x)                                        \
@@ -16,9 +16,9 @@ index ba57e5a..f2073e9 100644
      HYPERCALL(hvm_op),
      HYPERCALL(sysctl),
      HYPERCALL(domctl),
--    HYPERCALL(tmem_op)
-+    HYPERCALL(tmem_op),
-+    HYPERCALL(v4v_op)
+     HYPERCALL(tmem_op),
++    HYPERCALL(v4v_op),
+     [ __HYPERVISOR_arch_1 ] = (hvm_hypercall_t *)paging_domctl_continuation
  };
  
  int hvm_do_hypercall(struct cpu_user_regs *regs)

--- a/recipes-extended/xen/files/xc-xt-v4v.patch
+++ b/recipes-extended/xen/files/xc-xt-v4v.patch
@@ -2,7 +2,7 @@ diff --git a/xen/arch/x86/hvm/hvm.c b/xen/arch/x86/hvm/hvm.c
 index ba57e5a..f2073e9 100644
 --- a/xen/arch/x86/hvm/hvm.c
 +++ b/xen/arch/x86/hvm/hvm.c
-@@ -3310,7 +3310,8 @@ static hvm_hypercall_t *const hvm_hypercall64_table[NR_hypercalls] = {
+@@ -3365,8 +3365,9 @@ static hvm_hypercall_t *const hvm_hypercall64_table[NR_hypercalls] = {
      HYPERCALL(hvm_op),
      HYPERCALL(sysctl),
      HYPERCALL(domctl),
@@ -12,7 +12,7 @@ index ba57e5a..f2073e9 100644
  };
  
  #define COMPAT_CALL(x)                                        \
-@@ -3329,7 +3330,8 @@ static hvm_hypercall_t *const hvm_hypercall32_table[NR_hypercalls] = {
+@@ -3385,8 +3386,9 @@ static hvm_hypercall_t *const hvm_hypercall32_table[NR_hypercalls] = {
      HYPERCALL(hvm_op),
      HYPERCALL(sysctl),
      HYPERCALL(domctl),

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -65,13 +65,6 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://dom0_auto_mem.patch;patch=1 \
     file://rombios-faster.patch;patch=1 \
     file://include-seabios.patch;patch=1 \
-    file://XSA-59_chipset_updates.patch;patch=1 \
-    file://XSA-104_fix_race_condition_with_dirty_vram_state.patch;patch=1 \
-    file://XSA-105_priv_check_in_x86_HLT_LGDT_LIDT_LMSW.patch;patch=1 \
-    file://XSA-106_privilege_check_in_x86_sw_int.patch;patch=1 \
-    file://XSA-108_properly_bound_x2APIC_MSR_range.patch;patch=1 \
-    file://xsa109.patch;patch=1 \
-    file://xsa110-4.3-and-4.2.patch;patch=1 \
     file://xc-xt-hvm-get-time.patch;patch=1 \
     file://hvm-rtc-refresh-time.patch;patch=1 \
     file://fix-race-between-udev-and-tapctl.patch;patch=1 \


### PR DESCRIPTION
...s to use upstreams latest.

Signed-off-by: Brendan Kerrigan <kerriganb@ainfosec.com>