### PR TITLE
[qemu-dm] add max-ram-below-4g parameter.

### DIFF
--- a/recipes-openxt/qemu-dm/files/0030-xenfv-i440fx-max-ram-below-4g.patch
+++ b/recipes-openxt/qemu-dm/files/0030-xenfv-i440fx-max-ram-below-4g.patch
@@ -1,3 +1,63 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Add machine option "max-ram-below-4g" to configure the RAM limit below 32b
+address boundary.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+QEMU configures the guest memory layout using assumptions that will not always
+match what hvmloader sets up later, leaving the guest with an e820 not matching
+either the i440fx emulation or Xen configuration.
+
+By default, QEMU Xen memory listener will assume RAM below 4G cannot grow past
+0xf0000000, leaving a 256MB region for reserved IO regions. The memory layout
+is then set up based on this assumption. If the guest is 64bits capable and has
+more than 3840MB memory, another memory region will be created above the 4G
+limit to account for it. Also, the main memory region ("xen.ram") size will be
+processed based on that.
+The i440fx emulation, however, assumes RAM below 4G cannot grow past
+0xe0000000, leaving a 512MB region for reserved IO regions.
+Hvmloader will then process the size of the PCI hole the guest would require to
+be able to manage all its PCI devices resources and modify the e820
+accordingly, depending on what PCI devices it finds.
+
+This patch does 2 things:
+- When using Xen support, have i440fx and the Xen memory listener use the same
+  below 4G RAM boundary.
+- Add a machine option to change that limit so the PCI hole can be bigger to
+  accomodate more PCI resources (e.g, GPU pass-through)
+
+Hvmloader will still try to process the size of the PCI hole to map every PCI
+resource (max RAM below 4G will be 0x{f,e,c,8}0000000). Therefor,
+max-ram-below-4g should predict that.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Intial Commit: Eric Chanudet, chanudete@ainfosec.com, 14/05/2015
+
+################################################################################
+REMOVAL 
+################################################################################
+The same option has been introduced since QEMU 2.2 upstream.
+
+################################################################################
+UPSTREAM PLAN 
+################################################################################
+There is no plan to upstream this patch, it is an OpenXT workaround for QEMU<2.2
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+The toolstack will process the value for max-ram-below-4g.
+dm-agent will read the value processed by the toolstack and pass it on QEMU
+command line.
+
+################################################################################
+PATCHES 
+################################################################################
 --- a/hw/pc.h
 +++ b/hw/pc.h
 @@ -129,6 +129,7 @@ extern int no_hpet;

