### PR TITLE
[selinux] Allow XCPMD to talk to DBD and xenmgr

### DIFF
--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_xenpmd.te.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_xenpmd.te.patch
@@ -1,6 +1,8 @@
---- /dev/null   1970-01-01 00:00:00.000000000 +0000
-+++ refpolicy/policy/modules/services/xenpmd.te 2015-08-19 16:50:31.000000000 -0400
-@@ -0,0 +1,74 @@
+Index: refpolicy/policy/modules/services/xenpmd.te
+===================================================================
+--- /dev/null
++++ refpolicy/policy/modules/services/xenpmd.te
+@@ -0,0 +1,78 @@
 +#############################################################################
 +#
 +# Copyright (C) 2014 Citrix Systems, Inc.
@@ -51,6 +53,7 @@
 +uid_dbus_chat(xenpmd_t)
 +surfman_dbus_chat(xenpmd_t)
 +dbusbouncer_dbus_chat(xenpmd_t)
++dbd_dbus_chat(xenpmd_t)
 +
 +apm_stream_connect(xenpmd_t)
 +dev_rw_sysfs(xenpmd_t)
@@ -75,3 +78,6 @@
 +allow xenpmd_t xenpmd_var_t:dir manage_dir_perms;
 +allow xenpmd_t xenpmd_var_t:file manage_file_perms;
 +allow xenpmd_t xenpmd_var_run_t:file manage_file_perms;
++
++# allow XCPMD to receive messages from xenmgr
++xenpmd_dbus_chat(xend_t)


### PR DESCRIPTION
Changes to SELinux policy required for [xctools PR15](https://github.com/OpenXT/xctools/pull/15).