### PR TITLE
Add rtglobal scheduler

### DIFF
--- a/recipes-extended/xen/files/libxc-add-rtglobal-scheduler.patch
+++ b/recipes-extended/xen/files/libxc-add-rtglobal-scheduler.patch
@@ -1,0 +1,102 @@
+diff --git a/tools/libxc/Makefile b/tools/libxc/Makefile
+index 512a994..0fa4fbb 100644
+--- a/tools/libxc/Makefile
++++ b/tools/libxc/Makefile
+@@ -20,6 +20,7 @@ CTRL_SRCS-y       += xc_sedf.c
+ CTRL_SRCS-y       += xc_csched.c
+ CTRL_SRCS-y       += xc_csched2.c
+ CTRL_SRCS-y       += xc_arinc653.c
++CTRL_SRCS-y       += xc_rtglobal.c
+ CTRL_SRCS-y       += xc_tbuf.c
+ CTRL_SRCS-y       += xc_pm.c
+ CTRL_SRCS-y       += xc_cpu_hotplug.c
+diff --git a/tools/libxc/xc_rtglobal.c b/tools/libxc/xc_rtglobal.c
+new file mode 100644
+index 0000000..61f0a7a
+--- /dev/null
++++ b/tools/libxc/xc_rtglobal.c
+@@ -0,0 +1,64 @@
++/****************************************************************************
++ * (C) 2006 - Emmanuel Ackaouy - XenSource Inc.
++ ****************************************************************************
++ *
++ *        File: xc_rtglobal.c
++ *      Author: Sisu Xi
++ *
++ * Description: XC Interface to the rtglobal scheduler
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation;
++ * version 2.1 of the License.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ */
++
++#include "xc_private.h"
++
++int
++xc_sched_rtglobal_domain_set(
++	xc_interface *xch,
++    uint32_t domid,
++    struct xen_domctl_sched_rtglobal *sdom)
++{
++	int rc;
++	DECLARE_DOMCTL;
++
++	domctl.cmd = XEN_DOMCTL_scheduler_op;
++	domctl.domain = (domid_t) domid;
++	domctl.u.scheduler_op.sched_id = XEN_SCHEDULER_RTGLOBAL;
++	domctl.u.scheduler_op.cmd = XEN_DOMCTL_SCHEDOP_putinfo;
++	domctl.u.scheduler_op.u.rtglobal.period = sdom->period;
++	domctl.u.scheduler_op.u.rtglobal.budget = sdom->budget;
++	domctl.u.scheduler_op.u.rtglobal.vcpu = sdom->vcpu;
++	domctl.u.scheduler_op.u.rtglobal.rt = sdom->rt;
++
++	rc = do_domctl(xch, &domctl);
++	return rc;
++}
++
++int
++xc_sched_rtglobal_domain_get(
++    xc_interface *xch,
++    uint32_t domid,
++    struct xen_domctl_sched_rtglobal *sdom)
++{
++	DECLARE_DOMCTL;
++	int err;
++
++	domctl.cmd = XEN_DOMCTL_scheduler_op;
++	domctl.domain = (domid_t) domid;
++	domctl.u.scheduler_op.sched_id = XEN_SCHEDULER_RTGLOBAL;
++	domctl.u.scheduler_op.cmd = XEN_DOMCTL_SCHEDOP_getinfo;
++
++	err = do_domctl(xch, &domctl);
++	if(err == 0)
++		*sdom = domctl.u.scheduler_op.u.rtglobal;
++
++	return err;
++}
+diff --git a/tools/libxc/xenctrl.h b/tools/libxc/xenctrl.h
+index 388a9c3..72d2354 100644
+--- a/tools/libxc/xenctrl.h
++++ b/tools/libxc/xenctrl.h
+@@ -763,6 +763,15 @@ xc_sched_arinc653_schedule_get(
+     xc_interface *xch,
+     struct xen_sysctl_arinc653_schedule *schedule);
+ 
++int xc_sched_rtglobal_domain_set(xc_interface *xch,
++				 uint32_t domid,
++				 struct xen_domctl_sched_rtglobal *sdom);
++
++int xc_sched_rtglobal_domain_get(xc_interface *xch,
++				 uint32_t domid,
++				 struct xen_domctl_sched_rtglobal *sdom);
++
++
+ /**
+  * This function sends a trigger to a domain.
+  *

--- a/recipes-extended/xen/files/libxl-add-rtglobal-scheduler.patch
+++ b/recipes-extended/xen/files/libxl-add-rtglobal-scheduler.patch
@@ -1,0 +1,155 @@
+diff --git a/tools/libxl/libxl.c b/tools/libxl/libxl.c
+index ece9a1f..4ef4afd 100644
+--- a/tools/libxl/libxl.c
++++ b/tools/libxl/libxl.c
+@@ -4591,6 +4591,85 @@ static int sched_sedf_domain_set(libxl__gc *gc, uint32_t domid,
+     return 0;
+ }
+ 
++static int sched_rtglobal_domain_get(libxl__gc *gc, uint32_t domid,
++				     libxl_domain_sched_params *scinfo)
++{
++	struct xen_domctl_sched_rtglobal sdom;
++	int rc;
++
++	rc = xc_sched_rtglobal_domain_get(CTX->xch, domid, &sdom);
++ 	if (rc != 0) {
++		LOGE(ERROR, "getting domain sched rtglobal");
++		return ERROR_FAIL;
++	}
++
++	libxl_domain_sched_params_init(scinfo);
++
++	scinfo->sched = LIBXL_SCHEDULER_RTGLOBAL;
++	scinfo->period = sdom.period;
++	scinfo->budget = sdom.budget;
++	scinfo->vcpu = sdom.vcpu;
++	scinfo->rt = sdom.rt;
++
++	return 0;
++}
++
++static int sched_rtglobal_domain_set(libxl__gc *gc, uint32_t domid,
++				     const libxl_domain_sched_params *scinfo)
++{
++	struct xen_domctl_sched_rtglobal sdom;
++	int rc;
++
++	rc = xc_sched_rtglobal_domain_get(CTX->xch, domid, &sdom);
++	if (rc != 0) {
++		LOGE(ERROR, "getting domain sched rtglobal");
++		return ERROR_FAIL;
++	}
++
++	if (scinfo->period != LIBXL_DOMAIN_SCHED_PARAM_PERIOD_DEFAULT) {
++		if (scinfo->period < 1) {
++			LOG(ERROR, "VCPU period is not set or out of range, "
++						"valid values are larger than 1");
++			return ERROR_INVAL;
++		}
++		sdom.period = scinfo->period;
++	}
++
++	if (scinfo->budget != LIBXL_DOMAIN_SCHED_PARAM_BUDGET_DEFAULT) {
++		if (scinfo->period < 1) {
++			LOG(ERROR, "VCPU budget is not set or out of range, "
++						"valid values are larger than 1");
++			return ERROR_INVAL;
++		}
++		sdom.budget = scinfo->budget;
++	}
++
++	if (sdom.budget > sdom.period) {
++		LOG(ERROR, "VCPU budget is larger than VCPU period,"
++						"VCPU budget should be no larger than VCPU period");
++		return ERROR_INVAL;
++	}
++
++	if (scinfo->vcpu != LIBXL_DOMAIN_SCHED_PARAM_VCPU_DEFAULT) 
++		sdom.vcpu = scinfo->vcpu;
++
++	if (scinfo->rt != LIBXL_DOMAIN_SCHED_PARAM_RT_DEFAULT) {
++		if (!(scinfo->rt == 0 || scinfo->rt == 1)) {
++		LOG(ERROR, "rt is not valid should be either 0 or 1");
++			return ERROR_INVAL;
++		}
++		sdom.rt = scinfo->rt;
++	}
++
++	rc = xc_sched_rtglobal_domain_set(CTX->xch, domid, &sdom);
++	if (rc < 0) {
++		LOGE(ERROR, "setting domain sched rtglobal");
++		return ERROR_FAIL;
++	}
++
++	return 0;
++}
++
+ int libxl_domain_sched_params_set(libxl_ctx *ctx, uint32_t domid,
+                                   const libxl_domain_sched_params *scinfo)
+ {
+@@ -4614,6 +4693,9 @@ int libxl_domain_sched_params_set(libxl_ctx *ctx, uint32_t domid,
+     case LIBXL_SCHEDULER_ARINC653:
+         ret=sched_arinc653_domain_set(gc, domid, scinfo);
+         break;
++	case LIBXL_SCHEDULER_RTGLOBAL:
++		ret=sched_rtglobal_domain_set(gc, domid, scinfo);
++		break;
+     default:
+         LOG(ERROR, "Unknown scheduler");
+         ret=ERROR_INVAL;
+@@ -4644,6 +4726,9 @@ int libxl_domain_sched_params_get(libxl_ctx *ctx, uint32_t domid,
+     case LIBXL_SCHEDULER_CREDIT2:
+         ret=sched_credit2_domain_get(gc, domid, scinfo);
+         break;
++	case LIBXL_SCHEDULER_RTGLOBAL:
++		ret=sched_rtglobal_domain_get(gc, domid, scinfo);
++		break;
+     default:
+         LOG(ERROR, "Unknown scheduler");
+         ret=ERROR_INVAL;
+diff --git a/tools/libxl/libxl.h b/tools/libxl/libxl.h
+index 37e4d82..5dbfd9c 100644
+--- a/tools/libxl/libxl.h
++++ b/tools/libxl/libxl.h
+@@ -81,6 +81,8 @@
+  */
+ #define LIBXL_HAVE_DOMAIN_NODEAFFINITY 1
+ 
++#define LIBXL_HAVE_SCHED_RTGLOBAL 1
++
+ /*
+  * libxl ABI compatibility
+  *
+@@ -952,6 +954,9 @@ int libxl_sched_credit_params_set(libxl_ctx *ctx, uint32_t poolid,
+ #define LIBXL_DOMAIN_SCHED_PARAM_SLICE_DEFAULT     -1
+ #define LIBXL_DOMAIN_SCHED_PARAM_LATENCY_DEFAULT   -1
+ #define LIBXL_DOMAIN_SCHED_PARAM_EXTRATIME_DEFAULT -1
++#define LIBXL_DOMAIN_SCHED_PARAM_BUDGET_DEFAULT	   -1
++#define LIBXL_DOMAIN_SCHED_PARAM_VCPU_DEFAULT	   -1
++#define LIBXL_DOMAIN_SCHED_PARAM_RT_DEFAULT	   -1
+ 
+ int libxl_domain_sched_params_get(libxl_ctx *ctx, uint32_t domid,
+                                   libxl_domain_sched_params *params);
+diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
+index d218a2d..211f0ee 100644
+--- a/tools/libxl/libxl_types.idl
++++ b/tools/libxl/libxl_types.idl
+@@ -116,6 +116,7 @@ libxl_scheduler = Enumeration("scheduler", [
+     (5, "credit"),
+     (6, "credit2"),
+     (7, "arinc653"),
++    (8, "rtglobal"),
+     ])
+ 
+ # Consistent with SHUTDOWN_* in sched.h
+@@ -256,6 +257,9 @@ libxl_domain_sched_params = Struct("domain_sched_params",[
+     ("slice",        integer, {'init_val': 'LIBXL_DOMAIN_SCHED_PARAM_SLICE_DEFAULT'}),
+     ("latency",      integer, {'init_val': 'LIBXL_DOMAIN_SCHED_PARAM_LATENCY_DEFAULT'}),
+     ("extratime",    integer, {'init_val': 'LIBXL_DOMAIN_SCHED_PARAM_EXTRATIME_DEFAULT'}),
++    ("budget",       integer, {'init_val': 'LIBXL_DOMAIN_SCHED_PARAM_BUDGET_DEFAULT'}),
++    ("vcpu",         integer, {'init_val': 'LIBXL_DOMAIN_SCHED_PARAM_VCPU_DEFAULT'}),
++    ("rt",           integer, {'init_val': 'LIBXL_DOMAIN_SCHED_PARAM_RT_DEFAULT'}),
+     ])
+ 
+ libxl_domain_build_info = Struct("domain_build_info",[

--- a/recipes-extended/xen/files/xen-add-real-time-scheduler-rtglobal.patch
+++ b/recipes-extended/xen/files/xen-add-real-time-scheduler-rtglobal.patch
@@ -1,0 +1,1024 @@
+diff --git a/xen/common/Makefile b/xen/common/Makefile
+index 0dc2050..4c5dd88 100644
+--- a/xen/common/Makefile
++++ b/xen/common/Makefile
+@@ -22,6 +22,7 @@ obj-y += sched_credit.o
+ obj-y += sched_credit2.o
+ obj-y += sched_sedf.o
+ obj-y += sched_arinc653.o
++obj-y += sched_rtglobal.o
+ obj-y += schedule.o
+ obj-y += shutdown.o
+ obj-y += softirq.o
+diff --git a/xen/common/sched_rtglobal.c b/xen/common/sched_rtglobal.c
+new file mode 100644
+index 0000000..b9803c2
+--- /dev/null
++++ b/xen/common/sched_rtglobal.c
+@@ -0,0 +1,960 @@
++/******************************************************************************
++ * Preemptive Global EDF/RM scheduler for xen
++ *
++ * by Sisu Xi, 2013, Washington University in Saint Louis
++ * based on code of credit Scheduler
++ */
++
++#include <xen/config.h>
++#include <xen/init.h>
++#include <xen/lib.h>
++#include <xen/sched.h>
++#include <xen/domain.h>
++#include <xen/delay.h>
++#include <xen/event.h>
++
++#include <xen/time.h>
++#include <xen/perfc.h>
++#include <xen/sched-if.h>
++#include <xen/softirq.h>
++#include <asm/atomic.h>
++#include <xen/errno.h>
++#include <xen/trace.h>
++#include <xen/cpu.h>
++#include <xen/keyhandler.h>
++#include <xen/trace.h>
++
++/*
++ * TODO:
++ *
++ * How to show individual VCPU info?
++ * Migration compensation and resist like credit2
++ * Lock Holder Problem, using yield?
++ * Self switch problem?
++ * More testing with xentrace and xenanalyze
++ */
++
++/*
++ * Design:
++ *
++ * Follows the preemptive Global EDF/RM theory.
++ * Each VCPU can have a dedicated period/budget pair of parameter. When a VCPU
++	is running, it burns its budget, and when there are no budget, the VCPU need
++	to wait until next period to get replenished. Any unused budget is discarded
++	in the end of period.
++ * Server mechanism: deferrable server is used here. Therefore, when a VCPU
++	has no task but with budget left, the budget is preserved.
++ * Priority scheme: a global variable called priority_scheme is used to switch
++	between EDF and RM
++ * Queue scheme: a global runqueue is used here. It holds all runnable VCPUs.
++	VCPUs are divided into two parts: with and without remaining budget. Among
++	each part, VCPUs are sorted by their current deadlines.
++ * Scheduling quanta: 1 ms is picked as the scheduling quanta, but the
++	 accounting is done in microsecond level.
++ * Other: cpumask is also supported, as a result, although the runq is sorted,
++	the scheduler also need to verify whether the cpumask is allowed or not.
++ */
++
++/*
++ * Locking:
++ * Just like credit2, a global system lock is used to protect the RunQ.
++ *
++ * The lock is already grabbed when calling wake/sleep/schedule/ functions in schedule.c
++ *
++ * The functions involves RunQ and needs to grab locks are:
++ *    dump, vcpu_insert, vcpu_remove, context_saved,
++ */
++
++/*
++ * Default parameters
++ */
++#define RTGLOBAL_DEFAULT_PERIOD     10
++#define RTGLOBAL_DEFAULT_BUDGET     10
++
++#define EDF                         0
++#define RM                          1
++
++/*
++ * Useful macros
++ */
++#define RTGLOBAL_PRIV(_ops)   ((struct rtglobal_private *)((_ops)->sched_data))
++#define RTGLOBAL_VCPU(_vcpu)  ((struct rtglobal_vcpu *)(_vcpu)->sched_priv)
++#define RTGLOBAL_DOM(_dom)    ((struct rtglobal_dom *)(_dom)->sched_priv)
++#define RUNQ(_ops)            (&RTGLOBAL_PRIV(_ops)->runq)
++
++/*
++ * Flags
++ */
++#define __RTGLOBAL_scheduled            1
++#define RTGLOBAL_scheduled (1<<__RTGLOBAL_scheduled)
++#define __RTGLOBAL_delayed_runq_add     2
++#define RTGLOBAL_delayed_runq_add (1<<__RTGLOBAL_delayed_runq_add)
++
++/*
++ * Used to printout debug information
++ */
++#define printtime()		(printk("%d : %3ld.%3ld : %-19s ", smp_processor_id(), NOW()/MILLISECS(1), NOW()%MILLISECS(1)/1000, __func__))
++
++/*
++ * System-wide private data, include a global RunQueue
++ * The global lock is referenced by schedule_data.schedule_lock from all physical cpus.
++ * It can be grabbed via vcpu_schedule_lock_irq()
++ */
++struct rtglobal_private {
++	spinlock_t lock;        /* The global coarse grand lock */
++	struct list_head sdom;  /* list of available domains, used for dump */
++	struct list_head runq;  /* Ordered list of runnable VMs */
++	cpumask_t cpus;         /* cpumask_t of available physical cpus */
++	cpumask_t tickled;      /* another cpu in the queue already ticked this one */
++	unsigned priority_scheme;
++};
++
++/*
++ * Virtual CPU
++ */
++struct rtglobal_vcpu {
++	struct list_head runq_elem; /* On the runqueue list */
++	struct list_head sdom_elem; /* On the domain VCPU list */
++
++    /* Up-pointers */
++	struct rtglobal_dom *sdom;
++	struct vcpu *vcpu;
++
++    /* VCPU parameters, in milliseconds */
++	int period;
++	int budget;
++
++    /* VCPU current information */
++	long cur_budget;             /* current budget in microseconds */
++	s_time_t last_start;        /* last start time, used to calculate budget */
++	s_time_t cur_deadline;      /* current deadline, used to do EDF */
++	unsigned flags;             /* mark __RTGLOBAL_scheduled, etc.. */
++};
++
++/*
++ * Domain
++ */
++struct rtglobal_dom {
++	struct list_head vcpu;      /* link its VCPUs */
++	struct list_head sdom_elem; /* link list on rtglobal_priv */
++	struct domain *dom;         /* pointer to upper domain */
++	int    rt;                  /* rt domain or not */
++};
++
++/*
++ * RunQueue helper functions
++ */
++static int
++__vcpu_on_runq(struct rtglobal_vcpu *svc)
++{
++	return !list_empty(&svc->runq_elem);
++}
++
++static struct rtglobal_vcpu *
++__runq_elem(struct list_head *elem)
++{
++	return list_entry(elem, struct rtglobal_vcpu, runq_elem);
++}
++
++/* lock is grabbed before calling this function */
++static inline void
++__runq_remove(struct rtglobal_vcpu *svc)
++{
++	if(__vcpu_on_runq(svc))
++		list_del_init(&svc->runq_elem);
++}
++
++/* lock is grabbed before calling this function */
++static void
++__runq_insert(const struct scheduler *ops, struct rtglobal_vcpu *svc)
++{
++	struct list_head *runq = RUNQ(ops);
++	struct list_head *iter;
++	struct rtglobal_private *prv = RTGLOBAL_PRIV(ops);
++	ASSERT( spin_is_locked(per_cpu(schedule_data, svc->vcpu->processor).schedule_lock) );
++
++	if(__vcpu_on_runq(svc))
++		return;
++
++	list_for_each(iter, runq) {
++		struct rtglobal_vcpu *iter_svc = __runq_elem(iter);
++
++		if(svc->cur_budget > 0) { /* svc still has budget*/
++			if(iter_svc->cur_budget == 0) {
++				break;
++			}
++
++			if(svc->sdom->rt == 1) {
++				if(iter_svc->sdom->rt == 0 || 
++				   ((prv->priority_scheme == EDF && svc->cur_deadline < iter_svc->cur_deadline) ||
++				   (prv->priority_scheme == RM && svc->period < iter_svc->period))) {
++					break;
++				}
++			} else {
++				if(iter_svc->sdom->rt == 0 && 
++						((prv->priority_scheme == EDF && svc->cur_deadline < iter_svc->cur_deadline) ||
++						 (prv->priority_scheme == RM && svc->period < iter_svc->period))) {
++					break;
++				}
++			}
++		}else if(iter_svc->cur_budget == 0) { /* svc has no budget, and iter_svc also has no budget*/
++			if(svc->sdom->rt == 1) {
++				if(iter_svc->sdom->rt == 0 || 
++				   ((prv->priority_scheme == EDF && svc->cur_deadline < iter_svc->cur_deadline) ||
++				   (prv->priority_scheme == RM && svc->period < iter_svc->period))) {
++					break;
++				} 
++			}else{
++				if(iter_svc->sdom->rt == 0 && 
++						((prv->priority_scheme == EDF && svc->cur_deadline < iter_svc->cur_deadline) ||
++						 (prv->priority_scheme == RM && svc->period < iter_svc->period))) {
++					break;
++				}
++			}
++		}else{ /* svc has no budget, iter_svc has budget, skip this case*/
++		}
++	}
++
++	list_add_tail(&svc->runq_elem, iter);
++}
++
++/*
++ * Debug related code, dump vcpu/pcpu
++ */
++static void
++rtglobal_dump_vcpu(struct rtglobal_vcpu *svc)
++{
++	if(svc == NULL) {
++		printk("NULL!\n");
++		return;
++	}
++	/* #define cpustr keyhandler_scratch*/
++	/* cpumask_scnprintf(cpustr, sizeof(cpustr), svc->vcpu->cpu_affinity);*/
++	printk("[%5d.%-2d] cpu %d, (%-2d, %-2d), cur_b=%ld cur_d=%lu last_start=%lu onR=%d runnable=%d\n",
++			/* , affinity=%s\n",*/
++			svc->vcpu->domain->domain_id,
++			svc->vcpu->vcpu_id,
++			svc->vcpu->processor,
++			svc->period,
++			svc->budget,
++			svc->cur_budget,
++			svc->cur_deadline,
++			svc->last_start,
++			__vcpu_on_runq(svc),
++			vcpu_runnable(svc->vcpu));
++	/* cpustr);*/
++	/* #undef cpustr*/
++}
++
++static void
++rtglobal_dump_pcpu(const struct scheduler *ops, int cpu)
++{
++	struct rtglobal_vcpu *svc = RTGLOBAL_VCPU(curr_on_cpu(cpu));
++
++	printtime();
++	rtglobal_dump_vcpu(svc);
++}
++
++/* should not need lock here. only showing stuff */
++static void
++rtglobal_dump(const struct scheduler *ops)
++{
++	struct list_head *iter_sdom, *iter_svc, *runq, *iter;
++	struct rtglobal_private *prv = RTGLOBAL_PRIV(ops);
++	struct rtglobal_vcpu *svc;
++	int cpu = 0;
++	int loop = 0;
++
++	printtime();
++	if(prv->priority_scheme == EDF) printk("EDF\n");
++	else printk ("RM\n");
++
++	printk("PCPU info: \n");
++	for_each_cpu(cpu, &prv->cpus) {
++		rtglobal_dump_pcpu(ops, cpu);
++	}
++
++	printk("RunQueue info: \n");
++	loop = 0;
++	runq = RUNQ(ops);
++	list_for_each( iter, runq ) {
++		svc = __runq_elem(iter);
++		printk("\t%3d: ", ++loop);
++		rtglobal_dump_vcpu(svc);
++	}
++
++	printk("Domain info: \n");
++	loop = 0;
++	list_for_each( iter_sdom, &prv->sdom ) {
++		struct rtglobal_dom *sdom;
++		sdom = list_entry(iter_sdom, struct rtglobal_dom, sdom_elem);
++		printk("\tdomain: %d\n", sdom->dom->domain_id);
++
++		list_for_each( iter_svc, &sdom->vcpu ) {
++			svc = list_entry(iter_svc, struct rtglobal_vcpu, sdom_elem);
++			printk("\t\t%3d: ", ++loop);
++			rtglobal_dump_vcpu(svc);
++		}
++	}
++
++	printk("\n");
++}
++
++/*
++ * Init/Free related code
++ */
++static int
++rtglobal_init(struct scheduler *ops)
++{
++	struct rtglobal_private *prv;
++
++	prv = xmalloc(struct rtglobal_private);
++	if(prv == NULL) {
++		printk("malloc failed at rtglobal_private\n");
++		return -ENOMEM;
++	}
++	memset(prv, 0, sizeof(*prv));
++
++	ops->sched_data = prv;
++	spin_lock_init(&prv->lock);
++	INIT_LIST_HEAD(&prv->sdom);
++	INIT_LIST_HEAD(&prv->runq);
++	cpumask_clear(&prv->tickled);
++	cpumask_clear(&prv->cpus);
++	prv->priority_scheme = EDF;     /* by default, use EDF scheduler */
++
++	printk("This is the Deferrable Server version of the preemptive RTGLOBAL scheduler\n");
++	printk("If you want to use it as a periodic server, please run a background busy CPU task\n");
++
++	printtime();
++	printk("\n");
++
++	return 0;
++}
++
++static void
++rtglobal_deinit(const struct scheduler *ops)
++{
++	struct rtglobal_private *prv;
++
++	printtime();
++	printk("\n");
++
++	prv = RTGLOBAL_PRIV(ops);
++	if(prv)
++		xfree(prv);
++}
++
++/* point per_cpu spinlock to the global system lock */
++static void *
++rtglobal_alloc_pdata(const struct scheduler *ops, int cpu)
++{
++	struct rtglobal_private *prv = RTGLOBAL_PRIV(ops);
++
++	cpumask_set_cpu(cpu, &prv->cpus);
++
++	per_cpu(schedule_data, cpu).schedule_lock = &prv->lock;
++
++	printtime();
++	printk("total cpus: %d", cpumask_weight(&prv->cpus));
++	return (void *)1;
++}
++
++static void
++rtglobal_free_pdata(const struct scheduler *ops, void *pcpu, int cpu)
++{
++	struct rtglobal_private * prv = RTGLOBAL_PRIV(ops);
++	cpumask_clear_cpu(cpu, &prv->cpus);
++	printtime();
++	printk("cpu=%d\n", cpu);
++}
++
++static void *
++rtglobal_alloc_domdata(const struct scheduler *ops, struct domain *dom)
++{
++	unsigned long flags;
++	struct rtglobal_dom *sdom;
++	struct rtglobal_private * prv = RTGLOBAL_PRIV(ops);
++
++	printtime();
++	printk("dom=%d\n", dom->domain_id);
++
++	sdom = xmalloc(struct rtglobal_dom);
++	if(sdom == NULL) {
++		printk("%s, xmalloc failed\n", __func__);
++		return NULL;
++	}
++	memset(sdom, 0, sizeof(*sdom));
++
++	INIT_LIST_HEAD(&sdom->vcpu);
++	INIT_LIST_HEAD(&sdom->sdom_elem);
++	sdom->dom = dom;
++	sdom->rt = 0;         /* by default, non-rt domain */
++
++	/* spinlock here to insert the dom */
++	spin_lock_irqsave(&prv->lock, flags);
++	list_add_tail(&sdom->sdom_elem, &(prv->sdom));
++	spin_unlock_irqrestore(&prv->lock, flags);
++
++	return (void *)sdom;
++}
++
++static void
++rtglobal_free_domdata(const struct scheduler *ops, void *data)
++{
++    unsigned long flags;
++    struct rtglobal_dom *sdom = data;
++    struct rtglobal_private * prv = RTGLOBAL_PRIV(ops);
++
++    printtime();
++    printk("dom=%d\n", sdom->dom->domain_id);
++
++    spin_lock_irqsave(&prv->lock, flags);
++    list_del_init(&sdom->sdom_elem);
++    spin_unlock_irqrestore(&prv->lock, flags);
++    xfree(data);
++}
++
++static int
++rtglobal_dom_init(const struct scheduler *ops, struct domain *dom)
++{
++    struct rtglobal_dom *sdom;
++
++    printtime();
++    printk("dom=%d\n", dom->domain_id);
++
++    /* IDLE Domain does not link on rtglobal_private */
++	if(is_idle_domain(dom)) {return 0;}
++
++    sdom = rtglobal_alloc_domdata(ops, dom);
++	if(sdom == NULL) {
++        printk("%s, failed\n", __func__);
++        return -ENOMEM;
++    }
++    dom->sched_priv = sdom;
++
++    return 0;
++}
++
++static void
++rtglobal_dom_destroy(const struct scheduler *ops, struct domain *dom)
++{
++    printtime();
++    printk("dom=%d\n", dom->domain_id);
++
++    rtglobal_free_domdata(ops, RTGLOBAL_DOM(dom));
++}
++
++static void *
++rtglobal_alloc_vdata(const struct scheduler *ops, struct vcpu *vc, void *dd)
++{
++    struct rtglobal_vcpu *svc;
++    s_time_t now = NOW();
++    long count;
++
++    /* Allocate per-VCPU info */
++    svc = xmalloc(struct rtglobal_vcpu);
++	if(svc == NULL) {
++        printk("%s, xmalloc failed\n", __func__);
++        return NULL;
++    }
++    memset(svc, 0, sizeof(*svc));
++
++    INIT_LIST_HEAD(&svc->runq_elem);
++    INIT_LIST_HEAD(&svc->sdom_elem);
++    svc->flags = 0U;
++    svc->sdom = dd;
++    svc->vcpu = vc;
++    svc->last_start = 0;            /* init last_start is 0 */
++
++    svc->period = RTGLOBAL_DEFAULT_PERIOD;
++	if(!is_idle_vcpu(vc) && vc->domain->domain_id != 0) {
++        svc->budget = RTGLOBAL_DEFAULT_BUDGET;
++    } else {
++        svc->budget = RTGLOBAL_DEFAULT_PERIOD;
++    }
++
++    count = (now/MILLISECS(svc->period)) + 1;
++    svc->cur_deadline += count*MILLISECS(svc->period); /* sync all VCPU's start time to 0 */
++
++    svc->cur_budget = svc->budget*1000; /* counting in microseconds level */
++    printtime();
++    rtglobal_dump_vcpu(svc);
++
++    return svc;
++}
++
++static void
++rtglobal_free_vdata(const struct scheduler *ops, void *priv)
++{
++    struct rtglobal_vcpu *svc = priv;
++    printtime();
++    rtglobal_dump_vcpu(svc);
++    xfree(svc);
++}
++
++/* lock is grabbed before calling this function */
++static void
++rtglobal_vcpu_insert(const struct scheduler *ops, struct vcpu *vc)
++{
++    struct rtglobal_vcpu *svc = RTGLOBAL_VCPU(vc);
++
++    printtime();
++    rtglobal_dump_vcpu(svc);
++
++    /* IDLE VCPU not allowed on RunQ */
++	if(is_idle_vcpu(vc))
++        return;
++
++    list_add_tail(&svc->sdom_elem, &svc->sdom->vcpu);   /* add to dom vcpu list */
++}
++
++/* lock is grabbed before calling this function */
++static void
++rtglobal_vcpu_remove(const struct scheduler *ops, struct vcpu *vc)
++{
++    struct rtglobal_vcpu * const svc = RTGLOBAL_VCPU(vc);
++    struct rtglobal_dom * const sdom = svc->sdom;
++
++    printtime();
++    rtglobal_dump_vcpu(svc);
++
++    BUG_ON( sdom == NULL );
++    BUG_ON( __vcpu_on_runq(svc) );
++
++	if(!is_idle_vcpu(vc)) {
++        list_del_init(&svc->sdom_elem);
++    }
++}
++
++/*
++ * Other important functions
++ */
++/* do we need the lock here? */
++/* TODO: How to return the per VCPU parameters? Right now return the sum of budgets */
++static int
++rtglobal_dom_cntl(const struct scheduler *ops, struct domain *d, struct xen_domctl_scheduler_op *op)
++{
++    struct rtglobal_dom * const sdom = RTGLOBAL_DOM(d);
++    struct list_head *iter;
++    struct rtglobal_private * prv = RTGLOBAL_PRIV(ops);
++
++	if(op->cmd == XEN_DOMCTL_SCHEDOP_getinfo) {
++        /* for debug use, whenever adjust Dom0 parameter, do global dump */
++		if(d->domain_id == 0) {
++            rtglobal_dump(ops);
++        }
++
++        /* TODO: how to return individual VCPU parameters? */
++        op->u.rtglobal.budget = 0;
++        op->u.rtglobal.rt = sdom->rt;
++        list_for_each( iter, &sdom->vcpu ) {
++	       struct rtglobal_vcpu *svc = list_entry(iter, struct rtglobal_vcpu, sdom_elem);
++	       op->u.rtglobal.budget += svc->budget;
++	       op->u.rtglobal.period = svc->period;
++       }
++   }else{
++        ASSERT(op->cmd == XEN_DOMCTL_SCHEDOP_putinfo);
++
++		if(d->domain_id == 0) {
++			if(prv->priority_scheme == EDF) {
++                prv->priority_scheme = RM;
++                printk("priority changed to RM\n");
++            } else {
++                prv->priority_scheme = EDF;
++                printk("priority changed to EDF\n");
++            }
++        }
++
++        sdom->rt = op->u.rtglobal.rt;
++        list_for_each( iter, &sdom->vcpu ) {
++            struct rtglobal_vcpu *svc = list_entry(iter, struct rtglobal_vcpu, sdom_elem);
++			if(op->u.rtglobal.vcpu == svc->vcpu->vcpu_id) { /* adjust per VCPU parameter */
++                svc->period = op->u.rtglobal.period;
++                svc->budget = op->u.rtglobal.budget;
++                break;
++            }
++        }
++    }
++
++    return 0;
++}
++
++/* return a VCPU considering affinity */
++static int
++rtglobal_cpu_pick(const struct scheduler *ops, struct vcpu *vc)
++{
++    cpumask_t cpus;
++    const cpumask_t *pcpu_affinity;
++    int cpu;
++    struct rtglobal_private * prv = RTGLOBAL_PRIV(ops);
++
++    pcpu_affinity =  vc->cpu_affinity;
++    cpumask_copy(&cpus, pcpu_affinity);
++    cpumask_and(&cpus, &prv->cpus, &cpus);
++
++    cpu = cpumask_test_cpu(vc->processor, &cpus)
++            ? vc->processor 
++            : cpumask_cycle(vc->processor, &cpus);
++    ASSERT( !cpumask_empty(&cpus) && cpumask_test_cpu(cpu, &cpus) );
++
++
++    return cpu;
++}
++
++/* Implemented as deferrable server. */
++/* burn budget at microsecond level */
++static void
++burn_budgets(const struct scheduler *ops, struct rtglobal_vcpu *svc, s_time_t now) {
++    s_time_t delta;
++    unsigned int consume;
++    long count = 0;
++
++    /* first time called for this svc, update last_start */
++	if(svc->last_start == 0) {
++        svc->last_start = now;
++        return;
++    }
++
++    /* don't burn budget for idle VCPU */
++	if(is_idle_vcpu(svc->vcpu)) {
++        return;
++    }
++
++    /* update deadline info */
++    delta = now - svc->cur_deadline;
++	if(delta >= 0) {
++        count = ( delta/MILLISECS(svc->period) ) + 1;
++        svc->cur_deadline += count * MILLISECS(svc->period);
++        svc->cur_budget = svc->budget * 1000;
++        return;
++    }
++
++    delta = now - svc->last_start;
++	if(delta < 0) {
++        printk("%s, delta = %ld for ", __func__, delta);
++        rtglobal_dump_vcpu(svc);
++        svc->last_start = now;  /* update last_start */
++        svc->cur_budget = 0;
++        return;
++    }
++
++	if(svc->cur_budget == 0) return;
++
++    /* burn at microseconds level */
++    consume = ( delta/MICROSECS(1) );
++	if(delta%MICROSECS(1) > MICROSECS(1)/2) consume++;
++
++    svc->cur_budget -= consume;
++	if(svc->cur_budget < 0) svc->cur_budget = 0;
++}
++
++/* RunQ is sorted. Pick first one within cpumask. If no one, return NULL */
++/* lock is grabbed before calling this function */
++static struct rtglobal_vcpu *
++__runq_pick(const struct scheduler *ops, cpumask_t mask)
++{
++    struct list_head *runq = RUNQ(ops);
++    struct list_head *iter;
++    struct rtglobal_vcpu *svc = NULL;
++    struct rtglobal_vcpu *iter_svc = NULL;
++    cpumask_t cpu_common;
++    const cpumask_t *pcpu_affinity;
++
++
++    list_for_each(iter, runq) {
++        iter_svc = __runq_elem(iter);   
++
++    	pcpu_affinity = iter_svc->vcpu->cpu_affinity;
++        cpumask_copy(&cpu_common, pcpu_affinity);
++        cpumask_and(&cpu_common, &mask, &cpu_common);
++		if(cpumask_empty(&cpu_common))
++            continue;
++
++        if(iter_svc->cur_budget <= 0)
++            continue;
++
++        svc = iter_svc;
++        break;
++    }
++
++    return svc;
++}
++
++/* lock is grabbed before calling this function */
++static void
++__repl_update(const struct scheduler *ops, s_time_t now)
++{
++    struct list_head *runq = RUNQ(ops);
++    struct list_head *iter;
++    struct list_head *tmp;
++    struct rtglobal_vcpu *svc = NULL;
++
++    s_time_t diff;
++    long count;
++
++    list_for_each_safe(iter, tmp, runq) {
++        svc = __runq_elem(iter);
++
++        diff = now - svc->cur_deadline;
++		if(diff > 0) {
++            count = (diff/MILLISECS(svc->period)) + 1;
++            svc->cur_deadline += count * MILLISECS(svc->period);
++            svc->cur_budget = svc->budget * 1000;
++            __runq_remove(svc);
++            __runq_insert(ops, svc);
++        }
++    }
++}
++
++/* The lock is already grabbed in schedule.c, no need to lock here */
++static struct task_slice
++rtglobal_schedule(const struct scheduler *ops, s_time_t now, bool_t tasklet_work_scheduled)
++{
++    const int cpu = smp_processor_id();
++    struct rtglobal_private *prv = RTGLOBAL_PRIV(ops);
++    struct rtglobal_vcpu * const scurr = RTGLOBAL_VCPU(current);
++    struct rtglobal_vcpu *snext = NULL;
++    struct task_slice ret;
++
++    /* clear ticked bit now that we've been scheduled */
++	if(cpumask_test_cpu(cpu, &prv->tickled))
++        cpumask_clear_cpu(cpu, &prv->tickled);
++
++    /* burn_budget would return for IDLE VCPU */
++    burn_budgets(ops, scurr, now);
++
++    __repl_update(ops, now);
++
++	if(tasklet_work_scheduled){
++        snext = RTGLOBAL_VCPU(idle_vcpu[cpu]);
++    }else{
++        cpumask_t cur_cpu;
++        cpumask_clear(&cur_cpu);
++        cpumask_set_cpu(cpu, &cur_cpu);
++        snext = __runq_pick(ops, cur_cpu);
++		if(snext == NULL)
++            snext = RTGLOBAL_VCPU(idle_vcpu[cpu]);
++
++        /* if scurr has higher priority and budget, still pick scurr */
++		if(!is_idle_vcpu(current) &&
++             vcpu_runnable(current) &&
++             scurr->cur_budget > 0 &&
++             (is_idle_vcpu(snext->vcpu) ||
++               (scurr->sdom->rt == 1 && snext->sdom->rt == 0) ||  /* has strict higher priority*/
++               (scurr->sdom->rt == snext->sdom->rt && scurr->cur_deadline < snext->cur_deadline))) { /* round-robin when tie-breaking*/
++               /* scurr->vcpu->domain->domain_id == snext->vcpu->domain->domain_id ) ) {*/
++            snext = scurr;
++        }
++    }
++
++	if(snext != scurr &&
++         !is_idle_vcpu(current) &&
++         vcpu_runnable(current)) {
++        set_bit(__RTGLOBAL_delayed_runq_add, &scurr->flags);
++    }
++
++    snext->last_start = now;
++    ret.migrated = 0;
++	if(!is_idle_vcpu(snext->vcpu)){
++		if(snext != scurr){
++            __runq_remove(snext);
++            set_bit(__RTGLOBAL_scheduled, &snext->flags);
++        }
++		if(snext->vcpu->processor != cpu) {
++            snext->vcpu->processor = cpu;
++            ret.migrated = 1;
++        }
++    }
++
++	if(is_idle_vcpu(snext->vcpu) || snext->cur_budget > MILLISECS(1)) {
++        ret.time = MILLISECS(1);
++    }else{
++        ret.time = MICROSECS(snext->budget);
++    } 
++
++    ret.task = snext->vcpu;
++
++    return ret;
++}
++
++/* Remove VCPU from RunQ */
++/* The lock is already grabbed in schedule.c, no need to lock here */
++static void
++rtglobal_vcpu_sleep(const struct scheduler *ops, struct vcpu *vc)
++{
++    struct rtglobal_vcpu * const svc = RTGLOBAL_VCPU(vc);
++
++    BUG_ON( is_idle_vcpu(vc) );
++
++	if(curr_on_cpu(vc->processor) == vc) {
++        cpu_raise_softirq(vc->processor, SCHEDULE_SOFTIRQ);
++        return;
++    }
++
++	if(__vcpu_on_runq(svc)) {
++        __runq_remove(svc);
++    }
++
++    clear_bit(__RTGLOBAL_delayed_runq_add, &svc->flags);
++}
++
++/*
++ * called by wake() and context_saved()
++ * we have a running candidate here, the kick logic is:
++ * Among all the cpus that are within the cpu affinity
++ * 1) if the new->cpu is idle, kick it. This could benefit cache hit
++ * 2) if there are any idle vcpu, kick it.
++ * 3) now all pcpus are busy, among all the running vcpus, pick lowest priority one
++ *    if snext has higher priority, kick it.
++ * TODO: what if these two vcpus belongs to the same domain?
++ * replace a vcpu belonging to the same domain does not make sense
++ */
++/* lock is grabbed before calling this function */
++static void
++runq_tickle(const struct scheduler *ops, struct rtglobal_vcpu *new)
++{
++    struct rtglobal_private *prv = RTGLOBAL_PRIV(ops);
++    struct rtglobal_vcpu *scheduled = NULL;    /* lowest priority scheduled */
++    struct rtglobal_vcpu *iter_svc;
++    struct vcpu * iter_vc;
++    int cpu = 0;
++    cpumask_t not_tickled;                  /* not tickled cpus */
++    const cpumask_t *pcpu_affinity;
++
++	if(new == NULL || is_idle_vcpu(new->vcpu)) return;
++
++    pcpu_affinity = new->vcpu->cpu_affinity;
++
++    cpumask_copy(&not_tickled, pcpu_affinity);
++    cpumask_andnot(&not_tickled, &not_tickled, &prv->tickled);
++
++    /* 1) if new's previous cpu is idle, kick it for cache benefit */
++	if(is_idle_vcpu(curr_on_cpu(new->vcpu->processor))) {
++        cpumask_set_cpu(new->vcpu->processor, &prv->tickled);
++        cpu_raise_softirq(new->vcpu->processor, SCHEDULE_SOFTIRQ);
++        return;
++    }
++
++    /* 2) if there are any idle pcpu, kick it */
++    /* the same loop also found the one with lowest priority */
++    for_each_cpu(cpu, &not_tickled) {
++        iter_vc = curr_on_cpu(cpu);
++		if(is_idle_vcpu(iter_vc)) {
++            cpumask_set_cpu(cpu, &prv->tickled);
++            cpu_raise_softirq(cpu, SCHEDULE_SOFTIRQ);
++            return;
++        }
++        iter_svc = RTGLOBAL_VCPU(iter_vc);
++		if(scheduled == NULL || iter_svc->cur_deadline < scheduled->cur_deadline) {
++            scheduled = iter_svc;
++        }
++    }
++
++    /* 3) new has higher priority, kick it */
++	if(scheduled != NULL && new->cur_deadline < scheduled->cur_deadline) {
++        cpumask_set_cpu(scheduled->vcpu->processor, &prv->tickled);
++        cpu_raise_softirq(scheduled->vcpu->processor, SCHEDULE_SOFTIRQ);
++    }
++    return;
++}
++
++/* Should always wake up runnable, put it back to RunQ. Check priority to raise interrupt */
++/* The lock is already grabbed in schedule.c, no need to lock here */
++/* TODO: what if these two vcpus belongs to the same domain? */
++static void
++rtglobal_vcpu_wake(const struct scheduler *ops, struct vcpu *vc)
++{
++    struct rtglobal_vcpu * const svc = RTGLOBAL_VCPU(vc);
++    s_time_t diff;
++    s_time_t now = NOW();
++    long count = 0;
++    struct rtglobal_private *prv = RTGLOBAL_PRIV(ops);
++    struct rtglobal_vcpu *snext = NULL;        /* highest priority on RunQ */
++
++    BUG_ON( is_idle_vcpu(vc) );
++
++	if(unlikely(curr_on_cpu(vc->processor) == vc)) return;
++
++    /* on RunQ, just update info is ok */
++	if(unlikely(__vcpu_on_runq(svc))) return;
++
++    /* if context hasn't been saved yet, set flag so it will add later */
++	if(unlikely(test_bit(__RTGLOBAL_scheduled, &svc->flags))) {
++        set_bit(__RTGLOBAL_delayed_runq_add, &svc->flags);
++        return;
++    }
++
++    /* update deadline info */
++    diff = now - svc->cur_deadline;
++	if(diff >= 0) {
++        count = (diff/MILLISECS(svc->period)) + 1;
++        svc->cur_deadline += count * MILLISECS(svc->period);
++        svc->cur_budget = svc->budget * 1000;
++    }
++
++    __runq_insert(ops, svc);
++    __repl_update(ops, now);
++    snext = __runq_pick(ops, prv->cpus);    /* pick snext from ALL cpus */
++    runq_tickle(ops, snext);
++
++    return;
++}
++
++/* scurr has finished context switch, insert it back to the RunQ*/
++static void
++rtglobal_context_saved(const struct scheduler *ops, struct vcpu *vc)
++{
++    struct rtglobal_vcpu *svc = RTGLOBAL_VCPU(vc);
++    struct rtglobal_vcpu *snext = NULL;
++    struct rtglobal_private * prv = RTGLOBAL_PRIV(ops);
++    spinlock_t *lock;
++
++    clear_bit(__RTGLOBAL_scheduled, &svc->flags);
++	if( is_idle_vcpu(vc) ) return;
++
++    lock = vcpu_schedule_lock_irq(vc);
++	if(test_and_clear_bit(__RTGLOBAL_delayed_runq_add, &svc->flags) && likely(vcpu_runnable(vc))) {
++        __runq_insert(ops, svc);
++        __repl_update(ops, NOW());
++        snext = __runq_pick(ops, prv->cpus);    /* pick snext from ALL cpus */
++        runq_tickle(ops, snext);
++    }
++    vcpu_schedule_unlock_irq(lock, vc);
++}
++
++static struct rtglobal_private _rtglobal_priv;
++
++const struct scheduler sched_rtglobal_def = {
++    .name           = "SMP RTGLOBAL Scheduler",
++    .opt_name       = "rtglobal",
++    .sched_id       = XEN_SCHEDULER_RTGLOBAL,
++    .sched_data     = &_rtglobal_priv,
++
++    .dump_cpu_state = rtglobal_dump_pcpu,
++    .dump_settings  = rtglobal_dump,
++    .init           = rtglobal_init,
++    .deinit         = rtglobal_deinit,
++    .alloc_pdata    = rtglobal_alloc_pdata,
++    .free_pdata     = rtglobal_free_pdata,
++    .alloc_domdata  = rtglobal_alloc_domdata,
++    .free_domdata   = rtglobal_free_domdata,
++    .init_domain    = rtglobal_dom_init,
++    .destroy_domain = rtglobal_dom_destroy,
++    .alloc_vdata    = rtglobal_alloc_vdata,
++    .free_vdata     = rtglobal_free_vdata,
++    .insert_vcpu    = rtglobal_vcpu_insert,
++    .remove_vcpu    = rtglobal_vcpu_remove,
++
++    .adjust         = rtglobal_dom_cntl,
++
++    .pick_cpu       = rtglobal_cpu_pick,
++    .do_schedule    = rtglobal_schedule,
++    .sleep          = rtglobal_vcpu_sleep,
++    .wake           = rtglobal_vcpu_wake,
++    .context_saved  = rtglobal_context_saved,
++
++    .yield          = NULL,
++    .migrate        = NULL,
++};
++
+diff --git a/xen/common/schedule.c b/xen/common/schedule.c
+index 332a21f..77d6d92 100644
+--- a/xen/common/schedule.c
++++ b/xen/common/schedule.c
+@@ -63,11 +63,15 @@ static void poll_timer_fn(void *data);
+ DEFINE_PER_CPU(struct schedule_data, schedule_data);
+ DEFINE_PER_CPU(struct scheduler *, scheduler);
+ 
++// rt-xen
++extern const struct scheduler sched_rtglobal_def;
++
+ static const struct scheduler *schedulers[] = {
+     &sched_sedf_def,
+     &sched_credit_def,
+     &sched_credit2_def,
+     &sched_arinc653_def,
++    &sched_rtglobal_def,
+ };
+ 
+ static struct scheduler __read_mostly ops;
+diff --git a/xen/include/public/domctl.h b/xen/include/public/domctl.h
+index d381903..c2d2955 100644
+--- a/xen/include/public/domctl.h
++++ b/xen/include/public/domctl.h
+@@ -316,6 +316,8 @@ DEFINE_XEN_GUEST_HANDLE(xen_domctl_max_vcpus_t);
+ #define XEN_SCHEDULER_CREDIT   5
+ #define XEN_SCHEDULER_CREDIT2  6
+ #define XEN_SCHEDULER_ARINC653 7
++#define XEN_SCHEDULER_RTGLOBAL 8
++
+ /* Set or get info? */
+ #define XEN_DOMCTL_SCHEDOP_putinfo 0
+ #define XEN_DOMCTL_SCHEDOP_getinfo 1
+@@ -337,6 +339,12 @@ struct xen_domctl_scheduler_op {
+         struct xen_domctl_sched_credit2 {
+             uint16_t weight;
+         } credit2;
++	struct xen_domctl_sched_rtglobal {
++		uint16_t period;
++		uint16_t budget;
++		uint16_t rt;
++		uint16_t vcpu;
++	} rtglobal;
+     } u;
+ };
+ typedef struct xen_domctl_scheduler_op xen_domctl_scheduler_op_t;

