### PR TITLE
Allow Stubdomain configuration of a given VM through the toolstack

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
@@ -55,8 +55,6 @@ do
  fi
 done
 
-echo "Command line: `cat /proc/cmdline`"
-
 ln -s /proc/self/fd/2 /dev/stderr
 
 echo $*
@@ -69,19 +67,36 @@ export INTEL_DBUS=1
 
 rsyslogd -f /etc/rsyslog.conf -c4
 
-KERNEL_CMDLINE="`cat /proc/cmdline`"
+# Agent cmdline parsing.
+KERNEL_CMDLINE=`cat /proc/cmdline`
+for arg in $KERNEL_CMDLINE; do
+    case "$arg" in
+        guest_agent=*) AGENT=${arg##*=} ;;
+        guest_domid=*)  DOMID=${arg##*=} ;;
+        *) continue ;;
+    esac
+done
 
-echo "KERNEL_CMDLINE: $KERNEL_CMDLINE"
-if [ "${KERNEL_CMDLINE/dmagent/}" != "${KERNEL_CMDLINE}" ]; then
-    # Assumes we are stubbing for the domid passed at the end of the cmdline.
-    # TODO: That should be done in a more generic way...
-    DOMID=${KERNEL_CMDLINE##* }
-    echo "start dm-agent"
-    exec /usr/bin/dm-agent -q -n -t $DOMID
-else
-    QEMU_CMDLINE=`cat /proc/cmdline | cut -d' ' -f4- `
-    DOMID=`echo $QEMU_CMDLINE | cut -d' ' -f2 `
-    echo "qemu-dm-wrapper $DOMID -stubdom -name qemu-$DOMID $QEMU_CMDLINE"
-    exec /usr/bin/qemu-dm-wrapper $DOMID -stubdom -name qemu-$DOMID $QEMU_CMDLINE
-fi
+# Start requested agent.
+case "$AGENT" in
+    dmagent)
+        echo "Start dmagent..."
+        exec /usr/bin/dm-agent -q -n -t ${DOMID}
+        ;;
+
+    *)
+        echo "No agent specified. Assume retro-compatibility by falling back to the deprecated behaviour."
+        if [ "${KERNEL_CMDLINE/dmagent/}" != "${KERNEL_CMDLINE}" ]; then
+            # Assumes we are stubbing for the domid passed at the end of the cmdline.
+            DOMID=${KERNEL_CMDLINE##* }
+            echo "Start dmagent..."
+            exec /usr/bin/dm-agent -q -n -t $DOMID
+        else
+            QEMU_CMDLINE=`cat /proc/cmdline | cut -d' ' -f4- `
+            DOMID=`echo $QEMU_CMDLINE | cut -d' ' -f2 `
+            echo "Start qemu-dm-wrapper..."
+            exec /usr/bin/qemu-dm-wrapper $DOMID -stubdom -name qemu-$DOMID $QEMU_CMDLINE
+        fi
+        ;;
+esac
 


### PR DESCRIPTION
Change kernel cmdline parsing in the dmagent case so new parameters do
not affect dmagent argument recovery.

OXT-332

See related PR in:
- manager.git
- toolstack.git
- idl.git