### PR TITLE
[qemu-dm] FILESEXTRAPATHS_prepend ':'

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-stubdom_1.4.0.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm-stubdom_1.4.0.bb
@@ -4,7 +4,7 @@ PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
 PV_MINOR = "${@"${PV}".split('.', 3)[1]}"
 PV_MICRO = "${@"${PV}".split('.', 3)[2]}"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/qemu-dm-${PV_MAJOR}.${PV_MINOR}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/qemu-dm-${PV_MAJOR}.${PV_MINOR}:"
 
 require qemu-dm.inc
 

--- a/recipes-openxt/qemu-dm/qemu-dm_1.4.0.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm_1.4.0.bb
@@ -4,7 +4,7 @@ PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
 PV_MINOR = "${@"${PV}".split('.', 3)[1]}"
 PV_MICRO = "${@"${PV}".split('.', 3)[2]}"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV_MAJOR}.${PV_MINOR}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV_MAJOR}.${PV_MINOR}:"
 
 require qemu-dm.inc
 


### PR DESCRIPTION
Add the forgotten column separator to the FILESEXTRAPATHS_prepend.