### PR TITLE
[ralink] Remove module from images.

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -39,7 +39,6 @@ IMAGE_INSTALL = "\
     task-xenclient-installer \
     kernel-module-e1000e \
     linux-firmware \
-    rt2870-firmware \
     ${ANGSTROM_EXTRA_INSTALL}"
 
 IMAGE_FSTYPES = "cpio.gz"

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -34,8 +34,6 @@ IMAGE_INSTALL = "\
     networkmanager \
     xenclient-toolstack \
     linux-firmware \
-    rt2870-firmware \
-    rt3572 \
     bridge-utils \
     iptables \
     xenclient-ndvm-tweaks \
@@ -54,9 +52,6 @@ IMAGE_INSTALL = "\
     ppp \
     iputils-ping \
 "
-
-# Packages disabled for Linux3 to be fixed
-# rt5370
 
 #IMAGE_PREPROCESS_COMMAND = "create_etc_timestamp"
 


### PR DESCRIPTION
NDVM does not support USB, so remove the ralink USB Wifi dongle modules
and firmware from it.

While OpenXT installation could be done using a USB dongle, NDVM
would not handle network after that leading to confusion. So remove the
USB dongle support from the installer as well.
