### PR TITLE
[ralink] Move from NDVM to installer.

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -40,6 +40,7 @@ IMAGE_INSTALL = "\
     kernel-module-e1000e \
     linux-firmware \
     rt2870-firmware \
+    rt3572 \
     ${ANGSTROM_EXTRA_INSTALL}"
 
 IMAGE_FSTYPES = "cpio.gz"

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -34,8 +34,6 @@ IMAGE_INSTALL = "\
     networkmanager \
     xenclient-toolstack \
     linux-firmware \
-    rt2870-firmware \
-    rt3572 \
     bridge-utils \
     iptables \
     xenclient-ndvm-tweaks \
@@ -54,9 +52,6 @@ IMAGE_INSTALL = "\
     ppp \
     iputils-ping \
 "
-
-# Packages disabled for Linux3 to be fixed
-# rt5370
 
 #IMAGE_PREPROCESS_COMMAND = "create_etc_timestamp"
 


### PR DESCRIPTION
NDVM does not support USB, so remove the ralink USB Wifi dongle modules
and firmware from it.

This most likely belongs in the installer to allow PXE installation on
platforms without ethernet.

Discussion started in: https://github.com/OpenXT/xenclient-oe/pull/154, but changes in the branch have locked the PR.