### PR TITLE
Use GFP_KERNEL for GEM foreign page allocations.

### DIFF
--- a/recipes-kernel/linux/files/gem-foreign.patch
+++ b/recipes-kernel/linux/files/gem-foreign.patch
@@ -184,7 +184,7 @@
 +
 +	if ((vmap->flags & I915_FOREIGN_BALLOON_PAGES) == 0) {
 +		for (i = 0; i < vmap->num_pages; i++) {
-+			vmap->pvec[i] = alloc_page(GFP_HIGHUSER);
++			vmap->pvec[i] = alloc_page(GFP_KERNEL);
 +			if (!vmap->pvec[i]) {
 +				i915_gem_foreign_free_pages(vmap, i - 1);
 +				ret = -ENOMEM;


### PR DESCRIPTION
This prevents the cache line flush crashes on reboots. Using GFP_HIGHUSER
was returning pages from unusable memory regions in dom0. There is a separate
ticket (OXT-286) to figure out why.

OXT-279

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>