### PR TITLE
Qemu nic link state

### DIFF
--- a/recipes-openxt/qemu-dm/files/0001-generic-xenstore-extensions.patch
+++ b/recipes-openxt/qemu-dm/files/0001-generic-xenstore-extensions.patch
@@ -56,18 +56,20 @@ Chris Patterson, <pattersonc@ainfosec.com>, 03/31/2015
 
 --- a/hw/xen_backend.c
 +++ b/hw/xen_backend.c
-@@ -658,6 +658,10 @@ static void xenstore_update(void *unused
+@@ -658,6 +658,12 @@ static void xenstore_update(void *unused
      if (sscanf(vec[XS_WATCH_TOKEN], "fe:%" PRIxPTR, &ptr) == 1) {
          xenstore_update_fe(vec[XS_WATCH_PATH], (void*)ptr);
      }
 +    if (sscanf(vec[XS_WATCH_TOKEN], "cb:%" PRIxPTR ":%" PRIxPTR,
 +               &ptr, &ops) == 2) {
-+        ((xenstore_watch_cb_t)ptr)((void *)ops);
++        if (ptr) {
++            ((xenstore_watch_cb_t)ptr)((void *)ops);
++        }
 +    }
  
  cleanup:
      free(vec);
-@@ -685,7 +689,11 @@ static void xen_be_evtchn_event(void *op
+@@ -685,7 +691,11 @@ static void xen_be_evtchn_event(void *op
  
  int xen_be_init(void)
  {
@@ -80,7 +82,7 @@ Chris Patterson, <pattersonc@ainfosec.com>, 03/31/2015
      if (!xenstore) {
          xen_be_printf(NULL, 0, "can't connect to xenstored\n");
          return -1;
-@@ -785,3 +793,88 @@ void xen_be_printf(struct XenDevice *xen
+@@ -785,3 +795,88 @@ void xen_be_printf(struct XenDevice *xen
      }
      qemu_log_flush();
  }

--- a/recipes-openxt/qemu-dm/files/0001-generic-xenstore-extensions.patch
+++ b/recipes-openxt/qemu-dm/files/0001-generic-xenstore-extensions.patch
@@ -19,6 +19,9 @@ Adds the following functions:
 - xenstore_add_watch(): provides ability to register a xenstore watch callback 
   with an optional pointer.
 
+- xenstore_remove_watch(): remove a xenstore watch callback previously
+  registered with xenstore_add_watch().
+
 --------------------------------------------------------------------------------
 UPSTREAM PLAN
 --------------------------------------------------------------------------------
@@ -35,6 +38,9 @@ None.
 CHANGELOG
 --------------------------------------------------------------------------------
 
+Eric Chanudet, <chanudete@ainfosec.com>, 04/18/2015
+- Added xenstore_remove_watch()
+
 Chris Patterson, <pattersonc@ainfosec.com>, 02/15/2015
 - Added xenstore_add_watch()
 
@@ -48,11 +54,9 @@ Chris Patterson, <pattersonc@ainfosec.com>, 03/31/2015
  hw/xen_backend.h |    4 ++++
  2 files changed, 22 insertions(+)
 
-Index: qemu-1.4.0/hw/xen_backend.c
-===================================================================
---- qemu-1.4.0.orig/hw/xen_backend.c	2013-02-15 18:05:35.000000000 -0500
-+++ qemu-1.4.0/hw/xen_backend.c	2015-03-30 17:37:35.720427701 -0400
-@@ -658,6 +658,10 @@
+--- a/hw/xen_backend.c
++++ b/hw/xen_backend.c
+@@ -658,6 +658,10 @@ static void xenstore_update(void *unused
      if (sscanf(vec[XS_WATCH_TOKEN], "fe:%" PRIxPTR, &ptr) == 1) {
          xenstore_update_fe(vec[XS_WATCH_PATH], (void*)ptr);
      }
@@ -63,7 +67,7 @@ Index: qemu-1.4.0/hw/xen_backend.c
  
  cleanup:
      free(vec);
-@@ -685,7 +689,11 @@
+@@ -685,7 +689,11 @@ static void xen_be_evtchn_event(void *op
  
  int xen_be_init(void)
  {
@@ -76,7 +80,7 @@ Index: qemu-1.4.0/hw/xen_backend.c
      if (!xenstore) {
          xen_be_printf(NULL, 0, "can't connect to xenstored\n");
          return -1;
-@@ -785,3 +793,62 @@
+@@ -785,3 +793,88 @@ void xen_be_printf(struct XenDevice *xen
      }
      qemu_log_flush();
  }
@@ -123,6 +127,32 @@ Index: qemu-1.4.0/hw/xen_backend.c
 +}
 +
 +/**
++ * Un-register an existing xenstore node using the specified callback and opaque pointer.
++ * @returns 0 on success, -1 otherwise.
++ */
++int xenstore_remove_watch(const char *base, const char *node,
++                          xenstore_watch_cb_t cb, void *opaque)
++{
++    char abspath[XEN_BUFSIZE];
++    char token[XEN_BUFSIZE];
++
++    snprintf(abspath, sizeof (abspath), "%s/%s", base, node);
++    xen_be_printf(NULL, 1, "xenstore_remove_watch: %s\n", abspath);
++
++    /* For some reason, xs_unwatch will check the token... */
++    snprintf(token, sizeof(token), "cb:%p:%p", cb, opaque);
++    xen_be_printf(NULL, 1, "xenstore_remove_watch: %s - %s\n", abspath, token);
++
++    if (!xs_unwatch(xenstore, abspath, token)) {
++         xen_be_printf(NULL, 1, "xenstore_remove_watch: failed to remove watch for %s\n",
++                       abspath);
++        return -1;
++    }
++
++    return 0;
++}
++
++/**
 + * Open xenstore to support basic xenstore ops before xen_be_init() is invoked.
 + * @returns 0 on success, -1 otherwise.
 + */
@@ -139,11 +169,9 @@ Index: qemu-1.4.0/hw/xen_backend.c
 +
 +    return 0;
 +}
-Index: qemu-1.4.0/hw/xen_backend.h
-===================================================================
---- qemu-1.4.0.orig/hw/xen_backend.h	2013-02-15 18:05:35.000000000 -0500
-+++ qemu-1.4.0/hw/xen_backend.h	2015-03-30 17:35:25.000000000 -0400
-@@ -104,4 +104,11 @@
+--- a/hw/xen_backend.h
++++ b/hw/xen_backend.h
+@@ -104,4 +104,13 @@ int xen_config_dev_vfb(int vdev, const c
  int xen_config_dev_vkbd(int vdev);
  int xen_config_dev_console(int vdev);
  
@@ -153,5 +181,7 @@ Index: qemu-1.4.0/hw/xen_backend.h
 +typedef void (*xenstore_watch_cb_t)(void*);
 +int xenstore_add_watch(const char *base, const char *node,
 +                       xenstore_watch_cb_t cb, void *opaque);
++int xenstore_remove_watch(const char *base, const char *node,
++                          xenstore_watch_cb_t cb, void *opaque);
 +
  #endif /* QEMU_HW_XEN_BACKEND_H */

--- a/recipes-openxt/qemu-dm/files/0024-Stubdom-support-for-ISO-media-changes-after-boot.patch
+++ b/recipes-openxt/qemu-dm/files/0024-Stubdom-support-for-ISO-media-changes-after-boot.patch
@@ -59,10 +59,8 @@ PATCHES
  xen-all.c        |   4 +
  4 files changed, 248 insertions(+), 1 deletion(-)
 
-Index: qemu-1.4.0/blockdev.c
-===================================================================
---- qemu-1.4.0.orig/blockdev.c	2015-03-30 17:39:24.000000000 -0400
-+++ qemu-1.4.0/blockdev.c	2015-03-30 18:02:05.684455298 -0400
+--- a/blockdev.c
++++ b/blockdev.c
 @@ -20,7 +20,7 @@
  #include "qmp-commands.h"
  #include "trace.h"
@@ -72,7 +70,7 @@ Index: qemu-1.4.0/blockdev.c
  static QTAILQ_HEAD(drivelist, DriveInfo) drives = QTAILQ_HEAD_INITIALIZER(drives);
  
  static const char *const if_name[IF_COUNT] = {
-@@ -654,6 +654,13 @@
+@@ -654,6 +654,13 @@ DriveInfo *drive_init(QemuOpts *opts, Bl
          goto err;
      }
  
@@ -86,24 +84,18 @@ Index: qemu-1.4.0/blockdev.c
      if (bdrv_key_required(dinfo->bdrv))
          autostart = 0;
      return dinfo;
-Index: qemu-1.4.0/hw/xen_backend.c
-===================================================================
---- qemu-1.4.0.orig/hw/xen_backend.c	2015-03-30 17:39:24.000000000 -0400
-+++ qemu-1.4.0/hw/xen_backend.c	2015-03-30 18:02:05.684455298 -0400
-@@ -33,16 +33,20 @@
- #include <sys/stat.h>
- #include <sys/mman.h>
- #include <sys/signal.h>
-+#include <syslog.h>
- 
+--- a/hw/xen_backend.c
++++ b/hw/xen_backend.c
+@@ -37,6 +37,8 @@
  #include "hw.h"
  #include "char/char.h"
  #include "qemu/log.h"
 +#include "block/block.h"
 +#include "sysemu/blockdev.h"
  #include "xen_backend.h"
+ #include "qmp-commands.h"
  
- #include <xen/grant_table.h>
+@@ -44,6 +46,7 @@
  
  #include "ui/xen-input.h"
  #include "xen-dmbus.h"
@@ -111,7 +103,7 @@ Index: qemu-1.4.0/hw/xen_backend.c
  
  /* ------------------------------------------------------------- */
  
-@@ -54,6 +58,7 @@
+@@ -55,6 +58,7 @@ const char *xen_protocol;
  
  /* private */
  static QTAILQ_HEAD(XenDeviceHead, XenDevice) xendevs = QTAILQ_HEAD_INITIALIZER(xendevs);
@@ -119,7 +111,7 @@ Index: qemu-1.4.0/hw/xen_backend.c
  static int debug = 0;
  
  /* ------------------------------------------------------------- */
-@@ -643,6 +648,82 @@
+@@ -784,6 +788,82 @@ static void xenstore_update_fe(char *wat
      xen_be_check_state(xendev);
  }
  
@@ -202,7 +194,7 @@ Index: qemu-1.4.0/hw/xen_backend.c
  static void xenstore_update(void *unused)
  {
      char **vec = NULL;
-@@ -665,6 +746,11 @@
+@@ -806,6 +886,11 @@ static void xenstore_update(void *unused
                 &ptr, &ops) == 2) {
          ((xenstore_watch_cb_t)ptr)((void *)ops);
      }
@@ -214,7 +206,7 @@ Index: qemu-1.4.0/hw/xen_backend.c
  
  cleanup:
      free(vec);
-@@ -909,3 +995,149 @@
+@@ -1076,3 +1161,149 @@ bool xenstore_is_legacy_res_only(void)
      return !!val;
  }
  
@@ -228,14 +220,14 @@ Index: qemu-1.4.0/hw/xen_backend.c
 +    struct IsoNode *node = NULL;
 +
 +    if (!file || !dinfo) {
-+	fprintf(stderr, "Failed to register iso device due to incorrect parameters");
-+	return -EINVAL;
++        fprintf(stderr, "Failed to register iso device due to incorrect parameters");
++        return -EINVAL;
 +    }
 +
 +    node = g_malloc0(sizeof(*node));
 +
 +    if (!node) {
-+	return -ENOMEM;
++        return -ENOMEM;
 +    }
 +
 +    /*
@@ -251,8 +243,8 @@ Index: qemu-1.4.0/hw/xen_backend.c
 +    node->timer = qemu_new_timer_ms(rt_clock, update_iso_cb, node);
 +
 +    if (!node->iso_file || !node->timer) {
-+	g_free(node);
-+	return -ENOMEM;
++        g_free(node);
++        return -ENOMEM;
 +    }
 +
 +    QTAILQ_INSERT_TAIL(&iso_list, node, next);
@@ -272,16 +264,16 @@ Index: qemu-1.4.0/hw/xen_backend.c
 +    memset(token, 0x00, XEN_BUFSIZE);
 +
 +    if (!xenstore) {
-+	syslog(LOG_ERR, "%s: No handle to xenstore", __FUNCTION__);
-+	return -1;
++        fprintf(stderr, "%s: No handle to xenstore", __FUNCTION__);
++        return -1;
 +    }
 +
 +    // Stubdom domid is xen_domid+1
 +    dompath = xs_get_domain_path(xenstore, STUBDOMID(xen_domid));
 +
 +    if (!dompath) {
-+	syslog(LOG_ERR, "%s: Failed to retrieve dompath", __FUNCTION__);
-+	return -1;
++        fprintf(stderr, "%s: Failed to retrieve dompath", __FUNCTION__);
++        return -1;
 +    }
 +
 +    snprintf(path, XEN_BUFSIZE, "%s/device/vbd", dompath);
@@ -290,98 +282,93 @@ Index: qemu-1.4.0/hw/xen_backend.c
 +    vbd_devs = xs_directory(xenstore, XBT_NULL, path, &dirNum);
 +
 +    if (!vbd_devs) {
-+	return -1;
++        return -1;
 +    }
 +
 +    for (i = 0; i < dirNum; i++) {
 +
-+	if (!vbd_devs[i]) {
-+	    continue;
-+	}
++        if (!vbd_devs[i]) {
++            continue;
++        }
 +
-+	// Build paths to get necessary information from Xenstore
-+	// Check the device type as CDROM, and get the backend path
-+	memset(path, 0x00, XEN_BUFSIZE);
-+	snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s", dompath, vbd_devs[i]);
-+	char *dev_type = xenstore_read_str(path, "device-type");
-+	char *be = xenstore_read_str(path, "backend");
++        // Build paths to get necessary information from Xenstore
++        // Check the device type as CDROM, and get the backend path
++        memset(path, 0x00, XEN_BUFSIZE);
++        snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s", dompath, vbd_devs[i]);
++        char *dev_type = xenstore_read_str(path, "device-type");
++        char *be = xenstore_read_str(path, "backend");
 +
-+	if (dev_type && be && !strcmp(dev_type, "cdrom")) {
-+	    // We need to watch the backend for this device now.
-+	    char *params = xenstore_read_str(be, "params");
-+	    struct IsoNode *node;
++        if (dev_type && be && !strcmp(dev_type, "cdrom")) {
++            // We need to watch the backend for this device now.
++            char *params = xenstore_read_str(be, "params");
++            struct IsoNode *node;
 +
-+	    QTAILQ_FOREACH(node, &iso_list, next) {
-+		if (node && params &&
-+		    node->xen_vbd_id == NULL &&
-+		    node->frontend_state == NULL) {
-+		    // For mapping a fired watch to a specific device later
-+		    node->xen_vbd_id = strdup(be);
++            QTAILQ_FOREACH(node, &iso_list, next) {
++                if (node && params &&
++                    node->xen_vbd_id == NULL &&
++                    node->frontend_state == NULL) {
++                    // For mapping a fired watch to a specific device later
++                    node->xen_vbd_id = strdup(be);
 +
-+		    // Before the guest disk change can occur, make sure the state
-+		    // of the specified blkfront device is ready
-+		    memset(path, 0x00, XEN_BUFSIZE);
-+		    snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s/state", dompath, vbd_devs[i]);
-+		    node->frontend_state = strdup(path);
-+		    break;
-+		}
-+	    }
++                    // Before the guest disk change can occur, make sure the state
++                    // of the specified blkfront device is ready
++                    memset(path, 0x00, XEN_BUFSIZE);
++                    snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s/state", dompath, vbd_devs[i]);
++                    node->frontend_state = strdup(path);
++                    break;
++                }
++            }
 +
-+	    // Set up the watch on the backend vbd path params key
-+	    memset(path, 0x00, XEN_BUFSIZE);
-+	    snprintf(path, XEN_BUFSIZE, "%s/params", be);
++            // Set up the watch on the backend vbd path params key
++            memset(path, 0x00, XEN_BUFSIZE);
++            snprintf(path, XEN_BUFSIZE, "%s/params", be);
 +
-+	    if (!xs_watch(xenstore, path, "iso")) {
-+		fprintf(stderr, "[OXT-ISO] Failed to install xenstore watch on path: %s", path);
-+	    }
++            if (!xs_watch(xenstore, path, "iso")) {
++                fprintf(stderr, "[OXT-ISO] Failed to install xenstore watch on path: %s", path);
++            }
 +
-+	    if (be) {
-+		free(be);
-+		be = NULL;
-+	    }
++            if (be) {
++                free(be);
++                be = NULL;
++            }
 +
-+	    if (dev_type) {
-+		free(dev_type);
-+		dev_type = NULL;
-+	    }
++            if (dev_type) {
++                free(dev_type);
++                dev_type = NULL;
++            }
 +
-+	    if (params) {
-+		free(params);
-+		params = NULL;
-+	    }
-+	}
++            if (params) {
++                free(params);
++                params = NULL;
++            }
++        }
 +    }
 +
 +    if (dompath) {
-+	free(dompath);
-+	dompath = NULL;
++        free(dompath);
++        dompath = NULL;
 +    }
 +
 +    if (vbd_devs) {
-+	free(vbd_devs);
-+	vbd_devs = NULL;
++        free(vbd_devs);
++        vbd_devs = NULL;
 +    }
 +
 +    return 0;
 +}
-Index: qemu-1.4.0/hw/xen_backend.h
-===================================================================
---- qemu-1.4.0.orig/hw/xen_backend.h	2015-03-30 18:01:38.000000000 -0400
-+++ qemu-1.4.0/hw/xen_backend.h	2015-03-30 18:03:09.204456491 -0400
-@@ -111,4 +111,8 @@
- int xenstore_add_watch(const char *base, const char *node,
-                        xenstore_watch_cb_t cb, void *opaque);
+--- a/hw/xen_backend.h
++++ b/hw/xen_backend.h
+@@ -113,4 +113,7 @@ int xenstore_add_watch(const char *base,
+ int xenstore_remove_watch(const char *base, const char *node,
+                           xenstore_watch_cb_t cb, void *opaque);
  
-+/* TODO: get me outta here! */
 +int xenstore_register_iso_dev(const char *file, DriveInfo *disk);
 +int xenstore_init_iso_dev(void);
 +
  #endif /* QEMU_HW_XEN_BACKEND_H */
-Index: qemu-1.4.0/xen-all.c
-===================================================================
---- qemu-1.4.0.orig/xen-all.c	2015-03-30 17:39:25.000000000 -0400
-+++ qemu-1.4.0/xen-all.c	2015-03-30 18:02:05.684455298 -0400
-@@ -1197,6 +1197,10 @@
+--- a/xen-all.c
++++ b/xen-all.c
+@@ -1197,6 +1197,10 @@ int xen_hvm_init(void)
      xen_be_register("qdisk", &xen_blkdev_ops);
  #endif
  

--- a/recipes-openxt/qemu-dm/files/0025-Enable-changing-of-ISO-media-in-non-stubdom-device-m.patch
+++ b/recipes-openxt/qemu-dm/files/0025-Enable-changing-of-ISO-media-in-non-stubdom-device-m.patch
@@ -58,8 +58,6 @@ PATCHES
  xen-all.c        |   4 +
  4 files changed, 246 insertions(+), 1 deletion(-)
 
-diff --git a/blockdev.c b/blockdev.c
-index f25d242..3e69183 100644
 --- a/blockdev.c
 +++ b/blockdev.c
 @@ -20,7 +20,7 @@
@@ -71,7 +69,7 @@ index f25d242..3e69183 100644
  static QTAILQ_HEAD(drivelist, DriveInfo) drives = QTAILQ_HEAD_INITIALIZER(drives);
  
  static const char *const if_name[IF_COUNT] = {
-@@ -648,6 +648,12 @@ DriveInfo *drive_init(QemuOpts *opts, BlockInterfaceType block_default_type)
+@@ -654,6 +654,12 @@ DriveInfo *drive_init(QemuOpts *opts, Bl
          goto err;
      }
  
@@ -84,24 +82,18 @@ index f25d242..3e69183 100644
      if (bdrv_key_required(dinfo->bdrv))
          autostart = 0;
      return dinfo;
-diff --git a/hw/xen_backend.c b/hw/xen_backend.c
-index a8af20f..79f3073 100644
 --- a/hw/xen_backend.c
 +++ b/hw/xen_backend.c
-@@ -33,16 +33,20 @@
- #include <sys/stat.h>
- #include <sys/mman.h>
- #include <sys/signal.h>
-+#include <syslog.h>
- 
+@@ -37,6 +37,8 @@
  #include "hw.h"
  #include "char/char.h"
  #include "qemu/log.h"
 +#include "block/block.h"
 +#include "sysemu/blockdev.h"
  #include "xen_backend.h"
+ #include "qmp-commands.h"
  
- #include <xen/grant_table.h>
+@@ -44,6 +46,7 @@
  
  #include "ui/xen-input.h"
  #include "xen-dmbus.h"
@@ -109,7 +101,7 @@ index a8af20f..79f3073 100644
  
  /* ------------------------------------------------------------- */
  
-@@ -54,6 +58,7 @@ const char *xen_protocol;
+@@ -55,6 +58,7 @@ const char *xen_protocol;
  
  /* private */
  static QTAILQ_HEAD(XenDeviceHead, XenDevice) xendevs = QTAILQ_HEAD_INITIALIZER(xendevs);
@@ -117,7 +109,7 @@ index a8af20f..79f3073 100644
  static int debug = 0;
  
  /* ------------------------------------------------------------- */
-@@ -643,6 +648,81 @@ static void xenstore_update_fe(char *watch, struct XenDevice *xendev)
+@@ -784,6 +788,81 @@ static void xenstore_update_fe(char *wat
      xen_be_check_state(xendev);
  }
  
@@ -173,7 +165,7 @@ index a8af20f..79f3073 100644
 +            strstr(watch, node->xen_vbd_id) && !node->first_watch) {
 +
 +            newFile = xs_read(xenstore, XBT_NULL, watch, &fileLen);
-+            
++
 +            // Switch out the file path to the iso, so change gets made
 +            // when the node->timer fires.
 +            if (newFile) {
@@ -199,24 +191,24 @@ index a8af20f..79f3073 100644
  static void xenstore_update(void *unused)
  {
      char **vec = NULL;
-@@ -665,6 +745,11 @@ static void xenstore_update(void *unused)
+@@ -806,6 +885,11 @@ static void xenstore_update(void *unused
                 &ptr, &ops) == 2) {
          ((xenstore_watch_cb_t)ptr)((void *)ops);
      }
 +    /* OpenXT:
 +     * Notify the emulator of a change in media */
 +    if (!strcmp(vec[XS_WATCH_TOKEN], "iso")) {
-+      xenstore_update_iso(vec[XS_WATCH_PATH]);
++        xenstore_update_iso(vec[XS_WATCH_PATH]);
 +    }
  
  cleanup:
      free(vec);
-@@ -874,3 +959,150 @@ bool xenstore_is_legacy_res_only(void)
+@@ -1076,3 +1160,150 @@ bool xenstore_is_legacy_res_only(void)
      return !!val;
  }
  
 +/****************************************************
-+ * OpenXT: Media change handling 
++ * OpenXT: Media change handling
 +   Kind of a hack to get ISO updates when the UI changes it
 +   from dom0.
 +*/
@@ -225,17 +217,17 @@ index a8af20f..79f3073 100644
 +    struct IsoNode *node = NULL;
 +
 +    if (!file || !dinfo) {
-+	fprintf(stderr, "Failed to register iso device due to incorrect parameters");
-+	return -EINVAL;  
++        fprintf(stderr, "Failed to register iso device due to incorrect parameters");
++        return -EINVAL;
 +    }
 +
 +    node = g_malloc0(sizeof(*node));
 +
 +    if (!node) {
-+	return -ENOMEM;
++        return -ENOMEM;
 +    }
 +
-+    /* 
++    /*
 +       We can't do our Xen business just yet, because hvm init domain hasn't
 +       been called yet. So we have to save any information needed for registering
 +       until later.
@@ -249,12 +241,12 @@ index a8af20f..79f3073 100644
 +    node->first_watch = true;
 +
 +    if (!node->iso_file || !node->timer) {
-+	g_free(node);
-+	return -ENOMEM;
++        g_free(node);
++        return -ENOMEM;
 +    }
 +
 +    QTAILQ_INSERT_TAIL(&iso_list, node, next);
-+    
++
 +    return 0;
 +}
 +
@@ -265,121 +257,117 @@ index a8af20f..79f3073 100644
 +    char **vbd_devs = NULL;
 +    char path[XEN_BUFSIZE];
 +    char token[XEN_BUFSIZE];
-+    
++
 +    memset(path, 0x00, XEN_BUFSIZE);
 +    memset(token, 0x00, XEN_BUFSIZE);
-+    
++
 +    if (!xenstore) {
-+	syslog(LOG_ERR, "%s: No handle to xenstore", __FUNCTION__);
-+	return -1;
++        fprintf(stderr, "%s: No handle to xenstore", __FUNCTION__);
++        return -1;
 +    }
-+    
++
 +    // Gives us the /local/domain/<domid>
 +    dompath = xs_get_domain_path(xenstore, xen_domid);
-+    
++
 +    if (!dompath) {
-+	syslog(LOG_ERR, "%s: Failed to retrieve dompath", __FUNCTION__);
-+	return -1;
++        fprintf(stderr, "%s: Failed to retrieve dompath", __FUNCTION__);
++        return -1;
 +    }
-+    
++
 +    snprintf(path, XEN_BUFSIZE, "%s/device/vbd", dompath);
-+    
++
 +    // Find the virtual-device id that blkfront is using for this device
 +    vbd_devs = xs_directory(xenstore, XBT_NULL, path, &dirNum);
-+    
++
 +    if (!vbd_devs) {
-+	return -1;
++        return -1;
 +    }
 +
 +    for (i = 0; i < dirNum; i++) {
 +
-+	if (!vbd_devs[i]) {
-+	    continue;
-+	}
-+	
-+	// Build paths to get necessary information from Xenstore
-+	// Check the device type as CDROM, and get the backend path
-+	memset(path, 0x00, XEN_BUFSIZE);
-+	snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s", dompath, vbd_devs[i]);
-+	char *dev_type = xenstore_read_str(path, "device-type");
-+	char *be = xenstore_read_str(path, "backend");
-+	
-+	if (dev_type && be && !strcmp(dev_type, "cdrom")) {
-+	    // We need to watch the backend for this device now.
-+	    char *params = xenstore_read_str(be, "params");
-+	    struct IsoNode *node;
-+	    
-+	    QTAILQ_FOREACH(node, &iso_list, next) {
-+		if (node && params && 
-+		    node->xen_vbd_id == NULL &&
-+		    node->frontend_state == NULL) {
-+		    // For mapping a fired watch to a specific device later
-+		    node->xen_vbd_id = strdup(be);
-+		    
-+		    // Before the guest disk change can occur, make sure the state
-+		    // of the specified blkfront device is ready
-+		    memset(path, 0x00, XEN_BUFSIZE);
-+		    snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s/state", dompath, vbd_devs[i]);
-+		    node->frontend_state = strdup(path);
-+		    break;
-+		}
-+	    } 
++        if (!vbd_devs[i]) {
++            continue;
++        }
 +
-+	    // Set up the watch on the backend vbd path params key
-+	    memset(path, 0x00, XEN_BUFSIZE);
-+	    snprintf(path, XEN_BUFSIZE, "%s/params", be);   
++        // Build paths to get necessary information from Xenstore
++        // Check the device type as CDROM, and get the backend path
++        memset(path, 0x00, XEN_BUFSIZE);
++        snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s", dompath, vbd_devs[i]);
++        char *dev_type = xenstore_read_str(path, "device-type");
++        char *be = xenstore_read_str(path, "backend");
 +
-+	    if (!xs_watch(xenstore, path, "iso")) {
-+		fprintf(stderr, "[OXT-ISO] Failed to install xenstore watch on path: %s", path);
-+	    }
-+	    
-+	    if (be) {
-+		free(be);
-+		be = NULL;
-+	    }
++        if (dev_type && be && !strcmp(dev_type, "cdrom")) {
++            // We need to watch the backend for this device now.
++            char *params = xenstore_read_str(be, "params");
++            struct IsoNode *node;
 +
-+	    if (dev_type) {
-+		free(dev_type);
-+		dev_type = NULL;
-+	    }
-+	    
-+	    if (params) {
-+		free(params);
-+		params = NULL;
-+	    }
-+	}
++            QTAILQ_FOREACH(node, &iso_list, next) {
++                if (node && params &&
++                    node->xen_vbd_id == NULL &&
++                    node->frontend_state == NULL) {
++                    // For mapping a fired watch to a specific device later
++                    node->xen_vbd_id = strdup(be);
++
++                    // Before the guest disk change can occur, make sure the state
++                    // of the specified blkfront device is ready
++                    memset(path, 0x00, XEN_BUFSIZE);
++                    snprintf(path, XEN_BUFSIZE, "%s/device/vbd/%s/state", dompath, vbd_devs[i]);
++                    node->frontend_state = strdup(path);
++                    break;
++                }
++            }
++
++            // Set up the watch on the backend vbd path params key
++            memset(path, 0x00, XEN_BUFSIZE);
++            snprintf(path, XEN_BUFSIZE, "%s/params", be);
++
++            if (!xs_watch(xenstore, path, "iso")) {
++                fprintf(stderr, "[OXT-ISO] Failed to install xenstore watch on path: %s", path);
++            }
++
++            if (be) {
++                free(be);
++                be = NULL;
++            }
++
++            if (dev_type) {
++                free(dev_type);
++                dev_type = NULL;
++            }
++
++            if (params) {
++                free(params);
++                params = NULL;
++            }
++        }
 +    }
 +
 +    if (dompath) {
-+	free(dompath);
-+	dompath = NULL;
++        free(dompath);
++        dompath = NULL;
 +    }
-+    
++
 +    if (vbd_devs) {
-+	free(vbd_devs);
-+	vbd_devs = NULL;
++        free(vbd_devs);
++        vbd_devs = NULL;
 +    }
-+        
++
 +    return 0;
 +}
-diff --git a/hw/xen_backend.h b/hw/xen_backend.h
-index f1e12e0..d5f086b 100644
 --- a/hw/xen_backend.h
 +++ b/hw/xen_backend.h
-@@ -111,4 +111,8 @@
- int xenstore_add_watch(const char *base, const char *node,
-                        xenstore_watch_cb_t cb, void *opaque);
+@@ -113,4 +113,8 @@ int xenstore_add_watch(const char *base,
+ int xenstore_remove_watch(const char *base, const char *node,
+                           xenstore_watch_cb_t cb, void *opaque);
  
 +/* TODO: get me outta here! */
 +int xenstore_register_iso_dev(const char *file, DriveInfo *disk);
 +int xenstore_init_iso_dev(void);
 +
  #endif /* QEMU_HW_XEN_BACKEND_H */
-diff --git a/xen-all.c b/xen-all.c
-index 2a1a711..2264e40 100644
 --- a/xen-all.c
 +++ b/xen-all.c
-@@ -1180,6 +1180,10 @@ int xen_hvm_init(void)
+@@ -1197,6 +1197,10 @@ int xen_hvm_init(void)
      xen_be_register("qdisk", &xen_blkdev_ops);
  #endif
  
@@ -390,6 +378,3 @@ index 2a1a711..2264e40 100644
      xen_read_physmap(state);
  
      return 0;
--- 
-2.1.0
-

--- a/recipes-openxt/qemu-dm/files/0027-nic-link-state-propagation.patch
+++ b/recipes-openxt/qemu-dm/files/0027-nic-link-state-propagation.patch
@@ -1,0 +1,246 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Have the emulated NICs mirror the link-status of the network back-end, exposed
+through XenStore.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+QEMU's current default network configuration is to have two NICs (rtl8139
+emulations), one for the Ethernet interface and one for the Wireless.
+Each emulated card is connected to a "QEMU vlan" (not 802.1q VLAN), actually an
+emulated hub (-net option behaviour), to which is also connected the tap
+interface of its backend.
+
+For each NIC created by QEMU, we add a XenStore watch on the node of the
+network back-end plugged in the same hub. This let us retrieve the back-end
+information using the nd_table (NICInfo).
+
+################################################################################
+CHANGELOG 
+################################################################################
+Port & documentation: Eric Chanudet, chanudete@ainfosec.com, 17/04/2015
+Intial Commit: Unknown
+
+################################################################################
+REMOVAL 
+################################################################################
+With the current OpenXT guest network configuration, removing this patch will
+trigger routing issues in the guest.
+
+################################################################################
+UPSTREAM PLAN 
+################################################################################
+There is no plan to upstream this patch, it is OpenXT specific.
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+None
+
+################################################################################
+PATCHES 
+################################################################################
+--- a/hw/xen.h
++++ b/hw/xen.h
+@@ -38,6 +38,9 @@ void xen_piix_pci_write_config_client(ui
+ void xen_hvm_inject_msi(uint64_t addr, uint32_t data);
+ void xen_cmos_set_s3_resume(void *opaque, int irq, int level);
+ 
++int xenstore_register_nic(NetClientState *nc);
++int xenstore_unregister_nic(NetClientState *nc);
++
+ qemu_irq *xen_interrupt_controller_init(void);
+ 
+ int xen_init(void);
+--- a/hw/xen_backend.c
++++ b/hw/xen_backend.c
+@@ -38,6 +38,7 @@
+ #include "char/char.h"
+ #include "qemu/log.h"
+ #include "xen_backend.h"
++#include "qmp-commands.h"
+ 
+ #include <xen/grant_table.h>
+ 
+@@ -589,6 +590,143 @@ static int xenstore_scan(const char *typ
+     return 0;
+ }
+ 
++/*
++ * OpenXT: Get type and id from \([a-zA-Z]\+\)\([0-9]\+\).
++ */
++static void xenstore_nic_parse_name(const char *name, char *type, char *id)
++{
++    if (name) {
++        while (isalpha(*name)) {
++            *(type++) = *(name++);
++        }
++        while (isdigit(*name)) {
++            *(id++) = *(name++);
++        }
++    }
++    *type = '\0';
++    *id = '\0';
++}
++
++/*
++ * OpenXT: Get network backend type and ID from NIC information table.
++ */
++static int xenstore_net_client_state_fetch_backend_info(NetClientState *ncs, char *type, char *id)
++{
++    size_t i;
++
++    for (i = 0; i < MAX_NICS; ++i) {
++        /* We assume there is only one NIC per hub. So, if a NIC is on our
++         * hub, it is our back-end. */
++        if (nd_table[i].netdev == ncs->peer) {
++            xenstore_nic_parse_name(nd_table[i].name, type, id);
++            return 0;
++        }
++    }
++    return -1;
++}
++
++/* Define constants for network devices XenStore data representation. */
++#define XENSTORE_NET_TYPE_LEN   5   /* Currently "vif"|"vwif" */
++#define XENSTORE_NET_ID_LEN     5
++/* OpenXT: Read the appropriate Base Register and check if we have to change
++ * the device status. */
++static void xenstore_update_nic(void *opaque)
++{
++    NetClientState *nc = opaque;
++    char *dompath;
++    char type[XENSTORE_NET_TYPE_LEN];
++    char id[XENSTORE_NET_ID_LEN];
++    char base[XEN_BUFSIZE];
++    int val;
++
++    if (xenstore_net_client_state_fetch_backend_info(nc, type, id)) {
++        fprintf(stderr, "Failed to find a network back-end for `%s'.\n", nc->name);
++        return;
++    }
++
++    dompath = xs_get_domain_path(xenstore, xen_domid);
++    if (!dompath) {
++        fprintf(stderr, "Could not retrieve domain path.\n");
++        return;
++    }
++    snprintf(base, sizeof (base), "%s/device/%s/%s", dompath, type, id);
++    free(dompath);
++
++    if (xenstore_read_int(base, "disconnect", &val)) {
++        fprintf(stderr, "Failed to read xenstore path (%s/%s).\n", base, "disconnect");
++        return;
++    }
++
++    /* The value is actually a boolean. */
++    if (nc->link_down != !!val) {
++        fprintf(stderr, "%s (%s%s): link status is now %s.\n", nc->name, type, id, !!val ? "down" : "up");
++        /* Notify the emulation through QMP.
++         * Note that qmp_set_link boolean is "link-up?", not nc->link_down "link-down?". */
++        qmp_set_link(nc->name, !val, NULL);
++    }
++}
++
++/* OpenXT: Register a Net Client in Xenstore. */
++int xenstore_register_nic(NetClientState *nc)
++{
++    char *dompath;
++    char type[XENSTORE_NET_TYPE_LEN];
++    char id[XENSTORE_NET_ID_LEN];
++    char base[XEN_BUFSIZE];
++
++    if (xenstore_net_client_state_fetch_backend_info(nc, type, id)) {
++        fprintf(stderr, "Failed to find a network back-end for `%s'.\n", nc->name);
++        return -1;
++    }
++
++    dompath = xs_get_domain_path(xenstore, xen_domid);
++    if (!dompath) {
++        fprintf(stderr, "Could not retrieve domain path.\n");
++        return -1;
++    }
++    snprintf(base, sizeof (base), "%s/device/%s/%s", dompath, type, id);
++    free(dompath);
++
++    if (xenstore_add_watch(base, "disconnect", xenstore_update_nic, nc)) {
++        fprintf(stderr, "Could not install xenstore watch on path `%s/disconnect'.\n", base);
++        return -1;
++    }
++
++    xenstore_update_nic(nc);
++
++    return 0;
++}
++
++/* OpenXT: Unregister a Net Client in Xenstore.
++ * Called when a device is removed and no longer used. */
++int xenstore_unregister_nic(NetClientState *nc)
++{
++    char *dompath;
++    char type[XENSTORE_NET_TYPE_LEN];
++    char id[XENSTORE_NET_ID_LEN];
++    char base[XEN_BUFSIZE];
++
++    if (xenstore_net_client_state_fetch_backend_info(nc, type, id)) {
++        fprintf(stderr, "Failed to find a network back-end for `%s'.\n", nc->name);
++        return -1;
++    }
++
++    dompath = xs_get_domain_path(xenstore, xen_domid);
++    if (!dompath) {
++        fprintf(stderr, "Could not retrieve domain path.\n");
++        return -1;
++    }
++    snprintf(base, sizeof (base), "%s/device/%s/%s", dompath, type, id);
++    free(dompath);
++
++    if (xenstore_remove_watch(base, "disconnect", xenstore_update_nic, id)) {
++        fprintf(stderr, "Could not remove xenstore watch on path `%s/disconnect'.\n", base);
++        return -1;
++    }
++    /* TODO: xenstore_update_nic() and force disconnect if not already? */
++    return 0;
++}
++
+ static void xenstore_update_be(char *watch, char *type, int dom,
+                                struct XenDevOps *ops)
+ {
+--- a/net/net.c
++++ b/net/net.c
+@@ -40,6 +40,9 @@
+ #include "qapi/opts-visitor.h"
+ #include "qapi/dealloc-visitor.h"
+ 
++/* OpenXT: xenstore_register_nic() and xenstore_unregister_nic(). */
++#include "hw/xen.h"
++
+ /* Net bridge is currently not supported for W32. */
+ #if !defined(_WIN32)
+ # define CONFIG_NET_BRIDGE
+@@ -256,6 +259,12 @@ NICState *qemu_new_nic(NetClientInfo *in
+         nic->ncs[i].queue_index = i;
+     }
+ 
++    /* OpenXT: Register the new NetClientState to Xenstore.
++     * Required for link-state propagation logic. */
++    if (xen_enabled()) {
++        xenstore_register_nic(nc);
++    }
++
+     return nic;
+ }
+ 
+@@ -364,6 +373,10 @@ void qemu_del_nic(NICState *nic)
+ 
+     for (i = queues - 1; i >= 0; i--) {
+         NetClientState *nc = qemu_get_subqueue(nic, i);
++        /* OpenXT: Unregister NetClientState from Xenstore. */
++        if (xen_enabled()) {
++            xenstore_unregister_nic(nc);
++        }
+ 
+         qemu_cleanup_net_client(nc);
+         qemu_free_net_client(nc);

--- a/recipes-openxt/qemu-dm/files/0027-nic-link-state-propagation.patch
+++ b/recipes-openxt/qemu-dm/files/0027-nic-link-state-propagation.patch
@@ -64,50 +64,80 @@ PATCHES
  
  #include <xen/grant_table.h>
  
-@@ -589,6 +590,143 @@ static int xenstore_scan(const char *typ
+@@ -589,6 +590,188 @@ static int xenstore_scan(const char *typ
      return 0;
  }
  
 +/*
-+ * OpenXT: Get type and id from \([a-zA-Z]\+\)\([0-9]\+\).
++ * OpenXT: Get type and id from \([a-zA-Z]\\{1,XENSTORE_NET_TYPE_LEN - 1\}\)\([0-9]\{1,XENSTORE_NET_ID_LEN\}\).
++ *
++ * @param name is a null terminated character string.
++ * @param type is able to store at least XENSTORE_NET_TYPE_LEN bytes.
++ * @param id is able to store at least XENSTORE_NET_ID_LEN bytes.
++ * @return 0 on success, -ERRNO else.
 + */
-+static void xenstore_nic_parse_name(const char *name, char *type, char *id)
++/* Define constants for network devices XenStore data representation. */
++#define XENSTORE_NET_TYPE_LEN   5   /* Currently "vif"|"vwif" */
++#define XENSTORE_NET_ID_LEN     5
++static int xenstore_nic_parse_name(const char *name, char *type, char *id)
 +{
-+    if (name) {
-+        while (isalpha(*name)) {
-+            *(type++) = *(name++);
-+        }
-+        while (isdigit(*name)) {
-+            *(id++) = *(name++);
-+        }
++    size_t i;
++
++    assert(name);
++    assert(type);
++    assert(id);
++
++    for (i = 0; isalpha(*name) && (i < XENSTORE_NET_TYPE_LEN - 1); ++i) {
++        type[i] = *(name++);
 +    }
-+    *type = '\0';
-+    *id = '\0';
++    if (!i) {
++        return -EINVAL;
++    }
++    type[i] = '\0';
++
++    for (i = 0; isdigit(*name) && (i < XENSTORE_NET_ID_LEN - 1); ++i) {
++        id[i] = *(name++);
++    }
++    if (!i) {
++        return -EINVAL;
++    }
++    id[i] = '\0';
++
++    return 0;
 +}
 +
 +/*
 + * OpenXT: Get network backend type and ID from NIC information table.
++ *
++ * @param ncs a valid NetClientState.
++ * @param type is able to store at least XENSTORE_NET_TYPE_LEN bytes.
++ * @param id is able to store at least XENSTORE_NET_ID_LEN bytes.
++ * @return 0 on success, -ERRNO else.
 + */
 +static int xenstore_net_client_state_fetch_backend_info(NetClientState *ncs, char *type, char *id)
 +{
 +    size_t i;
 +
++    assert(ncs);
++    assert(type);
++    assert(id);
++
 +    for (i = 0; i < MAX_NICS; ++i) {
 +        /* We assume there is only one NIC per hub. So, if a NIC is on our
-+         * hub, it is our back-end. */
-+        if (nd_table[i].netdev == ncs->peer) {
-+            xenstore_nic_parse_name(nd_table[i].name, type, id);
-+            return 0;
++         * hub, it is our back-end. Also make sure name is still valid (reset at
++         * guest shutdown apparently).*/
++        if (nd_table[i].netdev == ncs->peer && nd_table[i].name) {
++            return xenstore_nic_parse_name(nd_table[i].name, type, id);
 +        }
 +    }
-+    return -1;
++    return -ENODEV;
 +}
 +
-+/* Define constants for network devices XenStore data representation. */
-+#define XENSTORE_NET_TYPE_LEN   5   /* Currently "vif"|"vwif" */
-+#define XENSTORE_NET_ID_LEN     5
 +/* OpenXT: Read the appropriate Base Register and check if we have to change
-+ * the device status. */
++ * the device status.
++ *
++ * @param opaque a valid pointer to a NetClientState object.
++ */
 +static void xenstore_update_nic(void *opaque)
 +{
 +    NetClientState *nc = opaque;
@@ -116,6 +146,8 @@ PATCHES
 +    char id[XENSTORE_NET_ID_LEN];
 +    char base[XEN_BUFSIZE];
 +    int val;
++
++    assert(opaque);
 +
 +    if (xenstore_net_client_state_fetch_backend_info(nc, type, id)) {
 +        fprintf(stderr, "Failed to find a network back-end for `%s'.\n", nc->name);
@@ -144,13 +176,20 @@ PATCHES
 +    }
 +}
 +
-+/* OpenXT: Register a Net Client in Xenstore. */
++/*
++ * OpenXT: Register a Net Client in Xenstore.
++ *
++ * @param nc a valid pointer to a NetClientState object.
++ * @return 0 on success, -1 else.
++ * */
 +int xenstore_register_nic(NetClientState *nc)
 +{
 +    char *dompath;
 +    char type[XENSTORE_NET_TYPE_LEN];
 +    char id[XENSTORE_NET_ID_LEN];
 +    char base[XEN_BUFSIZE];
++
++    assert(nc);
 +
 +    if (xenstore_net_client_state_fetch_backend_info(nc, type, id)) {
 +        fprintf(stderr, "Failed to find a network back-end for `%s'.\n", nc->name);
@@ -175,14 +214,21 @@ PATCHES
 +    return 0;
 +}
 +
-+/* OpenXT: Unregister a Net Client in Xenstore.
-+ * Called when a device is removed and no longer used. */
++/*
++ * OpenXT: Unregister a Net Client in Xenstore.
++ * Called when a device is removed and no longer used.
++ *
++ * @param nc a valid pointer to a NetClientState object.
++ * @return 0 on success, -1 else.
++ */
 +int xenstore_unregister_nic(NetClientState *nc)
 +{
 +    char *dompath;
 +    char type[XENSTORE_NET_TYPE_LEN];
 +    char id[XENSTORE_NET_ID_LEN];
 +    char base[XEN_BUFSIZE];
++
++    assert(nc);
 +
 +    if (xenstore_net_client_state_fetch_backend_info(nc, type, id)) {
 +        fprintf(stderr, "Failed to find a network back-end for `%s'.\n", nc->name);
@@ -201,7 +247,6 @@ PATCHES
 +        fprintf(stderr, "Could not remove xenstore watch on path `%s/disconnect'.\n", base);
 +        return -1;
 +    }
-+    /* TODO: xenstore_update_nic() and force disconnect if not already? */
 +    return 0;
 +}
 +

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -38,6 +38,7 @@ SRC_URI += "file://0001-generic-xenstore-extensions.patch \
             file://0020-audio-policy.patch;striplevel=1 \
             file://0023-msix-cap-disable.patch;striplevel=1 \
             file://0026-openxtaudio.patch;striplevel=1 \
+            file://0027-nic-link-state-propagation.patch;striplevel=1 \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"


### PR DESCRIPTION
Have the emulated NICs mirror the link-status of the network back-end, exposed through XenStore.

Add xenstore_remove_watch() in addition to the existing XenStore helpers.

I had to refresh patches 0024/0025 and took the opportunity to remove trailing white-spaces and tabs that went in. Also, there was a dependency on syslog in the patch, I choose to remove it since we make syslog logging optional by a configure flag.

OXT-254