### PR TITLE
Define recipes versions in distro.

### DIFF
--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -1,0 +1,34 @@
+#
+# This is how bitbake will establish its configuration:
+#
+# require conf/abi_version.conf
+# include conf/site.conf
+# include conf/auto.conf
+# include conf/local.conf
+# include conf/build/${BUILD_SYS}.conf
+# include conf/target/${TARGET_SYS}.conf
+# include conf/machine/${MACHINE}.conf
+# include conf/machine-sdk/${SDKMACHINE}.conf
+# include conf/distro/${DISTRO}.conf
+# include conf/distro/defaultsetup.conf
+# include conf/documentation.conf
+# include conf/licenses.conf
+# require conf/sanity.conf
+#
+
+PREFERRED_VERSION_linux-xenclient-dom0 = "3.18%"
+PREFERRED_VERSION_linux-xenclient-ndvm = "3.18%"
+PREFERRED_VERSION_linux-xenclient-nilfvm = "3.18%"
+PREFERRED_VERSION_linux-xenclient-stubdomain = "3.18%"
+PREFERRED_VERSION_linux-xenclient-syncvm = "3.18%"
+PREFERRED_VERSION_linux-xenclient-uivm = "3.18%"
+
+PREFERRED_VERSION_linux-libc-headers = "3.18%"
+PREFERRED_VERSION_linux-libc-headers-nativesdk = "${PREFERRED_VERSION_linux-libc-headers}"
+
+PREFERRED_VERSION_dojosdk-native = "1.7.2"
+# ${MACHINE}.conf is overriden by ${DISTRO}.conf
+# xenmgr_data and sync-wui (uivm and syncui machines) apparently depends on
+# different versions, so preserve that.
+PREFERRED_VERSION_dojosdk-native_xenclient-syncui = "1.8.1"
+

--- a/conf/machine/xenclient-dom0.conf
+++ b/conf/machine/xenclient-dom0.conf
@@ -13,8 +13,6 @@ require xenclient-common.conf
 VIRTUAL-RUNTIME_initscripts = ""
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xenclient-dom0"
-PREFERRED_VERSION_linux-xenclient-dom0 = "3.18%"
-PREFERRED_VERSION_udev = "182"
 PREFERRED_PROVIDER_libgl1 = "nvidia-lib"
 
 MACHINE_FEATURES = "kernel26 screen keyboard ethernet pci usbhost acpi ext2 x86"

--- a/conf/machine/xenclient-ndvm.conf
+++ b/conf/machine/xenclient-ndvm.conf
@@ -7,7 +7,5 @@
 require xenclient-common.conf
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xenclient-ndvm"
-PREFERRED_VERSION_linux-xenclient-ndvm = "3.18%"
-PREFERRED_VERSION_udev = "182"
 
 MACHINE_FEATURES = "kernel26 ethernet pci ext2 x86"

--- a/conf/machine/xenclient-nilfvm.conf
+++ b/conf/machine/xenclient-nilfvm.conf
@@ -10,8 +10,6 @@ require xenclient-common.conf
 PACKAGE_EXTRA_ARCHS_tune-core2 += " xenclient-nvdm "
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xenclient-nilfvm"
-PREFERRED_VERSION_linux-xenclient-nilfvm = "3.18%"
-PREFERRED_VERSION_linux-libc-headers = "3.11%"
 
 MACHINE_FEATURES = "kernel26 ethernet pci ext2 x86"
 

--- a/conf/machine/xenclient-sbuild.conf
+++ b/conf/machine/xenclient-sbuild.conf
@@ -7,7 +7,6 @@
 require xenclient-common.conf
 
 PREFERRED_PROVIDER_virtual/kernel = "sbuild-linux"
-PREFERRED_VERSION_linux-xenclient-nilfvm = "2.6.32"
 
 MACHINE_FEATURES = "kernel26 ethernet pci ext2 x86"
 

--- a/conf/machine/xenclient-stubdomain.conf
+++ b/conf/machine/xenclient-stubdomain.conf
@@ -7,6 +7,5 @@
 require xenclient-common.conf
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xenclient-stubdomain"
-PREFERRED_VERSION_linux-xenclient-stubdomain = "3.18%"
 
 MACHINE_FEATURES = "kernel26 screen keyboard ethernet pci acpi ext2 x86"

--- a/conf/machine/xenclient-syncui.conf
+++ b/conf/machine/xenclient-syncui.conf
@@ -1,5 +1,3 @@
 require xenclient-common.conf
 
-PREFERRED_VERSION_dojosdk-native = "1.8.1"
-
 MACHINE_FEATURES = ""

--- a/conf/machine/xenclient-syncvm.conf
+++ b/conf/machine/xenclient-syncvm.conf
@@ -1,7 +1,5 @@
 require xenclient-common.conf
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xenclient-syncvm"
-PREFERRED_VERSION_linux-xenclient-syncvm = "3.18%"
-PREFERRED_VERSION_udev = "182"
 
 MACHINE_FEATURES = "kernel26 pci acpi ext2 x86"

--- a/conf/machine/xenclient-uivm.conf
+++ b/conf/machine/xenclient-uivm.conf
@@ -9,8 +9,6 @@ require xenclient-common.conf
 VIRTUAL-RUNTIME_initscripts = "xenclient-uivm-initscripts"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xenclient-uivm"
-PREFERRED_VERSION_linux-xenclient-uivm = "3.18%"
-PREFERRED_VERSION_udev = "182"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = "xserver-xorg \


### PR DESCRIPTION
PREFERRED_VERSION variables are split between the general local.conf
file (in openxt.git) and machine specific configurations.
Regroup everything under a distro configuration (openxt-main in this
case), leaving machine specific configuration with PREFERRED_PROVIDER.

This is only a small attempt at making recipe selection a little bit easier than it is using the DISTRO configuration of Bitbake. I might have missed the canonical way of doing so.

See related commit in https://github.com/OpenXT/openxt.