### PR TITLE
Make 4f15 01 returns a valid EDID.

### DIFF
--- a/recipes-openxt/vgabios/vgabios-0.7a/vbe-edid-interface.patch
+++ b/recipes-openxt/vgabios/vgabios-0.7a/vbe-edid-interface.patch
@@ -46,9 +46,11 @@ Depended on by VGABIOS: vbe-extensions.patch
 ################################################################################
 PATCHES
 ################################################################################
---- a/vbe.c
-+++ b/vbe.c
-@@ -241,6 +241,18 @@ dispi_set_id:
+Index: vgabios-0.7a/vbe.c
+===================================================================
+--- vgabios-0.7a.orig/vbe.c	2015-11-18 17:50:03.400927090 +0100
++++ vgabios-0.7a/vbe.c	2015-11-27 15:23:51.764553004 +0100
+@@ -241,6 +241,18 @@
    ret
  ASM_END
  
@@ -67,7 +69,7 @@ PATCHES
  static void dispi_set_xres(xres)
    Bit16u xres;
  {
-@@ -776,6 +788,30 @@ _size64:
+@@ -776,6 +788,30 @@
    ret
  ASM_END
  
@@ -98,7 +100,7 @@ PATCHES
  
  /** Function 00h - Return VBE Controller Information
   * 
-@@ -800,9 +836,13 @@ Bit16u *AX;Bit16u ES;Bit16u DI;
+@@ -800,9 +836,13 @@
          Bit16u            cur_ptr=34;
          Bit16u            size_64k;
          ModeInfoListItem  *cur_info=&mode_info_list;
@@ -112,7 +114,7 @@ PATCHES
  #ifdef DEBUG
          printf("VBE vbe_biosfn_return_vbe_info ES%x DI%x AX%x\n",ES,DI,status);
  #endif
-@@ -882,7 +922,8 @@ Bit16u *AX;Bit16u ES;Bit16u DI;
+@@ -882,7 +922,8 @@
          {
                  size_64k = size64(cur_info->info.XResolution, cur_info->info.YResolution, cur_info->info.BitsPerPixel);
  
@@ -122,7 +124,7 @@ PATCHES
                      (cur_info->info.BitsPerPixel <= dispi_get_max_bpp()) &&
                      (size_64k <= vbe_info_block.TotalMemory)) {
  #ifdef DEBUG
-@@ -928,6 +969,7 @@ Bit16u *AX;Bit16u CX; Bit16u ES;Bit16u D
+@@ -928,6 +969,7 @@
          Boolean           using_lfb;
          Bit16u            lfb_addr;
          ModeInfoBlockCompact   info;
@@ -130,7 +132,7 @@ PATCHES
  
  #ifdef DEBUG
          printf("VBE vbe_biosfn_return_mode_information ES%x DI%x CX%x\n",ES,DI,CX);
-@@ -952,7 +994,7 @@ Bit16u *AX;Bit16u CX; Bit16u ES;Bit16u D
+@@ -952,7 +994,7 @@
  #endif
                  memcpyb(ss, &info, 0xc000, &(cur_info->info), sizeof(ModeInfoBlockCompact));
                  size_64k = size64(info.XResolution, info.YResolution, info.BitsPerPixel);
@@ -139,7 +141,7 @@ PATCHES
                      (info.BitsPerPixel > max_bpp) ||
                      (size_64k > totalMemory))
                    info.ModeAttributes &= ~VBE_MODE_ATTRIBUTE_SUPPORTED;
-@@ -1490,4 +1532,205 @@ vbe_biosfn_return_protected_mode_interfa
+@@ -1490,4 +1532,202 @@
  _fail:
    mov ax, #0x014f
    ret
@@ -245,11 +247,10 @@ PATCHES
 +static void vbe_edid(edid, es, di, ds)
 +    Bit16u ds,es,di; Bit8u *edid;
 +{
-+    Bit8u       e[128];
-+    Bit8u       t;
++    Bit16u      ss = get_SS();
++    Bit8u       i;
 +    Bit8u       sum;
-+    Bit8u       i = 0;
-+    Bit16u      ss=get_SS();
++    Bit8u       t;
 +    Bit16u      hres;
 +    Bit16u      vres;
 +    Bit32u      pixclock;
@@ -257,37 +258,35 @@ PATCHES
 +    hres = dispi_edid_get_xres();
 +    vres = dispi_edid_get_yres();
 +
++    // Process pixclock from geometry.
 +    pixclock = hres + 24;
 +    pixclock *= vres + 3;
 +    pixclock *= 75;
 +    pixclock /= 10000;
 +
-+    for (i = 0; i < 128; i++)
-+        memcpyb(ss, e + i, ds, edid + i, 1);
++    // Copy ref EDID
++    memcpyb(es, di, ds, edid, 0x80);
 +
-+    t = pixclock & 0xff;
-+    memcpyb(ss, e + 0x36, ss, &t, 1);
-+    t = (pixclock >> 8) & 0xff;
-+    memcpyb(ss, e + 0x37, ss, &t, 1);
-+
++    // Change mode info with our hres/vres compatible definition.
++    memcpyb(es, di + 0x36, ss, &pixclock, 2);
 +    t = hres & 0xFF;
-+    memcpyb(ss, e + 0x38, ss, &t, 1);
++    memcpyb(es, di + 0x38, ss, &t, 1);
 +    t = ((hres >> 8) & 0xF) << 4;
-+    memcpyb(ss, e + 0x3A, ss, &t, 1);
++    memcpyb(es, di + 0x3A, ss, &t, 1);
 +    t = vres & 0xFF;
-+    memcpyb(ss, e + 0x3B, ss, &t, 1);
++    memcpyb(es, di + 0x3B, ss, &t, 1);
 +    t = ((vres >> 8) & 0xF) << 4;
-+    memcpyb(ss, e + 0x3D, ss, &t, 1);
++    memcpyb(es, di + 0x3D, ss, &t, 1);
 +
++    // Process EDID csum
 +    sum = 0;
-+    for (i = 0; i < 127; i++) {
-+        memcpyb(ss, &t, ss, e + i, 1);
++    for (i = 0; i < 0x80; i++) {
++        memcpyb(ss, &t, es, di + i, 1);
 +        sum += t;
 +    }
-+    sum = -sum;
-+    memcpyb(ss, e + 127, ss, &sum, 1);
-+
-+    memcpyb(es, di, ss, e, 128);
++    // Write EDID csum.
++    t = -sum;
++    memcpyb(es, di + 0x7F, ss, &t, 1);
 +}
 +
 +ASM_START
@@ -345,9 +344,11 @@ PATCHES
 +  ret
 +
  ASM_END
---- a/vbe.h
-+++ b/vbe.h
-@@ -310,6 +310,9 @@ typedef struct ModeInfoListItem
+Index: vgabios-0.7a/vbe.h
+===================================================================
+--- vgabios-0.7a.orig/vbe.h	2009-01-25 16:46:08.000000000 +0100
++++ vgabios-0.7a/vbe.h	2015-11-27 15:23:33.374765089 +0100
+@@ -310,6 +310,9 @@
    #define VBE_DISPI_LFB_ENABLED            0x40
    #define VBE_DISPI_NOCLEARMEM             0x80
  
@@ -357,9 +358,11 @@ PATCHES
    #define VBE_DISPI_LFB_PHYSICAL_ADDRESS   0xE0000000
  
  #endif
---- a/vgabios.c
-+++ b/vgabios.c
-@@ -389,9 +389,14 @@ int10_test_vbe_08:
+Index: vgabios-0.7a/vgabios.c
+===================================================================
+--- vgabios-0.7a.orig/vgabios.c	2011-10-15 16:07:21.000000000 +0200
++++ vgabios-0.7a/vgabios.c	2015-11-27 15:23:32.801438367 +0100
+@@ -389,9 +389,14 @@
    jmp   int10_end
  int10_test_vbe_0A:
    cmp   al, #0x0A

--- a/recipes-openxt/vgabios/vgabios-0.7a/vbe-extensions.patch
+++ b/recipes-openxt/vgabios/vgabios-0.7a/vbe-extensions.patch
@@ -46,9 +46,11 @@ Depends on VGABIOS: vbe-edid-interface.patch
 ################################################################################
 PATCHES
 ################################################################################
---- a/vbe.c
-+++ b/vbe.c
-@@ -289,6 +289,25 @@ static void dispi_set_bpp(bpp)
+Index: vgabios-0.7a/vbe.c
+===================================================================
+--- vgabios-0.7a.orig/vbe.c	2015-11-27 15:25:13.243613259 +0100
++++ vgabios-0.7a/vbe.c	2015-11-27 15:25:15.146924639 +0100
+@@ -289,6 +289,25 @@
    outw(VBE_DISPI_IOPORT_DATA,bpp);
  }
  
@@ -74,7 +76,7 @@ PATCHES
  ASM_START
  ; AL = bits per pixel / AH = bytes per pixel
  dispi_get_bpp:
-@@ -838,12 +857,17 @@ Bit16u *AX;Bit16u ES;Bit16u DI;
+@@ -838,12 +857,17 @@
          ModeInfoListItem  *cur_info=&mode_info_list;
          Bit16u            xres;
          Bit16u            yres;
@@ -92,7 +94,7 @@ PATCHES
          printf("VBE vbe_biosfn_return_vbe_info ES%x DI%x AX%x\n",ES,DI,status);
  #endif
  
-@@ -924,7 +948,8 @@ Bit16u *AX;Bit16u ES;Bit16u DI;
+@@ -924,7 +948,8 @@
  
                  if ((cur_info->info.XResolution <= xres) &&
                      (cur_info->info.YResolution <= yres) &&
@@ -102,7 +104,7 @@ PATCHES
                      (size_64k <= vbe_info_block.TotalMemory)) {
  #ifdef DEBUG
                    printf("VBE found mode %x => %x\n", cur_info->mode,cur_mode);
-@@ -970,10 +995,13 @@ Bit16u *AX;Bit16u CX; Bit16u ES;Bit16u D
+@@ -970,10 +995,13 @@
          Bit16u            lfb_addr;
          ModeInfoBlockCompact   info;
          Bit16u            xres = dispi_edid_get_xres();
@@ -116,7 +118,7 @@ PATCHES
  
          using_lfb=((CX & VBE_MODE_LINEAR_FRAME_BUFFER) == VBE_MODE_LINEAR_FRAME_BUFFER);
  
-@@ -993,9 +1021,15 @@ Bit16u *AX;Bit16u CX; Bit16u ES;Bit16u D
+@@ -993,9 +1021,15 @@
                  printf("VBE found mode %x\n",CX);
  #endif
                  memcpyb(ss, &info, 0xc000, &(cur_info->info), sizeof(ModeInfoBlockCompact));
@@ -133,7 +135,7 @@ PATCHES
                      (size_64k > totalMemory))
                    info.ModeAttributes &= ~VBE_MODE_ATTRIBUTE_SUPPORTED;
  
-@@ -1050,6 +1084,9 @@ Bit16u *AX;Bit16u BX; Bit16u ES;Bit16u D
+@@ -1050,6 +1084,9 @@
          Boolean           using_lfb;
          Bit8u             no_clear;
          Bit8u             lfb_flag;
@@ -143,7 +145,7 @@ PATCHES
  
          using_lfb=((BX & VBE_MODE_LINEAR_FRAME_BUFFER) == VBE_MODE_LINEAR_FRAME_BUFFER);
          lfb_flag=using_lfb?VBE_DISPI_LFB_ENABLED:0;
-@@ -1101,6 +1138,10 @@ Bit16u *AX;Bit16u BX; Bit16u ES;Bit16u D
+@@ -1101,6 +1138,10 @@
                  dispi_set_bpp(cur_info->info.BitsPerPixel);
                  dispi_set_xres(cur_info->info.XResolution);
                  dispi_set_yres(cur_info->info.YResolution);
@@ -154,9 +156,11 @@ PATCHES
                  dispi_set_bank(0);
                  dispi_set_enable(VBE_DISPI_ENABLED | no_clear | lfb_flag);
                  vga_compat_setup();
---- a/vbe.h
-+++ b/vbe.h
-@@ -310,8 +310,11 @@ typedef struct ModeInfoListItem
+Index: vgabios-0.7a/vbe.h
+===================================================================
+--- vgabios-0.7a.orig/vbe.h	2015-11-27 15:25:13.210280310 +0100
++++ vgabios-0.7a/vbe.h	2015-11-27 15:25:15.246923485 +0100
+@@ -310,8 +310,11 @@
    #define VBE_DISPI_LFB_ENABLED            0x40
    #define VBE_DISPI_NOCLEARMEM             0x80
  
@@ -166,11 +170,13 @@ PATCHES
 +  #define VBE_DISPI_EXT_INDEX_STRIDE_ALIGN 0x10
 +  #define VBE_DISPI_EXT_INDEX_32BPP_ONLY   0X11
  
-   #define VBE_DISPI_LFB_PHYSICAL_ADDRESS   0xF0000000
+   #define VBE_DISPI_LFB_PHYSICAL_ADDRESS   0xE0000000
  
---- a/vbetables-gen.c
-+++ b/vbetables-gen.c
-@@ -101,6 +101,8 @@ int main(int argc, char **argv)
+Index: vgabios-0.7a/vbetables-gen.c
+===================================================================
+--- vgabios-0.7a.orig/vbetables-gen.c	2015-11-27 15:25:13.226946785 +0100
++++ vgabios-0.7a/vbetables-gen.c	2015-11-27 15:25:15.333589153 +0100
+@@ -101,6 +101,8 @@
    printf("static ModeInfoListItem mode_info_list[]=\n");
    printf("{\n");
    for (pm = modes; pm->mode != 0; pm++) {


### PR DESCRIPTION
Remove the EDID copy on the stack and modify the returned EDID in place
seems to avoid memory corruption. The returned EDID is now correct,
though lack of a complete explanation makes this a work-around.

See associated ticket for more details.

OXT-445