### PR TITLE
firstboot: remove chown for tss:tss on PS_DIR

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/firstboot.sh
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/firstboot.sh
@@ -68,9 +68,6 @@ if [ ! -s ${PS_FILE} ]; then
     install -m 600 -o ${TSS_USER} -g ${TSS_USER} ${PS_FILE_SRC} ${PS_FILE}
 fi
 
-# update the uid/gids for the upgrade case (new passwd and group files are shipped)
-chown -R ${TSS_USER}:${TSS_USER} ${PS_DIR}
-
 # Make /var/log/wtmp volatile.
 if [ ! -L /var/log/wtmp ] ; then
     rm -f /var/log/wtmp


### PR DESCRIPTION
It really needs to be only on PS_FILE, PS_DIR is too broad. It also
appears to be unnecessary for two reasons:

1) this needs to be done in time for init.root-ro, which this is not.
2) and init.root-ro looks like it replaces every boot (if it is non-zero
sized) anyways.

In fact, as a result of 2, the firstboot install of the trousers files
can probably be safely removed altogether.

OXT-272

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>