### PR TITLE
Dedicate a fixed amount of memory to dom0

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
@@ -31,7 +31,7 @@ fi
 # Set to drm-graphics to enable experimental DRM plugin support on pre-Haswell systems
 DRM_GRAPHICS_OPTION=""
 
-XEN_COMMON_CMD="console=com1 dom0_mem=320M com1=115200,8n1,pci mbi-video vga=current flask_enforcing=1 loglvl=debug guest_loglvl=debug"
+XEN_COMMON_CMD="console=com1 dom0_mem=min:320M,max:320M,320M com1=115200,8n1,pci mbi-video vga=current flask_enforcing=1 loglvl=debug guest_loglvl=debug"
 LINUX_COMMON_CMD="console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0"
 
 menuentry "XenClient: Normal" {


### PR DESCRIPTION
Follow "Xen best practice"
(http://wiki.xenproject.org/wiki/Xen_Project_Best_Practices) and make
sure to give dom0 a fixed amount of memory.

Having dom0_mem=320M leaves the possibility to dom0 to balloon up to 4G.

OXT-285