### PR TITLE
bbclasses: get makeclean to depend on force_rebuild

### DIFF
--- a/classes/xenclient-customtask.bbclass
+++ b/classes/xenclient-customtask.bbclass
@@ -45,7 +45,7 @@ do_force_rebuild[depends] = ""
 do_force_rebuild[nostamp] = "1"
 
 addtask makeclean
-do_makeclean[depends] = ""
+do_makeclean[depends] = "${PN}:do_force_rebuild"
 do_makeclean[nostamp] = "1"
 
 do_protos() {


### PR DESCRIPTION
This will simplify working in OE.
It may not be the best way to implement it, please chime in if you know better.

Signed-off-by: Jed <lejosnej@ainfosec.com>