### PR TITLE
Add selinux policy for XCPMD scripts and default rules.

### DIFF
--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_xenpmd.fc.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_xenpmd.fc.patch
@@ -1,6 +1,8 @@
---- a/policy/modules/services/xenpmd.fc	1969-12-31 19:00:00.000000000 -0500
-+++ b/policy/modules/services/xenpmd.fc	2015-01-05 16:03:12.793080030 -0500
-@@ -0,0 +1,22 @@
+Index: refpolicy/policy/modules/services/xenpmd.fc
+===================================================================
+--- /dev/null
++++ refpolicy/policy/modules/services/xenpmd.fc
+@@ -0,0 +1,26 @@
 +#############################################################################
 +#
 +# Copyright (C) 2014 Citrix Systems, Inc.
@@ -21,5 +23,9 @@
 +#
 +#############################################################################
 +
-+/usr/sbin/xcpmd		--	gen_context(system_u:object_r:xenpmd_exec_t,s0)
-+/var/run/xcpmd\.pid    --      gen_context(system_u:object_r:xenpmd_var_run_t,s0)
++/usr/sbin/xcpmd                     -- gen_context(system_u:object_r:xenpmd_exec_t,s0)
++/var/run/xcpmd\.pid                 -- gen_context(system_u:object_r:xenpmd_var_run_t,s0)
++/usr/share/xcpmd/                   -- gen_context(system_u:object_r:xenpmd_etc_t,s0)
++/usr/share/xcpmd/default.rules      -- gen_context(system_u:object_r:xenpmd_etc_t,s0)
++/usr/share/xcpmd/screen_off.sh      -- gen_context(system_u:object_r:xenpmd_script_exec_t,s0)
++/usr/share/xcpmd/screen_on.sh       -- gen_context(system_u:object_r:xenpmd_script_exec_t,s0)

--- a/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_xenpmd.te.patch
+++ b/recipes-security/selinux/refpolicy-mcs/openxt_policy_modules_services_xenpmd.te.patch
@@ -2,7 +2,7 @@ Index: refpolicy/policy/modules/services/xenpmd.te
 ===================================================================
 --- /dev/null
 +++ refpolicy/policy/modules/services/xenpmd.te
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,112 @@
 +#############################################################################
 +#
 +# Copyright (C) 2014 Citrix Systems, Inc.
@@ -25,6 +25,17 @@ Index: refpolicy/policy/modules/services/xenpmd.te
 +
 +policy_module(xenpmd, 0.1)
 +
++
++########################################
++#
++# Requirements
++#
++
++require {
++  type bin_t;
++  type shell_exec_t;
++}
++
 +########################################
 +#
 +# Declarations
@@ -41,6 +52,16 @@ Index: refpolicy/policy/modules/services/xenpmd.te
 +type xenpmd_var_run_t;
 +files_pid_file(xenpmd_var_run_t)
 +files_pid_filetrans(xenpmd_t, xenpmd_var_run_t, file)
++
++type xenpmd_etc_t;
++files_config_file(xenpmd_etc_t)
++
++# create a sandboxed xenpmd_script_t domain for shell scripts
++type xenpmd_script_t;
++type xenpmd_script_exec_t;
++domain_type(xenpmd_script_t)
++domain_entry_file(xenpmd_script_t, shell_exec_t)
++domain_auto_trans(xenpmd_t, shell_exec_t, xenpmd_script_t)
 +
 +########################################
 +#
@@ -78,6 +99,19 @@ Index: refpolicy/policy/modules/services/xenpmd.te
 +allow xenpmd_t xenpmd_var_t:dir manage_dir_perms;
 +allow xenpmd_t xenpmd_var_t:file manage_file_perms;
 +allow xenpmd_t xenpmd_var_run_t:file manage_file_perms;
++allow xenpmd_t xenpmd_etc_t:dir list_dir_perms;
++allow xenpmd_t xenpmd_etc_t:file read_file_perms;
++
++# allow XCPMD to run shell scripts in a sandboxed type, xenpmd_script_t
++allow xenpmd_t bin_t:lnk_file read_file_perms;
++allow xenpmd_t bin_t:file read_file_perms;
++allow xenpmd_t shell_exec_t:file exec_file_perms;
++allow xenpmd_script_t xenpmd_t:process { sigchld };
++allow xenpmd_script_t xenpmd_script_exec_t:file exec_file_perms;
++
++# xenpmd_script_t permissions
++# currently, it can only run bin_t processes
++allow xenpmd_script_t bin_t:file exec_file_perms;
 +
 +# allow XCPMD to receive messages from xenmgr
 +xenpmd_dbus_chat(xend_t)


### PR DESCRIPTION
This gives XCPMD permission to read its own default config, and creates a new context with limited permissions for any XCPMD scripts to run within. 

Accompanies [xctools PR18](https://github.com/OpenXT/xctools/pull/18).