### PR TITLE
[iasl]: Add iasl recipe and rework xentools and seabios

### DIFF
--- a/recipes-extended/iasl/iasl_20120215.bb
+++ b/recipes-extended/iasl/iasl_20120215.bb
@@ -1,0 +1,29 @@
+DESCRIPTION = "This is a cross development C compiler, assembler and linker environment for the production of 8086 executables (Optionally MSDOS COM)"
+HOMEPAGE = "http://www.acpica.org/"
+LICENSE = "Intel-ACPI"
+LIC_FILES_CHKSUM = "file://asldefine.h;endline=115;md5=d4d7cf809b8b5e03131327b3f718e8f0"
+SECTION = "console/tools"
+PR="r1"
+
+DEPENDS="flex bison"
+
+SRC_URI="https://acpica.org/sites/acpica/files/acpica-unix-${PV}.tar.gz"
+
+SRC_URI[md5sum] = "324c89e5bb9002e2711e0494290ceacc"
+SRC_URI[sha256sum] = "b2b497415f29ddbefe7be8b9429b62c1f1f6e1ec11456928e4e7da86578e5b8d"
+
+S="${WORKDIR}/acpica-unix-${PV}/source/compiler"
+
+NATIVE_INSTALL_WORKS = "1"
+BBCLASSEXTEND = "native"
+
+do_compile() {
+	CFLAGS="-Wno-error=redundant-decls" $MAKE
+}
+
+do_install() {
+	mkdir -p ${D}${prefix}/bin
+	cp ${S}/iasl ${D}${prefix}/bin
+}
+
+

--- a/recipes-extended/xen/xen-firmware.bb
+++ b/recipes-extended/xen/xen-firmware.bb
@@ -11,6 +11,7 @@ DEPENDS += "\
     ipxe \
     util-linux \
     vgabios \
+    iasl-native \
 "
 PR = "${INC_PR}.1"
 

--- a/recipes-extended/xen/xen-tools.bb
+++ b/recipes-extended/xen/xen-tools.bb
@@ -9,7 +9,7 @@ SRC_URI += "file://xenstored.initscript \
 	    file://do-not-overwrite-cc-and-ld.patch \
 "
 
-DEPENDS += " gettext ncurses openssl python zlib seabios ipxe gmp lzo glib-2.0"
+DEPENDS += " gettext ncurses openssl python zlib seabios ipxe gmp lzo glib-2.0 iasl-native"
 DEPENDS += "util-linux"
 # lzo2 required by libxenguest.
 RDEPENDS += " lzo"

--- a/recipes-openxt/seabios/seabios_1.7.5.bb
+++ b/recipes-openxt/seabios/seabios_1.7.5.bb
@@ -3,7 +3,7 @@ require seabios.inc
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504         \
                     file://COPYING.LESSER;md5=6a6a8e020838b23406c81b19c1d46df6  \
                     "
-DEPENDS = ""
+DEPENDS = "iasl-native"
 
 SRC_URI += "file://openxt-version.patch;patch=1                         \
             file://halt-if-no-bootable.patch;patch=1                    \


### PR DESCRIPTION
Add the iasl recipe so we don't require it to be on the build box.
Then moodify recipes to require the iasl-native package instead of
relying on the host to have the program.

OXT-210

Signed-off-by: David Quigley <drquigley@tycho.nsa.gov>