### PR TITLE
Allow QEMU to be notified when guests wake from S3.

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/0035-add-acpi-wakeup.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/0035-add-acpi-wakeup.patch
@@ -1,0 +1,153 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+
+Allow QEMU to be notified when guests awake from S3.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+
+Prior to this patch, QEMU requires a wake signal to be communicated
+from the input server via the DMbus, but:
+  - This is nonideal, as it requires the input server to be running, and
+    requires the input server to circumvent the toolstack for waking guests.
+  - This means that guests are not woken properly when using toolstack calls,
+    such as "xec-vm -n <domain-name> resume".
+
+This commit modifies QEMU to also respond to wake requests via a XenStore node.
+Ideally, this information would be communicated via a protocol like QMP; this is
+to be considered a stand-in until QMP support is integrated.
+
+################################################################################
+REMOVAL 
+################################################################################
+
+Ideally, when QMP (or a similar solution) is implemented, this patch
+will be removed wholesale, as it superseeded by QMP wakeup requests.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+
+None
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+
+Applied before this patch:
+- 0009-acpi.patch, which provides the OpenXT ACPI extensions
+
+Applied in any order:
+- 0001-generic-xenstore-extensions.patch, which provides XenStore
+  functionality
+
+
+---
+ hw/acpi.c |   76 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 files changed, 76 insertions(+), 0 deletions(-)
+
+diff --git a/hw/acpi.c b/hw/acpi.c
+index 6a2b8cd..0859f2f 100644
+--- a/hw/acpi.c
++++ b/hw/acpi.c
+@@ -32,6 +32,19 @@
+ #include "acpi.h"
+ #include "monitor/monitor.h"
+ 
++#include <hw/xen_backend.h>
++
++/**
++ * ACPI_LOG: information to always log (errors & important low-volume events)
++ * @param fmt,... printf style arguments
++ */
++#define ACPI_LOG(fmt, ...)                                                   \
++    do {                                                                   \
++            fprintf(stdout, "[%s:%s:%d] " fmt,                             \
++                    __FILE__, __FUNCTION__, __LINE__, ##__VA_ARGS__);      \
++    } while (0)
++
++
+ 
+ /* XenClient:
+  * needed for 'xenstore_update_power' */
+@@ -477,12 +490,75 @@ static void acpi_pm1_cnt_write(ACPIREGS *ar, uint16_t val)
+     }
+ }
+ 
++/**
++ * Event handler for OpenXT wakeup requests.
++ */
++static void openxt_wakeup_requested(void * unused)
++{
++    char domain_path[256];
++    int requested;
++
++    (void)unused;
++
++    // Determine the path that we'll be listening for wakeup events on.
++    snprintf(domain_path, sizeof(domain_path),
++             "/local/domain/%d", xen_domid);
++
++    // Check to see if a wakeup has been r
++    if(xenstore_read_int(domain_path, "wakeup-req", &requested) != 0)
++    {
++        ACPI_LOG("error: could not read the wakeup request node");
++        return;
++    }
++
++    //... if it has, wake up the guest.
++    if(requested)
++    {
++
++        // Clear the pending request...
++        xenstore_write_int(domain_path, "wakeup-req", 0);
++
++        // ... and issue our wakeup request!
++        if(runstate_check(RUN_STATE_SUSPENDED)) {
++            ACPI_LOG("QEMU: Waking device models from emulated S3.\n");
++            qemu_system_wakeup_request(QEMU_WAKEUP_REASON_OTHER);
++        }
++    }
++}
++
++/**
++ * Register a watcher to handle OpenXT wakeup requests.
++ */
++static void openxt_register_wakeup_listener(void)
++{
++    char domain_path[256];
++
++    // Ensure that our connection to the XenStore has been set up.
++    xenstore_generic_init();
++
++    // Determine the path that we'll be listening for wakeup events on.
++    snprintf(domain_path, sizeof(domain_path),
++             "/local/domain/%d", xen_domid);
++
++    // Create an emtpy wakeup-request node, as a hint that we're listening
++    // for wakeup requests.
++    xenstore_write_int(domain_path, "wakeup-req", 0);
++
++    //... and register an watch for the given node.
++    if (xenstore_add_watch(domain_path, "wakeup-req",
++          openxt_wakeup_requested, (void *) -1 )) {
++        ACPI_LOG("error: failed to register watch for domain wakeup\n");
++    }
++}
++
++
+ void acpi_pm1_cnt_update(ACPIREGS *ar,
+                          bool sci_enable, bool sci_disable)
+ {
+     /* ACPI specs 3.0, 4.7.2.5 */
+     if (sci_enable) {
+         ar->pm1.cnt.cnt |= ACPI_BITMASK_SCI_ENABLE;
++        openxt_register_wakeup_listener();
+     } else if (sci_disable) {
+         ar->pm1.cnt.cnt &= ~ACPI_BITMASK_SCI_ENABLE;
+     }
+-- 
+1.7.2.5
+

--- a/recipes-openxt/qemu-dm/qemu-dm-stubdom_1.4.0.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm-stubdom_1.4.0.bb
@@ -20,4 +20,4 @@ do_install_append(){
     install -m 0755 ${WORKDIR}/qemu-ifup-stubdom ${D}${sysconfdir}/qemu/qemu-ifup
 }
 
-PR = "${INC_PR}.8"
+PR = "${INC_PR}.9"

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -46,6 +46,7 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://0032-bp-hub-net-queue-flush-fix-199ee608f0d08510b5c6c37f31a7fbff211d63c4.patch;striplevel=1 \
             file://0033-acpi-pm-feature.patch;striplevel=1 \
             file://0034-maintain-time-offset.patch;striplevel=1 \
+            file://0035-add-acpi-wakeup.patch;striplevel=1 \
             file://xsa-126-unmediated-pci-command-register-access-in-qemu.patch;patch=1 \
             file://xsa-128-potential-unintended-writes-to-host-msi-message-data-field-via-qemu.patch;patch=1 \
             file://xsa-129-pci-msi-mask-bits-inadvertently-exposed-to-guests.patch;patch=1 \

--- a/recipes-openxt/qemu-dm/qemu-dm_1.4.0.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm_1.4.0.bb
@@ -10,4 +10,4 @@ require qemu-dm.inc
 
 EXTRA_OECONF += " --audio-drv-list=alsa --enable-openxt-iso "
 
-PR = "${INC_PR}.5"
+PR = "${INC_PR}.6"


### PR DESCRIPTION
**Test note:** Can be merged in any order, but should be tested with: https://github.com/OpenXT/toolstack/pull/11

Prior to this patch, QEMU requires a wake signal to be communicated
from the input server via the DMbus, but:
  - This is nonideal, as it requires the input server to be running, and
    requires the input server to circumvent the toolstack for waking guests.
  - This means that guests are not woken properly when using toolstack calls,
    such as "xec-vm -n <domain-name> resume".

This commit modifies QEMU to also respond to wake requests via a XenStore node.
Ideally, this information would be communicated via a protocol like QMP; this is
to be considered a stand-in until QMP support is integrated.

NOTE:
While the added patch could be merged into acpi.patch, in this case it seems to
make more sense to leave it separate. Ideally, this patch will eventually be
succeeded by a QMP-based solution, and this patch can just be removed without
having to extract anything from acpi.path.