### PR TITLE
qemu: backport qemu fixes for flushing net queues

### DIFF
--- a/recipes-openxt/qemu-dm/files/0031-bp-rt8139-net-queue-flush-fix-00b7ade807b5ce6779ddd86ce29c5521ec5c529a.patch
+++ b/recipes-openxt/qemu-dm/files/0031-bp-rt8139-net-queue-flush-fix-00b7ade807b5ce6779ddd86ce29c5521ec5c529a.patch
@@ -1,0 +1,78 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+
+Backported fix for rtl8139 net queue flush, which affects Windows 7 guests.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+
+From 00b7ade807b5ce6779ddd86ce29c5521ec5c529a Mon Sep 17 00:00:00 2001
+From: Stefan Hajnoczi <stefanha@redhat.com>
+Date: Wed, 22 May 2013 14:50:18 +0200
+Subject: [PATCH] rtl8139: flush queued packets when RxBufPtr is written
+
+Net queues support efficient "receive disable".  For example, tap's file
+descriptor will not be polled while its peer has receive disabled.  This
+saves CPU cycles for needlessly copying and then dropping packets which
+the peer cannot receive.
+
+rtl8139 is missing the qemu_flush_queued_packets() call that wakes the
+queue up when receive becomes possible again.
+
+As a result, the Windows 7 guest driver reaches a state where the
+rtl8139 cannot receive packets.  The driver has actually refilled the
+receive buffer but we never resume reception.
+
+The bug can be reproduced by running a large FTP 'get' inside a Windows
+7 guest:
+
+  $ qemu -netdev tap,id=tap0,...
+         -device rtl8139,netdev=tap0
+
+The Linux guest driver does not trigger the bug, probably due to a
+different buffer management strategy.
+
+Reported-by: Oliver Francke <oliver.francke@filoo.de>
+Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+---
+ hw/net/rtl8139.c |    3 +++
+ 1 files changed, 3 insertions(+), 0 deletions(-)
+
+################################################################################
+REMOVAL 
+################################################################################
+
+qemu >= 00b7ade807b5ce6779ddd86ce29c5521ec5c529a
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+
+Backported from qemu.git (00b7ade807b5ce6779ddd86ce29c5521ec5c529a)
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+
+None
+
+diff --git a/hw/net/rtl8139.c b/hw/net/rtl8139.c
+index 9369507..7993f9f 100644
+--- a/hw/rtl8139.c
++++ b/hw/rtl8139.c
+@@ -2575,6 +2575,9 @@ static void rtl8139_RxBufPtr_write(RTL8139State *s, uint32_t val)
+     /* this value is off by 16 */
+     s->RxBufPtr = MOD2(val + 0x10, s->RxBufferSize);
+ 
++    /* more buffer space may be available so try to receive */
++    qemu_flush_queued_packets(qemu_get_queue(s->nic));
++
+     DPRINTF(" CAPR write: rx buffer length %d head 0x%04x read 0x%04x\n",
+         s->RxBufferSize, s->RxBufAddr, s->RxBufPtr);
+ }
+-- 
+1.7.0.4
+
+