--- a/recipes-openxt/qemu-dm/files/0030-xenfv-i440fx-max-ram-below-4g.patch
+++ b/recipes-openxt/qemu-dm/files/0030-xenfv-i440fx-max-ram-below-4g.patch
@@ -1,0 +1,187 @@
+--- a/hw/pc.h
++++ b/hw/pc.h
+@@ -129,6 +129,7 @@ extern int no_hpet;
+ struct PCII440FXState;
+ typedef struct PCII440FXState PCII440FXState;
+ 
++#define I440FX_TOLUM  0xe0000000
+ PCIBus *i440fx_init(PCII440FXState **pi440fx_state, int *piix_devfn,
+                     ISABus **isa_bus, qemu_irq *pic,
+                     MemoryRegion *address_space_mem,
+--- a/hw/pc_piix.c
++++ b/hw/pc_piix.c
+@@ -67,7 +67,7 @@ static void pc_init1(MemoryRegion *syste
+                      int kvmclock_enabled)
+ {
+     int i;
+-    ram_addr_t below_4g_mem_size, above_4g_mem_size;
++    ram_addr_t below_4g_mem_size, above_4g_mem_size, max_ram_below_4g;
+     PCIBus *pci_bus;
+     ISABus *isa_bus;
+     PCII440FXState *i440fx_state;
+@@ -93,9 +93,24 @@ static void pc_init1(MemoryRegion *syste
+         kvmclock_create();
+     }
+ 
+-    if (ram_size >= 0xe0000000 ) {
+-        above_4g_mem_size = ram_size - 0xe0000000;
+-        below_4g_mem_size = 0xe0000000;
++    /* Default I440FX emulation will use 0xE0000000 hardcoded value as Top Of
++     * Low Usable Memory (upper RAM boundary below 32b address limit).  Above
++     * that limit is usually MMIO hole and reserved regions. With pass-through
++     * support and eventualy with some PCI configuration, the MMIO hole can be
++     * required to be more than 512MB. Also, Xen exports this limit in public
++     * headers to be 0xF0000000, so the top 256MB below the 32bits address
++     * space 4G limit (e820.h). On top of that, hvmloader tries to process that
++     * value after Qemu is initialized (pci.c).
++     * So, for now, we should consider that limit to be configurable. The
++     * toolstack will be responsible to figure out what MMIO hole would be
++     * required for the device model it starts up.
++     * Later versions of QEMU make that value a property of the machine
++     * emulated.
++     */
++    max_ram_below_4g = xen_enabled() ? xen_low_ram_boundary(ram_size) : I440FX_TOLUM;
++    if (ram_size >= max_ram_below_4g) {
++        above_4g_mem_size = ram_size - max_ram_below_4g;
++        below_4g_mem_size = max_ram_below_4g;
+     } else {
+         above_4g_mem_size = 0;
+         below_4g_mem_size = ram_size;
+--- a/xen-all.c
++++ b/xen-all.c
+@@ -167,30 +167,57 @@ qemu_irq *xen_interrupt_controller_init(
+ }
+ 
+ /* Memory Ops */
+-
+-static void xen_ram_init(ram_addr_t ram_size)
++/*
++ * Returns min("max-ram-below-4g", HVM_BELOW_4G_RAM_END).
++ * Default if max-ram-below-4g is not defined will ve HVM_BELOW_4G_RAM_END.
++ */
++uint64_t xen_low_ram_boundary(ram_addr_t ram_size)
+ {
+-    MemoryRegion *sysmem = get_system_memory();
+-    ram_addr_t below_4g_mem_size, above_4g_mem_size = 0;
+-    ram_addr_t block_len;
++    QemuOptsList *list = qemu_find_opts("machine");
++    ram_addr_t max_ram_below_4g = HVM_BELOW_4G_RAM_END;   /* 0xF0000000 by default. */
+ 
+-    block_len = ram_size;
+-    if (ram_size >= HVM_BELOW_4G_RAM_END) {
+-        /* Xen does not allocate the memory continuously, and keep a hole at
+-         * HVM_BELOW_4G_MMIO_START of HVM_BELOW_4G_MMIO_LENGTH
+-         */
+-        block_len += HVM_BELOW_4G_MMIO_LENGTH;
++    if (!QTAILQ_EMPTY(&list->head)) {
++        max_ram_below_4g = qemu_opt_get_size(QTAILQ_FIRST(&list->head), "max-ram-below-4g", -1);
++        if (max_ram_below_4g == (-1ULL)) {
++            max_ram_below_4g = HVM_BELOW_4G_RAM_END;    /* not configured, assume 0xF0000000. */
++        }
+     }
+-    memory_region_init_ram(&ram_memory, "xen.ram", block_len);
+-    vmstate_register_ram_global(&ram_memory);
++    fprintf(stderr, "HUGINN: %s() low RAM upper address configured to:%#llx\n",
++            __FUNCTION__, max_ram_below_4g);
++    return max_ram_below_4g;
++}
+ 
+-    if (ram_size >= HVM_BELOW_4G_RAM_END) {
+-        above_4g_mem_size = ram_size - HVM_BELOW_4G_RAM_END;
+-        below_4g_mem_size = HVM_BELOW_4G_RAM_END;
++static void xen_ram_init(ram_addr_t ram_size)
++{
++    MemoryRegion *sysmem = get_system_memory();
++    ram_addr_t below_4g_mem_size, above_4g_mem_size;
++    ram_addr_t block_len = ram_size;
++    ram_addr_t max_ram_below_4g = xen_low_ram_boundary(ram_size);
++
++    /* Top of low memory is processed in hvmloader dynamically depending on MMIO requirements
++     * from PCI devices. This is bad news as xen_ram_init will be called before that.
++     * It doesn't sound right to fiddle with the system memory when hvmloader is running either ...
++     * Instead, make it a qemu option that will be provided by the toolstack.
++     */
++    if (ram_size >= max_ram_below_4g) {
++        above_4g_mem_size = ram_size - max_ram_below_4g;
++        below_4g_mem_size = max_ram_below_4g;
++        /* There is RAM beyond 64b address range, but Xen won't alloc RAM contiguously.
++         * Instead it keeps a hole of the size computed above, so add the RAM beyond the
++         * 64bits limit. */
++        block_len = (1ULL << 32) + above_4g_mem_size;
+     } else {
++        above_4g_mem_size = 0;
+         below_4g_mem_size = ram_size;
++        block_len = ram_size;
+     }
+ 
++    fprintf(stdout, "xen_ram_init: ram_size=%#llx %#llx below 4G and %#llx above 4G.\n",
++            ram_size, below_4g_mem_size, above_4g_mem_size);
++
++    memory_region_init_ram(&ram_memory, "xen.ram", block_len);
++    vmstate_register_ram_global(&ram_memory);
++
+     memory_region_init_alias(&ram_640k, "xen.ram.640k",
+                              &ram_memory, 0, 0xa0000);
+     memory_region_add_subregion(sysmem, 0, &ram_640k);
+@@ -200,13 +227,13 @@ static void xen_ram_init(ram_addr_t ram_
+      * The area between 0xc0000 and 0x100000 will be used by SeaBIOS to load
+      * the Options ROM, so it is registered here as RAM.
+      */
+-    memory_region_init_alias(&ram_lo, "xen.ram.lo",
+-                             &ram_memory, 0xc0000, below_4g_mem_size - 0xc0000);
++    memory_region_init_alias(&ram_lo, "xen.ram.lo", &ram_memory,
++                             0xc0000, below_4g_mem_size - 0xc0000);
+     memory_region_add_subregion(sysmem, 0xc0000, &ram_lo);
+     if (above_4g_mem_size > 0) {
+-        memory_region_init_alias(&ram_hi, "xen.ram.hi",
+-                                 &ram_memory, 0x100000000ULL,
+-                                 above_4g_mem_size);
++        /* Define RAM region above 64b address range. */
++        memory_region_init_alias(&ram_hi, "xen.ram.hi", &ram_memory,
++                                 0x100000000ULL, above_4g_mem_size);
+         memory_region_add_subregion(sysmem, 0x100000000ULL, &ram_hi);
+     }
+ }
+@@ -1102,7 +1129,6 @@ int xen_hvm_init(void)
+     unsigned long ioreq_pfn;
+     unsigned long bufioreq_evtchn;
+     XenIOState *state;
+-
+     state = g_malloc0(sizeof (XenIOState));
+ 
+     state->xce_handle = xen_xc_evtchn_open(NULL, 0);
+--- a/vl.c
++++ b/vl.c
+@@ -429,6 +429,10 @@ static QemuOptsList qemu_machine_opts =
+             .name = "usb",
+             .type = QEMU_OPT_BOOL,
+             .help = "Set on/off to enable/disable usb",
++        },{
++            .name = "max-ram-below-4g",
++            .type = QEMU_OPT_SIZE,
++            .help = "maximum RAM below the 4G boundary (32bits addresses boundary)",
+         },
+         { /* End of list */ }
+     },
+--- a/qemu-options.hx
++++ b/qemu-options.hx
+@@ -35,7 +35,8 @@ DEF("machine", HAS_ARG, QEMU_OPTION_mach
+     "                kernel_irqchip=on|off controls accelerated irqchip support\n"
+     "                kvm_shadow_mem=size of KVM shadow MMU\n"
+     "                dump-guest-core=on|off include guest memory in a core dump (default=on)\n"
+-    "                mem-merge=on|off controls memory merge support (default: on)\n",
++    "                mem-merge=on|off controls memory merge support (default: on)\n"
++    "		     max-ram-below-4g sets the limit of RAM accessible below the 4G limit (used to determine PCI hole size)\n",
+     QEMU_ARCH_ALL)
+ STEXI
+ @item -machine [type=]@var{name}[,prop=@var{value}[,...]]
+--- a/hw/xen.h
++++ b/hw/xen.h
+@@ -53,6 +53,7 @@ struct MemoryRegion;
+ void xen_ram_alloc(ram_addr_t ram_addr, ram_addr_t size,
+                    struct MemoryRegion *mr);
+ void xen_modified_memory(ram_addr_t start, ram_addr_t length);
++ram_addr_t xen_low_ram_boundary(ram_addr_t ram_size);
+ #endif
+ 
+ struct MemoryRegion;

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -40,6 +40,7 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://0026-openxtaudio.patch;striplevel=1 \
             file://0027-nic-link-state-propagation.patch;striplevel=1 \
             file://0029-stubdom-read-gsi-from-device-config-space.patch;striplevel=1 \
+            file://0030-xenfv-i440fx-max-ram-below-4g.patch;striplevel=1 \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"


### PR DESCRIPTION
Add max-ram-below-4g parameter to machine option. This option is only
implemented for xenfv machine using i440fx PCI bus controller. Emulation
will use the value to set up the PCI hole base at a lower address,
making it bigger.

This parameter makes the PCI hole consistent between the Xen memory
listener and the i440fx emulation. Also, hvmloader will process that
value again after QEMU is initialized, both have to match.

The full fix for OXT-243 includes the toolstack commit to process that value before starting QEMU and the modification in dm-agent to pass it from Xenstore to QEMU command line.