### PR TITLE
[ralink] install in correct images

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -40,6 +40,7 @@ IMAGE_INSTALL = "\
     kernel-module-e1000e \
     linux-firmware \
     rt2870-firmware \
+    rt3572 \
     ${ANGSTROM_EXTRA_INSTALL}"
 
 IMAGE_FSTYPES = "cpio.gz"

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -34,8 +34,6 @@ IMAGE_INSTALL = "\
     networkmanager \
     xenclient-toolstack \
     linux-firmware \
-    rt2870-firmware \
-    rt3572 \
     bridge-utils \
     iptables \
     xenclient-ndvm-tweaks \


### PR DESCRIPTION
NDVM does not have USB support so rt3572 and rt2870-firmware are not
required there.
On the other hand, rt3572 could find its use in the installer.
