### PR TITLE
[xenvesa] Improve comments and fix incorrect length of register block.

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/0018-vga-shadow-bda.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/0018-vga-shadow-bda.patch
@@ -10,7 +10,9 @@ LONG DESCRIPTION:
 Add an IO range 0x3802-0x383F to cache VGABIOS data in QEMU memory. Using IO
 ports directly makes it easier to implement in VGABIOS.
 
+The following registers work in conjunction with the vga-shadow-bda.patch.
 VGABIOS will assume to access the following values at their given offsets:
+
 CONTROL_FLAGS 0x3802 /* word */
 RESERVED      0x3804 /* word */
 ALIGN         0x3806 /* byte */
@@ -35,11 +37,18 @@ VBE_FLAG      0x3830 /* word */
 VBE_MODE      0x3832 /* word */
 VBE_POWER     0x3834 /* byte */
 
+The following 2 registers work in conjunction with the vbe-xenvesa.patch and
+are used to hold pointers to the VBE support structure for xenvesa:
+
+VBE_XVTADDR   0x383A /* word */
+VBE_XVTSEG    0x383C /* word */
+
 ################################################################################
 CHANGELOG 
 ################################################################################
 Documented: Eric Chanudet, chanudete@ainfosec.com, 18/03/2015
 Port to qemu 1.4.0: Eric Chanudet, chanudete@ainfosec.com, 01/03/2015
+Original Author: Ross Philipson, ross.philipson@citrix.com
 
 ################################################################################
 REMOVAL 
@@ -96,7 +105,7 @@ Index: qemu-1.4.0/hw/vga_int.h
  #define VGA_OXT_BASE			0x3800
  #define VGA_OXT_SPINLOCK		VGA_OXT_BASE
 +#define VGA_OXT_SHADOW_BDA_BASE		(VGA_OXT_BASE + 0x2)
-+#define VGA_OXT_SHADOW_BDA_SIZE		0x38
++#define VGA_OXT_SHADOW_BDA_SIZE		0x3E
  
  struct vga_precise_retrace {
      int64_t ticks_per_char;


### PR DESCRIPTION
The comments need to include a reference to the registers used to store
the xenvesa support structure too.

OXT-430

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>