### PR TITLE
[ralink] Remove module and firmware.

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -39,8 +39,6 @@ IMAGE_INSTALL = "\
     task-xenclient-installer \
     kernel-module-e1000e \
     linux-firmware \
-    rt2870-firmware \
-    rt3572 \
     ${ANGSTROM_EXTRA_INSTALL}"
 
 IMAGE_FSTYPES = "cpio.gz"


### PR DESCRIPTION
rt2870/rt357x devices are USB Wifi dongles only.
There is no Wireless support in dom0's kernel shared by the installer. There is no claim to support installation through such means and no infrastructure in OpenXT either.

Currently, rt3572 will break the build in dom0's kernel (CONFIG_WIRELESS=n -> CONFIG_WEXT_PRIV=n).