### PR TITLE
xen-tools: enable xz compression support

### DIFF
--- a/recipes-extended/xen/xen-tools.bb
+++ b/recipes-extended/xen/xen-tools.bb
@@ -9,7 +9,7 @@ SRC_URI += "file://xenstored.initscript \
 	    file://do-not-overwrite-cc-and-ld.patch \
 "
 
-DEPENDS += " gettext ncurses openssl python zlib seabios ipxe gmp lzo glib-2.0 iasl-native"
+DEPENDS += " gettext ncurses openssl python zlib seabios ipxe gmp lzo glib-2.0 iasl-native xz "
 DEPENDS += "util-linux"
 # lzo2 required by libxenguest.
 RDEPENDS += " lzo"


### PR DESCRIPTION
This is needed to boot standard Debian kernels as PV guests.

All the credit goes to @rossphilipson for the find :)

Signed-off-by: Jed <lejosnej@ainfosec.com>