### PR TITLE
Fix build of Icedtea on newer linux kernels.

### DIFF
--- a/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
+++ b/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
@@ -9,3 +9,6 @@ export DISTRIBUTION_ECJ_PATCHES += " \
     patches/icedtea-ecj-fix-compil-gcc-4.7.patch \
     patches/icedtea-ecj-fix-currency-data.patch \
 "
+
+#Allow icedtea to build on 4.0+ host kernels.
+export DISABLE_HOTSPOT_OS_VERSION_CHECK = "1"


### PR DESCRIPTION
Icedtea has a hardcoded check for the kernel version prefix. We very
strongly suspect our host kernels are new enough to build icedtea,
so we'll disable the check (rather than having to change a constant
for every version).