### PR TITLE
[vusb] URB_SHORT_NOT_OK should only be set on IN URBs

### DIFF
--- a/recipes-kernel/linux/linux-xenclient-3.18/usbback-base.patch
+++ b/recipes-kernel/linux/linux-xenclient-3.18/usbback-base.patch
@@ -38,8 +38,8 @@ PATCHES
 ################################################################################
 Index: linux-3.18.19/drivers/usb/Kconfig
 ===================================================================
---- linux-3.18.19.orig/drivers/usb/Kconfig	2015-08-11 18:24:54.983504912 +0200
-+++ linux-3.18.19/drivers/usb/Kconfig	2015-08-11 18:32:55.835056574 +0200
+--- linux-3.18.19.orig/drivers/usb/Kconfig	2015-07-20 21:13:10.000000000 -0400
++++ linux-3.18.19/drivers/usb/Kconfig	2015-10-15 11:56:43.573012578 -0400
 @@ -94,6 +94,17 @@
  
  source "drivers/usb/usbip/Kconfig"
@@ -60,8 +60,8 @@ Index: linux-3.18.19/drivers/usb/Kconfig
  source "drivers/usb/musb/Kconfig"
 Index: linux-3.18.19/drivers/usb/Makefile
 ===================================================================
---- linux-3.18.19.orig/drivers/usb/Makefile	2015-08-11 18:24:55.050170864 +0200
-+++ linux-3.18.19/drivers/usb/Makefile	2015-08-11 18:32:55.971721797 +0200
+--- linux-3.18.19.orig/drivers/usb/Makefile	2015-07-20 21:13:10.000000000 -0400
++++ linux-3.18.19/drivers/usb/Makefile	2015-10-15 11:56:43.573012578 -0400
 @@ -62,3 +62,5 @@
  obj-$(CONFIG_USB_COMMON)	+= common/
  
@@ -70,8 +70,8 @@ Index: linux-3.18.19/drivers/usb/Makefile
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) += xen-usbback/
 Index: linux-3.18.19/drivers/usb/core/Makefile
 ===================================================================
---- linux-3.18.19.orig/drivers/usb/core/Makefile	2015-08-11 18:24:55.016837889 +0200
-+++ linux-3.18.19/drivers/usb/core/Makefile	2015-08-11 18:32:56.055054250 +0200
+--- linux-3.18.19.orig/drivers/usb/core/Makefile	2015-07-20 21:13:10.000000000 -0400
++++ linux-3.18.19/drivers/usb/core/Makefile	2015-10-15 11:56:43.573012578 -0400
 @@ -6,6 +6,7 @@
  usbcore-y += config.o file.o buffer.o sysfs.o endpoint.o
  usbcore-y += devio.o notify.o generic.o quirks.o devices.o
@@ -83,7 +83,7 @@ Index: linux-3.18.19/drivers/usb/core/Makefile
 Index: linux-3.18.19/drivers/usb/core/dusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/core/dusb.c	2015-08-11 18:32:56.165053088 +0200
++++ linux-3.18.19/drivers/usb/core/dusb.c	2015-10-15 11:56:43.573012578 -0400
 @@ -0,0 +1,169 @@
 +/*****************************************************************************/
 +
@@ -256,8 +256,8 @@ Index: linux-3.18.19/drivers/usb/core/dusb.c
 +
 Index: linux-3.18.19/drivers/usb/core/hub.c
 ===================================================================
---- linux-3.18.19.orig/drivers/usb/core/hub.c	2015-08-11 18:31:51.105741715 +0200
-+++ linux-3.18.19/drivers/usb/core/hub.c	2015-08-11 18:32:56.235052348 +0200
+--- linux-3.18.19.orig/drivers/usb/core/hub.c	2015-10-15 11:56:42.309012513 -0400
++++ linux-3.18.19/drivers/usb/core/hub.c	2015-10-15 11:56:43.577014611 -0400
 @@ -1011,6 +1011,15 @@
  	return 0;
  }
@@ -300,7 +300,7 @@ Index: linux-3.18.19/drivers/usb/core/hub.c
 Index: linux-3.18.19/drivers/usb/xen-usbback/Makefile
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/Makefile	2015-08-11 18:32:56.321718099 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/Makefile	2015-10-15 11:56:43.577014611 -0400
 @@ -0,0 +1,3 @@
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) := usbbk.o
 +
