### PR TITLE
New vusb daemon

### DIFF
--- a/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
+++ b/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
@@ -69,7 +69,7 @@ script rpc-proxy
 dep dbus-1 xenstored surfman
 
 script xenclient-vusb-daemon
-dep dbus-1 xenstored surfman
+dep dbus-1 xenstored surfman xenmgr
 
 script xcpmd
 dep dbus-1 xenstored surfman

--- a/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
+++ b/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
@@ -69,7 +69,7 @@ script rpc-proxy
 dep dbus-1 xenstored surfman
 
 script xenclient-vusb-daemon
-dep dbus-1 xenstored surfman xenmgr
+dep dbus-1 udev xenstored surfman xenmgr
 
 script xcpmd
 dep dbus-1 xenstored surfman

--- a/recipes-openxt/xenclient/vusb/files/xenclient-vusb.initscript
+++ b/recipes-openxt/xenclient/vusb/files/xenclient-vusb.initscript
@@ -27,7 +27,7 @@ PROG=/usr/sbin/vusb-daemon
 [ -f "$PROG" ] || exit 0
 
 start() {
-	"$PROG" & 2> /dev/null 2>&1
+	"$PROG" 2>&1 | logger -t 'vusb-daemon' &
 	echo "OK"
 }
 stop() {

--- a/recipes-openxt/xenclient/vusb/files/xenclient-vusb.initscript
+++ b/recipes-openxt/xenclient/vusb/files/xenclient-vusb.initscript
@@ -21,7 +21,7 @@
 # Starts vusb daemon.
 #
 
-PROG=/usr/sbin/vusb_daemon
+PROG=/usr/sbin/vusb-daemon
 
 # Make sure the progam exists
 [ -f "$PROG" ] || exit 0

--- a/recipes-openxt/xenclient/vusb/vusb-daemon_git.bb
+++ b/recipes-openxt/xenclient/vusb/vusb-daemon_git.bb
@@ -7,7 +7,7 @@ RDEPENDS += "libxcxenstore"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xc-vusb-daemon.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://${OPENXT_GIT_MIRROR}/vusb-daemon.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
            file://xenclient-vusb.initscript \
            "
 

--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.fc.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.fc.patch
@@ -1,5 +1,7 @@
---- a/policy/modules/services/ctxusb.fc	1969-12-31 19:00:00.000000000 -0500
-+++ b/policy/modules/services/ctxusb.fc	2015-01-05 16:03:12.793080030 -0500
+Index: refpolicy/policy/modules/services/ctxusb.fc
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ refpolicy/policy/modules/services/ctxusb.fc	2015-07-21 09:42:37.621965221 -0400
 @@ -0,0 +1,26 @@
 +#############################################################################
 +#
@@ -22,7 +24,7 @@
 +#############################################################################
 +
 +/usr/bin/usbowls        --      gen_context(system_u:object_r:ctxusbc_exec_t,s0)
-+/usr/sbin/vusb_daemon	--	gen_context(system_u:object_r:ctxusbd_exec_t,s0)
++/usr/sbin/vusb-daemon	--	gen_context(system_u:object_r:ctxusbd_exec_t,s0)
 +/etc/USB_fakenames.conf	-l	gen_context(system_u:object_r:ctxusbd_etc_t,s0)
 +/usr/share/usb.ids	--	gen_context(system_u:object_r:ctxusbd_etc_t,s0)
 +/config/etc/USB_always.conf	--	gen_context(system_u:object_r:ctxusbd_config_t,s0)

--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.fc.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.fc.patch
@@ -1,7 +1,7 @@
 Index: refpolicy/policy/modules/services/ctxusb.fc
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ refpolicy/policy/modules/services/ctxusb.fc	2015-07-21 09:42:37.621965221 -0400
++++ refpolicy/policy/modules/services/ctxusb.fc	2015-07-27 12:56:24.841931996 -0400
 @@ -0,0 +1,26 @@
 +#############################################################################
 +#
@@ -27,5 +27,5 @@ Index: refpolicy/policy/modules/services/ctxusb.fc
 +/usr/sbin/vusb-daemon	--	gen_context(system_u:object_r:ctxusbd_exec_t,s0)
 +/etc/USB_fakenames.conf	-l	gen_context(system_u:object_r:ctxusbd_etc_t,s0)
 +/usr/share/usb.ids	--	gen_context(system_u:object_r:ctxusbd_etc_t,s0)
-+/config/etc/USB_always.conf	--	gen_context(system_u:object_r:ctxusbd_config_t,s0)
++/config/etc/USB_always.conf	--	gen_context(system_u:object_r:ctxusbd_etc_t,s0)
 +/config/etc/USB_fakenames.conf	--	gen_context(system_u:object_r:ctxusbd_etc_t,s0)

--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.if.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.if.patch
@@ -1,6 +1,8 @@
---- a/policy/modules/services/ctxusb.if	1969-12-31 19:00:00.000000000 -0500
-+++ b/policy/modules/services/ctxusb.if	2015-01-05 16:03:12.793080030 -0500
-@@ -0,0 +1,185 @@
+Index: refpolicy/policy/modules/services/ctxusb.if
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ refpolicy/policy/modules/services/ctxusb.if	2015-07-27 12:56:05.741966817 -0400
+@@ -0,0 +1,168 @@
 +#############################################################################
 +#
 +# Copyright (C) 2014 Citrix Systems, Inc.
@@ -168,21 +170,4 @@
 +	')
 +	
 +        allow $1 ctxusbd_etc_t:file read_file_perms;
-+')
-+#######################################
-+## <summary>
-+##      Read ctxusb config files
-+## </summary>
-+## <param name="domain">
-+##      <summary>
-+##      The type of the process connecting.
-+##      </summary>
-+## </param>
-+#
-+interface(`ctxusbd_read_config',`
-+        gen_require(`
-+                type ctxusbd_config_t;
-+        ')
-+
-+        allow $1 ctxusbd_config_t:file read_file_perms;
 +')

--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.te.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.te.patch
@@ -1,6 +1,8 @@
---- a/policy/modules/services/ctxusb.te	1969-12-31 19:00:00.000000000 -0500
-+++ b/policy/modules/services/ctxusb.te	2015-01-05 16:03:12.793080030 -0500
-@@ -0,0 +1,105 @@
+Index: refpolicy/policy/modules/services/ctxusb.te
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ refpolicy/policy/modules/services/ctxusb.te	2015-07-27 12:50:05.501964183 -0400
+@@ -0,0 +1,101 @@
 +#############################################################################
 +#
 +# Copyright (C) 2014 Citrix Systems, Inc.
@@ -41,10 +43,6 @@
 +type ctxusbd_etc_t;
 +files_config_file(ctxusbd_etc_t)
 +
-+type ctxusbd_config_t;
-+files_config_file(ctxusbd_config_t)
-+xc_config_filetrans(ctxusbd_t, ctxusbd_config_t, file)
-+
 +#######################################
 +#
 +# ctxusb daemon local policy
@@ -84,9 +82,9 @@
 +allow ctxusbd_t self:process { getsched signal };
 +allow ctxusbd_t self:fifo_file manage_fifo_file_perms;
 +
++files_etc_filetrans(ctxusbd_t, ctxusbd_etc_t, file)
 +allow ctxusbd_t ctxusbd_etc_t:lnk_file read_lnk_file_perms;
-+allow ctxusbd_t ctxusbd_etc_t:file rw_file_perms;
-+allow ctxusbd_t ctxusbd_config_t:file manage_file_perms;
++allow ctxusbd_t ctxusbd_etc_t:file manage_file_perms;
 +
 +#######################################
 +#

--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.te.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.te.patch
@@ -1,8 +1,8 @@
 Index: refpolicy/policy/modules/services/ctxusb.te
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ refpolicy/policy/modules/services/ctxusb.te	2015-07-27 12:50:05.501964183 -0400
-@@ -0,0 +1,101 @@
++++ refpolicy/policy/modules/services/ctxusb.te	2015-07-27 13:33:12.465964505 -0400
+@@ -0,0 +1,102 @@
 +#############################################################################
 +#
 +# Copyright (C) 2014 Citrix Systems, Inc.
@@ -72,6 +72,7 @@ Index: refpolicy/policy/modules/services/ctxusb.te
 +kernel_write_xen_state(ctxusbd_t)
 +kernel_write_xen_state(ctxusbd_t)
 +xen_stream_connect_xenstore(ctxusbd_t)
++udev_read_db(ctxusbd_t)
 +
 +corecmd_search_bin(ctxusbd_t)
 +ctxusbc_exec_domtrans(ctxusbd_t)

--- a/recipes-support/monit/monit-5.5/monitrc
+++ b/recipes-support/monit/monit-5.5/monitrc
@@ -139,7 +139,7 @@ check process input_server with pidfile /var/run/input_server.pid
 	if 10 restarts within 11 cycles then exec "/usr/bin/display_reboot input_server_failed"
 
 
-check process vusb_daemon matching "vusb_daemon"
+check process vusb-daemon matching "vusb-daemon"
 	start program = "/etc/init.d/xenclient-vusb-daemon start"
 	stop program = "/etc/init.d/xenclient-vusb-daemon stop"
 	if 10 restarts within 11 cycles then exec "/usr/bin/display_reboot vusb_daemon_failed"


### PR DESCRIPTION
This pull request changes the vusb daemon recipe to build the new daemon, located there:
https://github.com/OpenXT/vusb-daemon (see https://github.com/OpenXT/vusb-daemon/pull/1)

A build that includes this pull request (and the related one in manager.git) can be found there:
http://openxt.ainfosec.com:81/builds/master/ext-dev-269-master/

The daemon code is well documented, but you can find some additional information there:
https://github.com/jean-edouard/vusb-daemon/wiki

If you have any interest in USB in OpenXT, whether you're a user or a developer, please give this a try and write a short comment here.

Most of the vusb daemon code was written from scratch and never reviewed, I'm sure there's bugs in it. If you can read C, please have a look and comment here.