--- a/recipes-openxt/qemu-dm/files/0032-bp-hub-net-queue-flush-fix-199ee608f0d08510b5c6c37f31a7fbff211d63c4.patch
+++ b/recipes-openxt/qemu-dm/files/0032-bp-hub-net-queue-flush-fix-199ee608f0d08510b5c6c37f31a7fbff211d63c4.patch
@@ -1,0 +1,100 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+
+Backported fix for net queue flush, which affects Windows 7 guests.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+
+commit 199ee608f0d08510b5c6c37f31a7fbff211d63c4
+Author: Luigi Rizzo <rizzo@iet.unipi.it>
+Date:   Tue Feb 5 17:53:31 2013 +0100
+
+    net: fix qemu_flush_queued_packets() in presence of a hub
+    
+    When frontend and backend are connected through a hub as below
+    (showing only one direction), and the frontend (or in general, all
+    output ports of the hub) cannot accept more traffic, the backend
+    queues packets in queue-A.
+    
+    When the frontend (or in general, one output port) becomes ready again,
+    quemu tries to flush packets from queue-B, which is unfortunately empty.
+    
+      e1000.0 <--[queue B]-- hub0port0(hub)hub0port1 <--[queue A]-- tap.0
+    
+    To fix this i propose to introduce a new function net_hub_flush()
+    which is called when trying to flush a queue connected to a hub.
+    
+    Signed-off-by: Luigi Rizzo <rizzo@iet.unipi.it>
+    Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+
+################################################################################
+REMOVAL 
+################################################################################
+
+qemu >= 199ee608f0d08510b5c6c37f31a7fbff211d63c4
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+
+Backported from qemu.git (199ee608f0d08510b5c6c37f31a7fbff211d63c4)
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+
+None
+
+diff --git a/net/hub.c b/net/hub.c
+index a24c9d1..df32074 100644
+--- a/net/hub.c
++++ b/net/hub.c
+@@ -338,3 +338,17 @@ void net_hub_check_clients(void)
+         }
+     }
+ }
++
++bool net_hub_flush(NetClientState *nc)
++{
++    NetHubPort *port;
++    NetHubPort *source_port = DO_UPCAST(NetHubPort, nc, nc);
++    int ret = 0;
++
++    QLIST_FOREACH(port, &source_port->hub->ports, next) {
++        if (port != source_port) {
++            ret += qemu_net_queue_flush(port->nc.send_queue);
++        }
++    }
++    return ret ? true : false;
++}
+diff --git a/net/hub.h b/net/hub.h
+index 583ada8..a625eff 100644
+--- a/net/hub.h
++++ b/net/hub.h
+@@ -21,5 +21,6 @@ NetClientState *net_hub_add_port(int hub_id, const char *name);
+ NetClientState *net_hub_find_client_by_name(int hub_id, const char *name);
+ void net_hub_info(Monitor *mon);
+ void net_hub_check_clients(void);
++bool net_hub_flush(NetClientState *nc);
+ 
+ #endif /* NET_HUB_H */
+diff --git a/net/net.c b/net/net.c
+index be03a8d..a66aa02 100644
+--- a/net/net.c
++++ b/net/net.c
+@@ -441,6 +441,12 @@ void qemu_flush_queued_packets(NetClientState *nc)
+ {
+     nc->receive_disabled = 0;
+ 
++    if (nc->peer && nc->peer->info->type == NET_CLIENT_OPTIONS_KIND_HUBPORT) {
++        if (net_hub_flush(nc->peer)) {
++            qemu_notify_event();
++        }
++        return;
++    }
+     if (qemu_net_queue_flush(nc->send_queue)) {
+         /* We emptied the queue successfully, signal to the IO thread to repoll
+          * the file descriptor (for tap, for example).

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -41,6 +41,8 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://0027-nic-link-state-propagation.patch;striplevel=1 \
             file://0029-stubdom-read-gsi-from-device-config-space.patch;striplevel=1 \
             file://0030-xenfv-i440fx-max-ram-below-4g.patch;striplevel=1 \
+            file://0031-bp-rt8139-net-queue-flush-fix-00b7ade807b5ce6779ddd86ce29c5521ec5c529a.patch;striplevel=1 \
+            file://0032-bp-hub-net-queue-flush-fix-199ee608f0d08510b5c6c37f31a7fbff211d63c4.patch;striplevel=1 \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"
@@ -101,4 +103,4 @@ do_install(){
     DESTDIR=${D} oe_runmake STRIP='' install
 }
 
-INC_PR = "r11"
+INC_PR = "r12"


### PR DESCRIPTION
These should resolve issues with Windows 7 guests losing
network connectivity (receive) when using the rtl8139 emulated
nic.

Requires two patches, one to fix the flush for rtl8139
and another to fix the flush for the qemu "hub".

OXT-294

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>