@@ -308,7 +308,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/Makefile
 Index: linux-3.18.19/drivers/usb/xen-usbback/buffers.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/buffers.c	2015-08-11 18:32:56.408383850 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/buffers.c	2015-10-15 11:56:43.577014611 -0400
 @@ -0,0 +1,422 @@
 +/******************************************************************************
 + * usbback/buffers.c
@@ -735,7 +735,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/buffers.c
 Index: linux-3.18.19/drivers/usb/xen-usbback/common.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/common.h	2015-08-11 18:32:56.475049812 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/common.h	2015-10-15 11:56:43.577014611 -0400
 @@ -0,0 +1,361 @@
 +/*
 + * Copyright (c) Citrix Systems Inc.
@@ -1101,7 +1101,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/common.h
 Index: linux-3.18.19/drivers/usb/xen-usbback/interface.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/interface.c	2015-08-11 18:32:56.545049073 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/interface.c	2015-10-15 11:56:43.581027727 -0400
 @@ -0,0 +1,164 @@
 +/******************************************************************************
 + *
@@ -1270,7 +1270,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/interface.c
 Index: linux-3.18.19/drivers/usb/xen-usbback/usbback.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/usbback.c	2015-09-14 16:22:32.704286067 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/usbback.c	2015-10-15 11:56:43.581027727 -0400
 @@ -0,0 +1,1267 @@
 +/******************************************************************************
 + *
@@ -2542,7 +2542,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/usbback.c
 Index: linux-3.18.19/drivers/usb/xen-usbback/vusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/vusb.c	2015-08-11 18:32:56.678380997 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/vusb.c	2015-10-16 09:30:20.935698176 -0400
 @@ -0,0 +1,938 @@
 +/******************************************************************************
 + * usbback/vusb.c
@@ -3316,7 +3316,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/vusb.c
 +	}
 +
 +	urb->dev = usbdev;
-+	if (!usbif_request_shortok(req))
++	if (!usbif_request_shortok(req) && usbif_request_dir_in(req))
 +		urb->transfer_flags |= URB_SHORT_NOT_OK;
 +
 +	switch((ep->desc.bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)) {
@@ -3485,7 +3485,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/vusb.c
 Index: linux-3.18.19/drivers/usb/xen-usbback/xenbus.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/drivers/usb/xen-usbback/xenbus.c	2015-08-11 18:32:56.745046959 +0200
++++ linux-3.18.19/drivers/usb/xen-usbback/xenbus.c	2015-10-15 11:56:43.585014859 -0400
 @@ -0,0 +1,582 @@
 +/*  Xenbus code for usbif backend
 +    Copyright (C) 2005 Rusty Russell <rusty@rustcorp.com.au>
@@ -4072,7 +4072,7 @@ Index: linux-3.18.19/drivers/usb/xen-usbback/xenbus.c
 Index: linux-3.18.19/include/linux/dusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/include/linux/dusb.h	2015-08-11 18:32:56.811712922 +0200
++++ linux-3.18.19/include/linux/dusb.h	2015-10-15 11:56:43.585014859 -0400
 @@ -0,0 +1,44 @@
 +/*****************************************************************************/
 +
@@ -4121,7 +4121,7 @@ Index: linux-3.18.19/include/linux/dusb.h
 Index: linux-3.18.19/include/xen/interface/io/usbif.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/include/xen/interface/io/usbif.h	2015-08-11 18:32:56.915045163 +0200
++++ linux-3.18.19/include/xen/interface/io/usbif.h	2015-10-15 11:56:43.585014859 -0400
 @@ -0,0 +1,196 @@
 +/******************************************************************************
 + * usbif.h
@@ -4322,7 +4322,7 @@ Index: linux-3.18.19/include/xen/interface/io/usbif.h
 Index: linux-3.18.19/include/xen/vusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.19/include/xen/vusb.h	2015-08-11 18:32:57.031710597 +0200
++++ linux-3.18.19/include/xen/vusb.h	2015-10-15 11:56:43.585014859 -0400
 @@ -0,0 +1,56 @@
 +#ifndef __XEN_VUSB_H__
 +#define __XEN_VUSB_H__
@@ -4382,8 +4382,8 @@ Index: linux-3.18.19/include/xen/vusb.h
 +#endif /* __XEN_VUSB_H__ */
 Index: linux-3.18.19/drivers/scsi/sr.c
 ===================================================================
---- linux-3.18.19.orig/drivers/scsi/sr.c	2015-08-11 18:24:54.966838424 +0200
-+++ linux-3.18.19/drivers/scsi/sr.c	2015-08-11 18:32:57.091709963 +0200
+--- linux-3.18.19.orig/drivers/scsi/sr.c	2015-07-20 21:13:10.000000000 -0400
++++ linux-3.18.19/drivers/scsi/sr.c	2015-10-15 11:56:43.585014859 -0400
 @@ -264,6 +264,15 @@
  	if (!(clearing & DISK_EVENT_MEDIA_CHANGE))
  		return events;
@@ -4423,8 +4423,8 @@ Index: linux-3.18.19/drivers/scsi/sr.c
  		events |= DISK_EVENT_MEDIA_CHANGE;
 Index: linux-3.18.19/drivers/usb/host/xhci-pci.c
 ===================================================================
---- linux-3.18.19.orig/drivers/usb/host/xhci-pci.c	2015-08-11 18:24:55.000171400 +0200
-+++ linux-3.18.19/drivers/usb/host/xhci-pci.c	2015-08-11 18:32:57.191708907 +0200
+--- linux-3.18.19.orig/drivers/usb/host/xhci-pci.c	2015-07-20 21:13:10.000000000 -0400
++++ linux-3.18.19/drivers/usb/host/xhci-pci.c	2015-10-15 11:56:43.605014721 -0400
 @@ -142,6 +142,7 @@
  		 pdev->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI)) {
  		xhci->quirks |= XHCI_PME_STUCK_QUIRK;


### PR DESCRIPTION
OXT-394

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>