### PR TITLE
xenclient-deb-kernel.bbclass: be nice to Linux 3.18

### DIFF
--- a/classes/xenclient-deb-kernel.bbclass
+++ b/classes/xenclient-deb-kernel.bbclass
@@ -114,6 +114,7 @@ do_deb_package() {
 \${pkg_name}: changelog-file-missing-in-native-package
 \${pkg_name}: debian-changelog-file-missing
 \${pkg_name}: wrong-path-for-interpreter
+\${pkg_name}: shell-script-fails-syntax-check
 EOFOVD
 
 		pkg_size=\$(du -s . | cut -f1)
@@ -218,6 +219,7 @@ DEB_STEP
 \${pkg_name}: changelog-file-missing-in-native-package
 \${pkg_name}: debian-changelog-file-missing
 \${pkg_name}: wrong-path-for-interpreter
+\${pkg_name}: shell-script-fails-syntax-check
 EOFOVD
 
 		pkg_size=\$(du -s . | cut -f1)


### PR DESCRIPTION
The version of Lintian that is in Debian Wheezy doesn't seem to be compatible with Linux 3.18.
This override seems to make it work.

Signed-off-by: Jed <lejosnej@ainfosec.com>