--- a/recipes-extended/xen/files/xl-introduce-rtglobal-scheduler.patch
+++ b/recipes-extended/xen/files/xl-introduce-rtglobal-scheduler.patch
@@ -1,0 +1,188 @@
+diff --git a/tools/libxl/xl.h b/tools/libxl/xl.h
+index 5ad3e17..f82ae74 100644
+--- a/tools/libxl/xl.h
++++ b/tools/libxl/xl.h
+@@ -65,6 +65,7 @@ int main_memset(int argc, char **argv);
+ int main_sched_credit(int argc, char **argv);
+ int main_sched_credit2(int argc, char **argv);
+ int main_sched_sedf(int argc, char **argv);
++int main_sched_rtglobal(int argc, char **argv);
+ int main_domid(int argc, char **argv);
+ int main_domname(int argc, char **argv);
+ int main_rename(int argc, char **argv);
+diff --git a/tools/libxl/xl_cmdimpl.c b/tools/libxl/xl_cmdimpl.c
+index b251f4c..7c28ba7 100644
+--- a/tools/libxl/xl_cmdimpl.c
++++ b/tools/libxl/xl_cmdimpl.c
+@@ -4964,6 +4964,37 @@ static int sched_sedf_domain_output(
+     return 0;
+ }
+ 
++static int sched_rtglobal_domain_output(int domid)
++{
++	char *domname;
++	libxl_domain_sched_params scinfo;
++	int rc = 0;
++
++	if (domid < 0) {
++		printf("%-33s %4s %6s %6s %6s %6s\n", "Name", "ID", "Budget", "Period", "VCPU", "RT");
++		return 0;
++	}
++
++	libxl_domain_sched_params_init(&scinfo);
++	rc = sched_domain_get(LIBXL_SCHEDULER_RTGLOBAL, domid, &scinfo);
++	if (rc)
++		goto out;
++
++	domname = libxl_domid_to_name(ctx, domid);
++	printf("%-33s %4d %6d %6d %6d %6d\n",
++			domname,
++			domid,
++			scinfo.budget,
++			scinfo.period,
++			scinfo.vcpu,
++			scinfo.rt);
++	free(domname);
++
++out:
++	libxl_domain_sched_params_dispose(&scinfo);
++	return rc;
++}
++
+ static int sched_default_pool_output(uint32_t poolid)
+ {
+     char *poolname;
+@@ -4975,6 +5006,7 @@ static int sched_default_pool_output(uint32_t poolid)
+     return 0;
+ }
+ 
++
+ static int sched_domain_output(libxl_scheduler sched, int (*output)(int),
+                                int (*pooloutput)(uint32_t), const char *cpupool)
+ {
+@@ -5026,6 +5058,104 @@ static int sched_domain_output(libxl_scheduler sched, int (*output)(int),
+     return 0;
+ }
+ 
++
++
++int main_sched_rtglobal(int argc, char **argv)
++{
++	const char *cpupool = NULL;
++	const char *dom = NULL;
++	int period = 0; /* period is in microsecond */
++	int budget = 0; /* budget is in microsecond */
++	int vcpu = 0;
++	int rt = 0;
++	bool opt_p = false;
++	bool opt_b = false;
++	bool opt_v = false;
++	bool opt_r = false;
++	int opt, rc;
++	static struct option opts[] = {
++		{"domain", 1, 0, 'd'},
++		{"period", 1, 0, 'p'},
++		{"budget", 1, 0, 'b'},
++		{"vcpu", 1, 0, 'v'},
++		{"rt", 1, 0, 'r'},
++		{"cpupool", 1, 0, 'c'},
++		COMMON_LONG_OPTS,
++		{0, 0, 0, 0}
++	};
++
++	SWITCH_FOREACH_OPT(opt, "d:p:b:v:r:c:h", opts, "sched‐rtglobal", 0) {
++		case 'd':
++			dom = optarg;
++			break;
++		case 'p':
++			period = strtol(optarg, NULL, 10);
++			opt_p = 1;
++			break;
++		case 'b':
++			budget = strtol(optarg, NULL, 10);
++			opt_b = 1;
++			break;
++		case 'v':
++			vcpu = strtol(optarg, NULL, 10);
++			opt_v = 1;
++			break;
++		case 'r':
++			rt = strtol(optarg, NULL, 10);
++			opt_r = 1;
++			break;
++		case 'c':
++			cpupool = optarg;
++			break;
++	}
++
++
++	if (cpupool && (dom || opt_p || opt_b || opt_v || opt_r)) {
++		fprintf(stderr, "Specifying a cpupool is not allowed with other options.\n");
++		return 1;
++	}
++
++	if (!dom && (opt_p || opt_b || opt_v || opt_r)) {
++		fprintf(stderr, "Must specify a domain.\n");
++		return 1;
++	}
++
++	if (opt_p != opt_b) {
++		fprintf(stderr, "Must specify period and budget\n");
++		return 1;
++	}
++
++	if (!dom) { /* list all domain's rt scheduler info */
++		return -sched_domain_output(LIBXL_SCHEDULER_RTGLOBAL,
++				sched_rtglobal_domain_output,
++				sched_default_pool_output,
++				cpupool);
++	} else {
++		uint32_t domid = find_domain(dom);
++		if (!opt_p && !opt_b) { /* output rt scheduler info */
++			sched_rtglobal_domain_output(-1);
++
++			return -sched_rtglobal_domain_output(domid);
++
++		} else { /* set rt scheduler paramaters */
++			libxl_domain_sched_params scinfo;
++			libxl_domain_sched_params_init(&scinfo);
++
++			scinfo.sched = LIBXL_SCHEDULER_RTGLOBAL;
++			scinfo.period = period;
++			scinfo.budget = budget;
++			scinfo.vcpu = vcpu;
++			scinfo.rt = rt;
++
++			rc = sched_domain_set(domid, &scinfo);
++			libxl_domain_sched_params_dispose(&scinfo);
++			if (rc)
++				return -rc;
++		}
++	}
++
++	return 0;
++}
+ /* 
+  * <nothing>             : List all domain params and sched params from all pools
+  * -d [domid]            : List domain params for domain
+diff --git a/tools/libxl/xl_cmdtable.c b/tools/libxl/xl_cmdtable.c
+index 44b42b0..a5cbc40 100644
+--- a/tools/libxl/xl_cmdtable.c
++++ b/tools/libxl/xl_cmdtable.c
+@@ -271,6 +271,16 @@ struct cmd_spec cmd_table[] = {
+       "                               --period/--slice)\n"
+       "-c CPUPOOL, --cpupool=CPUPOOL  Restrict output to CPUPOOL"
+     },
++	{ "sched-rtglobal",
++	 &main_sched_rtglobal, 0, 1,
++	  "Get/set rtglobal scheduler parameters",
++	  "[‐d <Domain> [‐p[=PERIOD]] [‐b[=BUDGET]]]",
++	  "‐d DOMAIN, ‐‐domain=DOMAIN Domain to modify\n"
++	  "‐p PERIOD, ‐‐period=PERIOD Period (us)\n"
++	  "‐b BUDGET, ‐‐budget=BUDGET Budget (us)\n"
++	  "‐v VCPU, ‐‐vcpu=VCPU\n"
++	  "‐r RT, ‐‐rt=RT or Non RT (1 or 0)\n"
++	},
+     { "domid",
+       &main_domid, 0, 0,
+       "Convert a domain name to domain id",

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -106,7 +106,7 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://xl-introduce-rtglobal-scheduler.patch;patch=1 \
     file://libxl-add-rtglobal-scheduler.patch;patch=1 \
     file://libxc-add-rtglobal-scheduler.patch;patch=1 \
-    file://xen-add-real-time-scheduler-rtglobal.patch:patch=1 \
+    file://xen-add-real-time-scheduler-rtglobal.patch;patch=1 \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -103,6 +103,10 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://blktap-timeout.patch;patch=1 \
     file://stubdomain-msi-irq-access.patch;striplevel=1 \
     file://workaround-nehalem-igd-vtd.patch;patch=1 \
+    file://xl-introduce-rtglobal-scheduler.patch;patch=1 \
+    file://libxl-add-rtglobal-scheduler.patch;patch=1 \
+    file://libxc-add-rtglobal-scheduler.patch;patch=1 \
+    file://xen-add-real-time-scheduler-rtglobal.patch:patch=1 \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"


### PR DESCRIPTION
We need an RT Scheduler in OpenXT environment. For this we have ported the patches from 
https://sites.google.com/site/realtimexen/rt-openstack into the xen-4.3.4 used in the xenclient-oe interface.

Please review and merge.

Thanks,
Ashu.