### PR TITLE
[linux-pq] Remove incorrect memsets.

### DIFF
--- a/recipes-kernel/linux/linux-xenclient-3.18/usbback-base.patch
+++ b/recipes-kernel/linux/linux-xenclient-3.18/usbback-base.patch
@@ -1270,8 +1270,8 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/interface.c
 Index: linux-3.18.19/drivers/usb/xen-usbback/usbback.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/usbback.c	2015-08-11 18:32:56.611715035 +0200
-@@ -0,0 +1,1269 @@
++++ linux-3.18.19/drivers/usb/xen-usbback/usbback.c	2015-09-14 16:22:32.704286067 +0200
+@@ -0,0 +1,1267 @@
 +/******************************************************************************
 + *
 + * Back-end of the driver for virtual block devices. This portion of the
@@ -2492,7 +2492,6 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/usbback.c
 +	if (!pending_reqs || !pending_pages || !pending_segments)
 +		goto out_of_memory;
 +
-+	memset(pending_segments, 0, sizeof(pending_segments));
 +	INIT_LIST_HEAD(&pending_segments_free);
 +
 +	for (i = 0; i < mmap_pages; i++) {
@@ -2507,7 +2506,6 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/usbback.c
 +
 +	usbif_interface_init();
 +
-+	memset(pending_reqs, 0, sizeof(pending_reqs));
 +	INIT_LIST_HEAD(&pending_free);
 +
 +	for (i = 0; i < usbif_reqs; i++) {


### PR DESCRIPTION
pending_reqs and pending_segments are both allocated through kzalloc().
No need to memset() those to 0, also the size given to memset is invalid
and will cause recent gcc versions to output some warnings.
