### PR TITLE
Remove the remaining currency expirations from the icedtea utility.

### DIFF
--- a/recipes-core/icedtea/icedtea6-native/icedtea-ecj-fix-currency-data.patch
+++ b/recipes-core/icedtea/icedtea6-native/icedtea-ecj-fix-currency-data.patch
@@ -1,6 +1,33 @@
---- openjdk-ecj.orig/jdk/src/share/classes/java/util/CurrencyData.properties	2011-06-27 13:30:33.000000000 -0400
+--- openjdk-ecj/jdk/src/share/classes/java/util/CurrencyData.properties	2011-06-27 13:30:33.000000000 -0400
 +++ openjdk-ecj/jdk/src/share/classes/java/util/CurrencyData.properties	2014-12-30 16:28:44.802805865 -0500
-@@ -526,7 +526,7 @@
+@@ -105,7 +105,7 @@ AU=AUD
+ # AUSTRIA
+ AT=EUR
+ # AZERBAIJAN
+-AZ=AZM;2005-12-31-20-00-00;AZN
++AZ=AZN
+ # BAHAMAS
+ BS=BSD
+ # BAHRAIN
+@@ -374,7 +374,7 @@ MS=XCD
+ # MOROCCO
+ MA=MAD
+ # MOZAMBIQUE
+-MZ=MZM;2006-06-30-22-00-00;MZN
++MZ=MZN
+ # MYANMAR
+ MM=MMK
+ # NAMIBIA
+@@ -436,7 +436,7 @@ QA=QAR
+ # REUNION
+ RE=EUR
+ # ROMANIA
+-RO=ROL;2005-06-30-21-00-00;RON
++RO=RON
+ # RUSSIAN FEDERATION
+ RU=RUB
+ # RWANDA
+@@ -522,7 +522,7 @@ TT=TTD
  # TUNISIA
  TN=TND
  # TURKEY
@@ -9,3 +36,12 @@
  # TURKMENISTAN
  TM=TMM
  # TURKS AND CAICOS ISLANDS
+@@ -548,7 +548,7 @@ UZ=UZS
+ # VANUATU
+ VU=VUV
+ # VENEZUELA
+-VE=VEB;2008-01-01-04-00-00;VEF
++VE=VEF
+ # VIET NAM
+ VN=VND
+ # VIRGIN ISLANDS, BRITISH

--- a/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
+++ b/recipes-core/icedtea/icedtea6-native_1.8.11.bbappend
@@ -9,3 +9,5 @@ export DISTRIBUTION_ECJ_PATCHES += " \
     patches/icedtea-ecj-fix-compil-gcc-4.7.patch \
     patches/icedtea-ecj-fix-currency-data.patch \
 "
+
+PR .= ".1"


### PR DESCRIPTION
This is a cherry-pick of a master commit that's needed for legacy-ioemu to build.
If you think this should be done a different way, please shout.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>