### PR TITLE
Allow custom source cert filenames

### DIFF
--- a/recipes-openxt/xenclient-repo-certs/xenclient-repo-certs_1.0.bb
+++ b/recipes-openxt/xenclient-repo-certs/xenclient-repo-certs_1.0.bb
@@ -12,14 +12,13 @@ FILES_${PN} = "${datadir}/xenclient/repo-certs \
 inherit xenclient
 
 do_install() {
-    install -d ${D}${datadir}/xenclient/repo-certs/prod
+    CERTDIR_PROD=${D}${datadir}/xenclient/repo-certs/prod
+    CERTDIR_DEV=${D}${datadir}/xenclient/repo-certs/dev
+    install -d ${CERTDIR_PROD}
+    install -d ${CERTDIR_DEV}
 
-    for i in prod dev ; do
-        CERTDIR=${D}${datadir}/xenclient/repo-certs/$i
-
-        install -d ${CERTDIR}
-        install -m 0644 ${WORKDIR}/$i-cacert.pem ${CERTDIR}/cert.pem
-    done
+    install -m 0644 ${WORKDIR}/$(basename ${REPO_PROD_CACERT}) ${CERTDIR_PROD}/cert.pem
+    install -m 0644 ${WORKDIR}/$(basename ${REPO_DEV_CACERT}) ${CERTDIR_DEV}/cert.pem
 
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/verify-repo-metadata ${D}${bindir}/


### PR DESCRIPTION
The previous recipe requires the source filenames to be
"prod-cacert.pem" and "dev-cacert.pem" otherwise do_install would fail
to find what it was expecting. This patch modifies do_install to use the
basename from the configuration file for these certificates and put them
into the package in their standardized format without requiring an
intermediate standard that was also different.

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>