### PR TITLE
Fix kernel OOPS when changing backend for XenBus device with no driver.

### DIFF
--- a/recipes-kernel/linux/linux-xenclient-3.18/xenbus-move-otherend-watches-on-relocate.patch
+++ b/recipes-kernel/linux/linux-xenclient-3.18/xenbus-move-otherend-watches-on-relocate.patch
@@ -39,7 +39,7 @@ Index: linux-3.18.16/drivers/xen/xenbus/xenbus_probe.c
 ===================================================================
 --- linux-3.18.16.orig/drivers/xen/xenbus/xenbus_probe.c	2015-06-14 18:19:31.000000000 +0200
 +++ linux-3.18.16/drivers/xen/xenbus/xenbus_probe.c	2015-06-19 15:19:06.509597181 +0200
-@@ -545,12 +545,34 @@
+@@ -545,12 +545,36 @@
  	return (len == 0) ? i : -ERANGE;
  }
  
@@ -48,6 +48,8 @@ Index: linux-3.18.16/drivers/xen/xenbus/xenbus_probe.c
 +	int err;
 +
 +	/* Only move netdevs. */
++	if (!dev || !dev->dev.driver)
++		return 0;
 +	if (!xenbus_dev_is_vif(dev))
 +		return 0;
 +
@@ -75,7 +77,7 @@ Index: linux-3.18.16/drivers/xen/xenbus/xenbus_probe.c
  
  	if (char_count(node, '/') < 2)
  		return;
-@@ -573,12 +595,20 @@
+@@ -573,12 +597,20 @@
  	if (!root)
  		return;
  

--- a/recipes-kernel/linux/linux-xenclient-dom0_3.18.19.bb
+++ b/recipes-kernel/linux/linux-xenclient-dom0_3.18.19.bb
@@ -15,5 +15,5 @@ SRC_URI += " \
             file://0002-Add-thorough-reset-interface-to-pciback-s-sysfs.patch;patch=1 \
             "
 
-PR = "r1"
+PR = "r2"
 

--- a/recipes-kernel/linux/linux-xenclient-ndvm_3.18.19.bb
+++ b/recipes-kernel/linux/linux-xenclient-ndvm_3.18.19.bb
@@ -10,5 +10,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV_MAJOR}.${PV_MINOR}:"
 
 require linux-xenclient-${PV_MAJOR}.${PV_MINOR}.inc
 
-PR = "r1"
+PR = "r2"
 

--- a/recipes-kernel/linux/linux-xenclient-stubdomain_3.18.19.bb
+++ b/recipes-kernel/linux/linux-xenclient-stubdomain_3.18.19.bb
@@ -10,5 +10,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV_MAJOR}.${PV_MINOR}:"
 
 require linux-xenclient-${PV_MAJOR}.${PV_MINOR}.inc
 
-PR = "r1"
+PR = "r2"
 

--- a/recipes-kernel/linux/linux-xenclient-uivm_3.18.19.bb
+++ b/recipes-kernel/linux/linux-xenclient-uivm_3.18.19.bb
@@ -10,4 +10,4 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV_MAJOR}.${PV_MINOR}:"
 
 require linux-xenclient-${PV_MAJOR}.${PV_MINOR}.inc
 
-PR = "r1"
+PR = "r2"


### PR DESCRIPTION
Fixes a kernel OOPS that disrupts a VM's kernel if it winds up with XenBus device (backend or frontend) that it can't provide a driver for.

See https://openxt.atlassian.net/browse/OXT-420.

OXT-420