### PR TITLE
fix config file permissions for the vusb daemon

### DIFF
--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.te.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_ctxusb.te.patch
@@ -1,5 +1,7 @@
---- a/policy/modules/services/ctxusb.te	1969-12-31 19:00:00.000000000 -0500
-+++ b/policy/modules/services/ctxusb.te	2015-01-05 16:03:12.793080030 -0500
+Index: refpolicy/policy/modules/services/ctxusb.te
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ refpolicy/policy/modules/services/ctxusb.te	2015-09-29 17:46:55.991015669 -0400
 @@ -0,0 +1,105 @@
 +#############################################################################
 +#
@@ -43,14 +45,14 @@
 +
 +type ctxusbd_config_t;
 +files_config_file(ctxusbd_config_t)
-+xc_config_filetrans(ctxusbd_t, ctxusbd_config_t, file)
++files_etc_filetrans(ctxusbd_t, ctxusbd_config_t, file)
 +
 +#######################################
 +#
 +# ctxusb daemon local policy
 +#
 +files_search_etc(ctxusbd_t)
-+files_read_etc_files(ctxusbd_t)
++files_rw_etc_dirs(ctxusbd_t)
 +files_search_usr(ctxusbd_t)
 +libs_use_ld_so(ctxusbd_t)
 +dev_rw_usbfs(ctxusbd_t)


### PR DESCRIPTION
WARNING: this is stable-4, not master

Without this fix, the vusb daemon can't create and write to /config/etc/USB_always.conf, losing auto-assign settings on reboot.

This may not be the correct/best way to fix it, but that's my best shot and it seems to work.

Signed-off-by: Jed <lejosnej@ainfosec.com>