### PR TITLE
Use ACPI guest firmware that matches upstream QEMU

### DIFF
--- a/recipes-extended/xen/files/acpi-hvmloader-pm-xt.patch
+++ b/recipes-extended/xen/files/acpi-hvmloader-pm-xt.patch
@@ -69,7 +69,7 @@ index 13af0ed..4c903b0 100644
  
 -        /* Future patches will extend AC object to better account for
 -         * AC to DC transition and more. */
-+        Method (E0, 0, NotSerialized)
++        Method (E05, 0, NotSerialized)
 +        {
 +            If (\_SB.SLP)
 +            {
@@ -84,7 +84,7 @@ index 13af0ed..4c903b0 100644
 +            }
 +        }
 +
-+        Method (E1, 0, NotSerialized)
++        Method (E06, 0, NotSerialized)
 +        {
 +            If (\_SB.SLP)
 +            {
@@ -99,23 +99,23 @@ index 13af0ed..4c903b0 100644
 +            }
 +        }
 +
-+        Method (E1C, 0, NotSerialized)
++        Method (E0C, 0, NotSerialized)
 +        {
 +            Notify (\_SB.AC, 0x80)
 +        }
 +
-+        Method (E17, 0, NotSerialized)
++        Method (E07, 0, NotSerialized)
 +        {
 +            Notify (\_SB.LID, 0x80)
 +        }
 +
-+        Method (E1D, 0, NotSerialized)
++        Method (E0D, 0, NotSerialized)
 +        {
 +            Notify(\_SB.BAT0, 0x80)
 +            Notify(\_SB.BAT1, 0x80)
 +        }
 +
-+        Method (E1E, 0, NotSerialized)
++        Method (E0E, 0, NotSerialized)
 +        {
 +            Notify(\_SB.BAT0, 0x81)
 +            Notify(\_SB.BAT1, 0x81)
@@ -290,34 +290,34 @@ index 13af0ed..4c903b0 100644
 +         *        an io port to get the type of event.
 +         */
 +
-+        Method (_L00, 0, NotSerialized)
++        Method (_L05, 0, NotSerialized)
 +        {
-+            \_SB.E0()
++            \_SB.E05()
 +        }
 +
-+        Method (_L01, 0, NotSerialized)
++        Method (_L06, 0, NotSerialized)
 +        {
-+            \_SB.E1()
++            \_SB.E06()
 +        }
 +
-+        Method (_L1C, 0, NotSerialized)
++        Method (_L0C, 0, NotSerialized)
 +        {
-+            \_SB.E1C()
++            \_SB.E0C()
 +        }
 +
-+        Method (_L17, 0, NotSerialized)
++        Method (_L07, 0, NotSerialized)
 +        {
-+            \_SB.E17()
++            \_SB.E07()
 +        }
 +
-+        Method (_L1D, 0, NotSerialized)
++        Method (_L0D, 0, NotSerialized)
 +        {
-+            \_SB.E1D()
++            \_SB.E0D()
 +        }
 +
-+        Method (_L1E, 0, NotSerialized)
++        Method (_L0E, 0, NotSerialized)
 +        {
-+            \_SB.E1E()
++            \_SB.E0E()
 +        }
 +    }
  }
@@ -326,15 +326,6 @@ diff --git a/tools/firmware/hvmloader/acpi/static_tables.c b/tools/firmware/hvml
 index 323ae31..a73f2ef 100644
 --- a/tools/firmware/hvmloader/acpi/static_tables.c
 +++ b/tools/firmware/hvmloader/acpi/static_tables.c
-@@ -62,7 +62,7 @@ struct acpi_20_fadt Fadt = {
-     .pm1_evt_len = ACPI_PM1A_EVT_BLK_BIT_WIDTH / 8,
-     .pm1_cnt_len = ACPI_PM1A_CNT_BLK_BIT_WIDTH / 8,
-     .pm_tmr_len = ACPI_PM_TMR_BLK_BIT_WIDTH / 8,
--    .gpe0_blk_len = ACPI_GPE0_BLK_LEN_V1,
-+    .gpe0_blk_len = ACPI_GPE0_BLK_LEN_V0,
- 
-     .p_lvl2_lat = 0x0fff, /* >100,  means we do not support C2 state */
-     .p_lvl3_lat = 0x0fff, /* >1000, means we do not support C3 state */
 @@ -70,7 +70,8 @@ struct acpi_20_fadt Fadt = {
      .flags = (ACPI_PROC_C1 |
                ACPI_WBINVD |
@@ -345,27 +336,3 @@ index 323ae31..a73f2ef 100644
  
      .reset_reg = {
          .address_space_id    = ACPI_SYSTEM_IO,
-diff --git a/tools/firmware/hvmloader/seabios.c b/tools/firmware/hvmloader/seabios.c
-index dc298ea..6740a2a 100644
---- a/tools/firmware/hvmloader/seabios.c
-+++ b/tools/firmware/hvmloader/seabios.c
-@@ -44,6 +44,8 @@
- 
- extern unsigned char dsdt_anycpu_qemu_xen[];
- extern int dsdt_anycpu_qemu_xen_len;
-+extern unsigned char dsdt_anycpu[];
-+extern int dsdt_anycpu_len;
- 
- struct seabios_info {
-     char signature[14]; /* XenHVMSeaBIOS\0 */
-@@ -106,8 +108,8 @@ static void seabios_acpi_build_tables(void)
- {
-     uint32_t rsdp = (uint32_t)scratch_alloc(sizeof(struct acpi_20_rsdp), 0);
-     struct acpi_config config = {
--        .dsdt_anycpu = dsdt_anycpu_qemu_xen,
--        .dsdt_anycpu_len = dsdt_anycpu_qemu_xen_len,
-+        .dsdt_anycpu = dsdt_anycpu,
-+        .dsdt_anycpu_len = dsdt_anycpu_len,
-         .dsdt_15cpu = NULL,
-         .dsdt_15cpu_len = 0,
-     };


### PR DESCRIPTION
We used to use the ACPI firmware for QEMU traditional but now we want the
version that matches our new QEMU. Note gpe0_blk_len = ACPI_GPE0_BLK_LEN_V1
is left intact. This matches the new QEMU and is 1/2 as big as the traditional
GPE space. This is also why all of the GPE's in the patch are changed to fit
in 16 bits now. Finally we let the Seabios ACPI builder use the new DSDT
version by removing where we patched it to use traditional.

OXT-259

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>