### PR TITLE
Set XenVESA IO ports for xenvesa driver.

### DIFF
--- a/recipes-openxt/vgabios/vgabios-0.7a/vbe-xenvesa.patch
+++ b/recipes-openxt/vgabios/vgabios-0.7a/vbe-xenvesa.patch
@@ -1,0 +1,116 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Use the "shadow-bda" IO ports region (0x383A-0x383D) to pass a table to the
+XenVESA device driver, containing EDID and mode information.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Take advantage of the unused IO ports of the "shadow BDA" region to pass the
+EDID table and mode info list to a guest driver.
+This is done by "adding" (using actually) two IO ports:
+- 0x383A VGA_PORT_VBE_XVTSEG
+- 0x383C VGA_PORT_VBE_XVTADDR
+
+################################################################################
+CHANGELOG 
+################################################################################
+Original Author: Ross Philipson, ross.philipson@citrix.com
+Ported to VGABIOS: Eric Chanudet, chanudete@ainfosec.com, 18/11/2015
+
+################################################################################
+REMOVAL 
+################################################################################
+This patch is required for the XenVESA driver in windows guests.
+
+################################################################################
+UPSTREAM PLAN 
+################################################################################
+This is OpenXT specific. There is no plan to upstream this patch.
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+Use QEMU: vga-shadow-bda.patch
+
+################################################################################
+PATCHES
+################################################################################
+Index: vgabios-0.7a/vbe.c
+===================================================================
+--- vgabios-0.7a.orig/vbe.c	2015-11-05 16:27:13.250611770 +0100
++++ vgabios-0.7a/vbe.c	2015-11-18 17:40:30.047552069 +0100
+@@ -1729,6 +1729,43 @@
+ 
+ ASM_START
+ 
++vbe_xenvesa_table:
++  .word vesa_EDID        /* VESA EDID addr */
++  .word 0xc000           /* VESA EDID seg */
++
++  .word _mode_info_list  /* VESA mode list addr */
++  .word 0xc000           /* VESA mode list seg */
++
++  .ascii "XENVTBL"
++  .byte  0x00
++
++/** Function to initialize shadow port values for EDID
++ *   and module list for XenVesa.
++ */
++vbe_xenvesa_init:
++  push ds
++  push ax
++  push dx
++
++  mov ax, #0xc000
++  mov ds, ax
++
++  mov dx, # VGA_PORT_VBE_XVTSEG
++  out dx, ax
++
++  mov ax, #vbe_xenvesa_table
++  mov dx, # VGA_PORT_VBE_XVTADDR
++  out dx, ax
++
++  pop dx
++  pop ax
++  pop ds
++  ret
++
++ASM_END
++
++ASM_START
++
+ /** Function 15h - Display Identification Extensions
+  * Input:    AX    = 4F15h   VBE 2.0 Protected Mode Interface
+  *           BL    = 00h     Get capabilities
+Index: vgabios-0.7a/vgabios.c
+===================================================================
+--- vgabios-0.7a.orig/vgabios.c	2015-11-05 16:27:13.300611209 +0100
++++ vgabios-0.7a/vgabios.c	2015-11-18 17:18:04.743083006 +0100
+@@ -281,6 +281,8 @@
+ #ifdef VBE  
+ ;; init vbe functions
+   call vbe_init  
++;; init xenvesa vbe support
++  call vbe_xenvesa_init
+ #endif
+ 
+ ;; set int10 vect
+Index: vgabios-0.7a/vgatables.h
+===================================================================
+--- vgabios-0.7a.orig/vgatables.h	2015-11-05 16:27:13.250611770 +0100
++++ vgabios-0.7a/vgatables.h	2015-11-18 17:21:05.360994160 +0100
+@@ -61,7 +61,10 @@
+ #define VGA_PORT_VBE_FLAG      0x3830 /* word */
+ #define VGA_PORT_VBE_MODE      0x3832 /* word */
+ #define VGA_PORT_VBE_POWER     0x3834 /* byte */
+-                                      /* 0x3035 - 0x303F unused */
++                                      /* 0x3035 - 0x3039 unused */
++#define VGA_PORT_VBE_XVTADDR   0x383A /* word */
++#define VGA_PORT_VBE_XVTSEG    0x383C /* word */
++                                      /* 0x303E - 0x303F unused */
+ 
+ #define VGA_SHADOW_NONE        0x0000
+ #define VGA_SHADOW_ONLY        0x0001

--- a/recipes-openxt/vgabios/vgabios_0.7a.bb
+++ b/recipes-openxt/vgabios/vgabios_0.7a.bb
@@ -16,6 +16,7 @@ SRC_URI += "file://xen-fix-vbe-size-computation-overflow.patch;patch=1  \
             file://vga-shadow-bda.patch;patch=1                         \
             file://xen-log-to-ioport-0xe9.patch;patch=1                 \
             file://vbe-extended-edid-modes.patch                        \
+            file://vbe-xenvesa.patch                                    \
             "
 SRC_URI[tarball.md5sum] = "2c0fe5c0ca08082a9293e3a7b23dc900"
 SRC_URI[tarball.sha256sum] = "9d24c33d4bfb7831e2069cf3644936a53ef3de21d467872b54ce2ea30881b865"


### PR DESCRIPTION
Use IO ports 0x383A-0x383D from the shadow bda region defined in QEMU to
pass graphic information to windows guest driver.

This patch was left out during the QEMU 1.4 upgrade.