### PR TITLE
Fix USB (PCI in general) pass-through problems w/ stubdoms.

### DIFF
--- a/recipes-openxt/qemu-dm/files/0029-stubdom-read-gsi-from-device-config-space.patch
+++ b/recipes-openxt/qemu-dm/files/0029-stubdom-read-gsi-from-device-config-space.patch
@@ -1,0 +1,75 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Stubdoms read the GSI for pass-through devices from the device config space.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+It starts with the error that comes out of QEMU:
+
+xen_pt_initfn: Error: Mapping machine irq 25 to pirq -1 failed, (rc: -1)
+
+This is happening because Xen and the stubdom kernel have already mapped
+the GSI to a PIRQ for the stubdom while the PCI bus was being initialized
+at boot time. This is normal behavior but having the GSI->PIRQ mapping in
+the stubdom doesn't do the real domU any good. Worse, when this mapping
+is done, the pci_dev instance is updated with the mapped device PIRQ.
+This is where QEMU gets the updated value and erroneously passes to Xen
+to map for the real domU. This causes the error above because the PIRQ
+is not the host GSI.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Created: Ross Philipson, philipsonr@ainfosec.com, 05/05/2015
+
+################################################################################
+REMOVAL 
+################################################################################
+This patch is required for PCI pass-through to work in stubdoms.
+
+################################################################################
+UPSTREAM PLAN
+This patch should be upstreamed.
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+Depended on: 0028-compile-time-stubdom-flag.patch
+
+################################################################################
+PATCHES 
+################################################################################
+Index: qemu-1.4.0/hw/xen_pt.c
+===================================================================
+--- qemu-1.4.0.orig/hw/xen_pt.c	2015-05-05 10:46:36.316412156 -0400
++++ qemu-1.4.0/hw/xen_pt.c	2015-05-05 10:46:46.947428711 -0400
+@@ -701,7 +701,27 @@
+         goto out;
+     }
+ 
++#ifdef CONFIG_STUBDOM
++    /*
++     * In stubdoms, the kernel and Xen have already setup a GSI->PIRQ mapping
++     * for PCI devices when the PCI bus is initialized. A side effect of this
++     * is that the irq field in the pci_dev instance is updated with the PIRQ
++     * value (see xen_pcifront_enable_irq). This is not a correct value to
++     * call xc_physdev_map_pirq with. The config space of the pcifront device
++     * still contains the valid GSI value so it can be gotten from there.
++     */
++    rc = xen_host_pci_get_byte(&s->real_device, PCI_INTERRUPT_LINE, &machine_irq);
++    if (rc) {
++        XEN_PT_ERR(d, "Read PCI_INTERRUPT_LINE value failed.\n");
++        return -1;
++    }
++
++    xen_pt_log(d, "PCI stubdom - read GSI from config: %d\n", machine_irq);
++#else
+     machine_irq = s->real_device.irq;
++    xen_pt_log(d, "PCI - use GSI from pci_dev: %d\n", machine_irq);
++#endif
++
+     rc = xc_physdev_map_pirq(xen_xc, xen_domid, machine_irq, &pirq);
+ 
+     if (rc < 0) {

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -39,6 +39,7 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://0023-msix-cap-disable.patch;striplevel=1 \
             file://0026-openxtaudio.patch;striplevel=1 \
             file://0027-nic-link-state-propagation.patch;striplevel=1 \
+            file://0029-stubdom-read-gsi-from-device-config-space.patch;striplevel=1 \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"


### PR DESCRIPTION
See comments in the patch and the patch header.

OXT-269

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>