### PR TITLE
Linux 3.18.25 & latest XSAs

### DIFF
--- a/recipes-extended/xen/files/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
+++ b/recipes-extended/xen/files/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
@@ -1,0 +1,127 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-155 (http://xenbits.xen.org/xsa/advisory-155.html)
+paravirtualized drivers incautious about shared memory contents
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-155.html
+Patches: xsa155-xen-0001-xen-Add-RING_COPY_REQUEST.patch
+         xsa155-xen-0002-blktap2-Use-RING_COPY_REQUEST.patch
+         xsa155-xen-0003-libvchan-Read-prod-cons-only-once.patch
+
+The compiler can emit optimizations in the PV backend drivers which can lead to
+double fetch vulnerabilities. Specifically the shared memory between the
+frontend and backend can be fetched twice (during which time the frontend can
+alter the contents) possibly leading to arbitrary code execution in
+backend.
+
+Malicious guest administrators can cause denial of service.  If driver domains
+are not in use, the impact can be a host crash, or privilege escalation.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.3.4/xen/include/public/io/ring.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/public/io/ring.h	2015-03-19 16:08:36.000000000 +0100
++++ xen-4.3.4/xen/include/public/io/ring.h	2015-12-18 17:36:55.133252177 +0100
+@@ -212,6 +212,20 @@
+ #define RING_GET_REQUEST(_r, _idx)                                      \
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].req))
+ 
++/*
++ * Get a local copy of a request.
++ *
++ * Use this in preference to RING_GET_REQUEST() so all processing is
++ * done on a local copy that cannot be modified by the other end.
++ *
++ * Note that https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58145 may cause this
++ * to be ineffective where _req is a struct which consists of only bitfields.
++ */
++#define RING_COPY_REQUEST(_r, _idx, _req) do {				\
++	/* Use volatile to force the copy into _req. */			\
++	*(_req) = *(volatile typeof(_req))RING_GET_REQUEST(_r, _idx);	\
++} while (0)
++
+ #define RING_GET_RESPONSE(_r, _idx)                                     \
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].rsp))
+ 
+Index: xen-4.3.4/tools/blktap2/drivers/block-log.c
+===================================================================
+--- xen-4.3.4.orig/tools/blktap2/drivers/block-log.c	2015-12-18 17:38:50.494965019 +0100
++++ xen-4.3.4/tools/blktap2/drivers/block-log.c	2015-12-18 17:39:01.971470485 +0100
+@@ -494,11 +494,12 @@
+   reqstart = s->bring.req_cons;
+   reqend = s->sring->req_prod;
+ 
++  xen_mb();
+   BDPRINTF("ctl: ring kicked (start = %u, end = %u)", reqstart, reqend);
+ 
+   while (reqstart != reqend) {
+     /* XXX actually submit these! */
+-    memcpy(&req, RING_GET_REQUEST(&s->bring, reqstart), sizeof(req));
++    RING_COPY_REQUEST(&s->bring, reqstart, &req);
+     BDPRINTF("ctl: read request %"PRIu64":%u", req.sector, req.count);
+     s->bring.req_cons = ++reqstart;
+ 
+Index: xen-4.3.4/tools/blktap2/drivers/tapdisk-vbd.c
+===================================================================
+--- xen-4.3.4.orig/tools/blktap2/drivers/tapdisk-vbd.c	2015-12-18 17:38:50.494965019 +0100
++++ xen-4.3.4/tools/blktap2/drivers/tapdisk-vbd.c	2015-12-18 17:39:01.971470485 +0100
+@@ -1587,7 +1587,7 @@
+ 	int idx;
+ 	RING_IDX rp, rc;
+ 	td_ring_t *ring;
+-	blkif_request_t *req;
++	blkif_request_t req;
+ 	td_vbd_request_t *vreq;
+ 
+ 	ring = &vbd->ring;
+@@ -1598,16 +1598,16 @@
+ 	xen_rmb();
+ 
+ 	for (rc = ring->fe_ring.req_cons; rc != rp; rc++) {
+-		req = RING_GET_REQUEST(&ring->fe_ring, rc);
++		RING_COPY_REQUEST(&ring->fe_ring, rc, &req);
+ 		++ring->fe_ring.req_cons;
+ 
+-		idx  = req->id;
++		idx  = req.id;
+ 		vreq = &vbd->request_list[idx];
+ 
+ 		ASSERT(list_empty(&vreq->next));
+ 		ASSERT(vreq->secs_pending == 0);
+ 
+-		memcpy(&vreq->req, req, sizeof(blkif_request_t));
++		memcpy(&vreq->req, &req, sizeof(blkif_request_t));
+ 		vbd->received++;
+ 		vreq->vbd = vbd;
+ 
+Index: xen-4.3.4/tools/libvchan/io.c
+===================================================================
+--- xen-4.3.4.orig/tools/libvchan/io.c	2015-12-18 17:38:49.978305609 +0100
++++ xen-4.3.4/tools/libvchan/io.c	2015-12-18 17:39:04.404769641 +0100
+@@ -118,6 +118,7 @@
+ static inline int raw_get_data_ready(struct libxenvchan *ctrl)
+ {
+ 	uint32_t ready = rd_prod(ctrl) - rd_cons(ctrl);
++	xen_mb(); /* Ensure 'ready' is read only once. */
+ 	if (ready >= rd_ring_size(ctrl))
+ 		/* We have no way to return errors.  Locking up the ring is
+ 		 * better than the alternatives. */
+@@ -159,6 +160,7 @@
+ static inline int raw_get_buffer_space(struct libxenvchan *ctrl)
+ {
+ 	uint32_t ready = wr_ring_size(ctrl) - (wr_prod(ctrl) - wr_cons(ctrl));
++	xen_mb(); /* Ensure 'ready' is read only once. */
+ 	if (ready > wr_ring_size(ctrl))
+ 		/* We have no way to return errors.  Locking up the ring is
+ 		 * better than the alternatives. */

--- a/recipes-extended/xen/files/xsa-159-XENMEM_exchange-error-handling-issues.patch
+++ b/recipes-extended/xen/files/xsa-159-XENMEM_exchange-error-handling-issues.patch
@@ -1,0 +1,61 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-159 (http://xenbits.xen.org/xsa/advisory-159.html)
+XENMEM_exchange error handling issues
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-159.html
+Patches: xsa159.patch
+
+Error handling in the operation may involve handing back pages to
+the domain. This operation may fail when in parallel the domain gets
+torn down. So far this failure unconditionally resulted in the host
+being brought down due to an internal error being assumed. This is
+CVE-2015-8339.
+
+Furthermore error handling so far wrongly included the release of a
+lock. That lock, however, was either not acquired or already released
+on all paths leading to the error handling sequence. This is
+CVE-2015-8340.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.3.4/xen/common/memory.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/memory.c	2015-12-14 13:24:27.461775959 +0100
++++ xen-4.3.4/xen/common/memory.c	2015-12-18 18:07:09.554428333 +0100
+@@ -442,7 +442,7 @@
+     PAGE_LIST_HEAD(out_chunk_list);
+     unsigned long in_chunk_order, out_chunk_order;
+     xen_pfn_t     gpfn, gmfn, mfn;
+-    unsigned long i, j, k = 0; /* gcc ... */
++    unsigned long i, j, k;
+     unsigned int  memflags = 0;
+     long          rc = 0;
+     struct domain *d;
+@@ -679,11 +679,12 @@
+  fail:
+     /* Reassign any input pages we managed to steal. */
+     while ( (page = page_list_remove_head(&in_chunk_list)) )
+-    {
+-        put_gfn(d, gmfn + k--);
+         if ( assign_pages(d, page, 0, MEMF_no_refcount) )
+-            BUG();
+-    }
++        {
++            BUG_ON(!d->is_dying);
++            if ( test_and_clear_bit(_PGC_allocated, &page->count_info) )
++                put_page(page);
++        }
+ 
+  dying:
+     rcu_unlock_domain(d);

--- a/recipes-extended/xen/files/xsa-160-libxl-leak-of-pv-kernel-and-initrd-on-error.patch
+++ b/recipes-extended/xen/files/xsa-160-libxl-leak-of-pv-kernel-and-initrd-on-error.patch
@@ -1,0 +1,58 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-160 (http://xenbits.xen.org/xsa/advisory-160.html)
+libxl leak of pv kernel and initrd on error
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-160.html
+Patches: xsa160-4.4.patch
+
+when constructing a guest which is configured to use a pv bootloader
+which runs as a userspace process in the toolstack domain
+(e.g. pygrub) libxl creates a mapping of the files to be used as
+kernel and initial ramdisk when building the guest domain.
+
+however if building the domain subsequently fails these mappings would
+not be released leading to a leak of virtual address space in the
+calling process, as well as preventing the recovery of the temporary
+disk files containing the kernel and initial ramdisk.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.3.4/tools/libxl/libxl_create.c
+===================================================================
+--- xen-4.3.4.orig/tools/libxl/libxl_create.c	2015-03-19 16:08:36.000000000 +0100
++++ xen-4.3.4/tools/libxl/libxl_create.c	2015-12-18 18:09:49.188858815 +0100
+@@ -1197,6 +1197,9 @@
+     STATE_AO_GC(dcs->ao);
+     libxl_domain_config *const d_config = dcs->guest_config;
+ 
++    libxl__file_reference_unmap(&dcs->build_state.pv_kernel);
++    libxl__file_reference_unmap(&dcs->build_state.pv_ramdisk);
++
+     if (!rc && d_config->b_info.exec_ssidref)
+         rc = xc_flask_relabel_domain(CTX->xch, dcs->guest_domid, d_config->b_info.exec_ssidref);
+ 
+Index: xen-4.3.4/tools/libxl/libxl_dom.c
+===================================================================
+--- xen-4.3.4.orig/tools/libxl/libxl_dom.c	2015-12-14 13:24:27.655106526 +0100
++++ xen-4.3.4/tools/libxl/libxl_dom.c	2015-12-18 18:09:49.192192102 +0100
+@@ -420,9 +420,6 @@
+         state->store_mfn = xc_dom_p2m_host(dom, dom->xenstore_pfn);
+     }
+ 
+-    libxl__file_reference_unmap(&state->pv_kernel);
+-    libxl__file_reference_unmap(&state->pv_ramdisk);
+-
+     ret = 0;
+ out:
+     xc_dom_release(dom);

--- a/recipes-extended/xen/files/xsa-165-information-leak-in-legacy-x86-FPU-XMM-initialization.patch
+++ b/recipes-extended/xen/files/xsa-165-information-leak-in-legacy-x86-FPU-XMM-initialization.patch
@@ -1,0 +1,103 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-165 (http://xenbits.xen.org/xsa/advisory-165.html)
+libxl: information leak in legacy x86 FPU/XMM initialization
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-165.html
+Patches: xsa165-4.3.patch
+
+When XSAVE/XRSTOR are not in use by Xen to manage guest extended register
+state, the initial values in the FPU stack and XMM registers seen by the guest
+upon first use are those left there by the previous user of those registers.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.3.4/xen/arch/x86/domain.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/domain.c	2015-03-19 16:08:36.000000000 +0100
++++ xen-4.3.4/xen/arch/x86/domain.c	2015-12-18 18:15:44.813876567 +0100
+@@ -730,6 +730,17 @@
+ 
+     if ( flags & VGCF_I387_VALID )
+         memcpy(v->arch.fpu_ctxt, &c.nat->fpu_ctxt, sizeof(c.nat->fpu_ctxt));
++    else if ( v->arch.xsave_area )
++        memset(&v->arch.xsave_area->xsave_hdr, 0,
++               sizeof(v->arch.xsave_area->xsave_hdr));
++    else
++    {
++        typeof(v->arch.xsave_area->fpu_sse) *fpu_sse = v->arch.fpu_ctxt;
++
++        memset(fpu_sse, 0, sizeof(*fpu_sse));
++        fpu_sse->fcw = FCW_DEFAULT;
++        fpu_sse->mxcsr = MXCSR_DEFAULT;
++    }
+ 
+     if ( !compat )
+     {
+Index: xen-4.3.4/xen/arch/x86/i387.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/i387.c	2015-03-19 16:08:36.000000000 +0100
++++ xen-4.3.4/xen/arch/x86/i387.c	2015-12-18 18:15:44.813876567 +0100
+@@ -17,19 +17,6 @@
+ #include <asm/xstate.h>
+ #include <asm/asm_defns.h>
+ 
+-static void fpu_init(void)
+-{
+-    unsigned long val;
+-    
+-    asm volatile ( "fninit" );
+-    if ( cpu_has_xmm )
+-    {
+-        /* load default value into MXCSR control/status register */
+-        val = MXCSR_DEFAULT;
+-        asm volatile ( "ldmxcsr %0" : : "m" (val) );
+-    }
+-}
+-
+ /*******************************/
+ /*     FPU Restore Functions   */
+ /*******************************/
+@@ -254,15 +241,8 @@
+ 
+     if ( cpu_has_xsave )
+         fpu_xrstor(v, XSTATE_LAZY);
+-    else if ( v->fpu_initialised )
+-    {
+-        if ( cpu_has_fxsr )
+-            fpu_fxrstor(v);
+-        else
+-            fpu_frstor(v);
+-    }
+     else
+-        fpu_init();
++        fpu_fxrstor(v);
+ 
+     v->fpu_initialised = 1;
+     v->fpu_dirtied = 1;
+@@ -323,7 +303,14 @@
+     else
+     {
+         v->arch.fpu_ctxt = _xzalloc(sizeof(v->arch.xsave_area->fpu_sse), 16);
+-        if ( !v->arch.fpu_ctxt )
++        if ( v->arch.fpu_ctxt )
++        {
++            typeof(v->arch.xsave_area->fpu_sse) *fpu_sse = v->arch.fpu_ctxt;
++
++            fpu_sse->fcw = FCW_DEFAULT;
++            fpu_sse->mxcsr = MXCSR_DEFAULT;
++        }
++        else
+         {
+             rc = -ENOMEM;
+             goto done;

--- a/recipes-extended/xen/files/xsa-166-ioreq-handling-possibly-susceptible-to-multiple-read-issue.patch
+++ b/recipes-extended/xen/files/xsa-166-ioreq-handling-possibly-susceptible-to-multiple-read-issue.patch
@@ -1,0 +1,70 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-166 (http://xenbits.xen.org/xsa/advisory-166.html)
+ioreq handling possibly susceptible to multiple read issue
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-166.html
+Patches: xsa166-4.3.patch
+
+Single memory accesses in source code can be translated to multiple ones in
+machine code by the compiler, requiring special caution when accessing shared
+memory.  Such precaution was missing from the hypervisor code inspecting the
+state of I/O requests sent to the device model for assistance.
+
+Due to the offending field being a bitfield, it is however believed that there
+is no issue in practice, since compilers, at least when optimizing (which is
+always the case for non-debug builds), should find it more expensive to
+extract the bit field value twice than to keep the calculated value in a
+register.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.3.4/xen/arch/x86/hvm/hvm.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/hvm/hvm.c	2015-12-14 13:24:27.571774385 +0100
++++ xen-4.3.4/xen/arch/x86/hvm/hvm.c	2015-12-18 18:18:20.308366202 +0100
+@@ -342,6 +342,7 @@
+ void hvm_do_resume(struct vcpu *v)
+ {
+     ioreq_t *p;
++    unsigned int state;
+ 
+     pt_restore_timer(v);
+ 
+@@ -349,9 +350,10 @@
+ 
+     /* NB. Optimised for common case (p->state == STATE_IOREQ_NONE). */
+     p = get_ioreq(v);
+-    while ( p->state != STATE_IOREQ_NONE )
++    while ( (state = p->state) != STATE_IOREQ_NONE )
+     {
+-        switch ( p->state )
++        rmb();
++        switch ( state )
+         {
+         case STATE_IORESP_READY: /* IORESP_READY -> NONE */
+             hvm_io_assist();
+@@ -359,11 +361,10 @@
+         case STATE_IOREQ_READY:  /* IOREQ_{READY,INPROCESS} -> IORESP_READY */
+         case STATE_IOREQ_INPROCESS:
+             wait_on_xen_event_channel(v->arch.hvm_vcpu.xen_port,
+-                                      (p->state != STATE_IOREQ_READY) &&
+-                                      (p->state != STATE_IOREQ_INPROCESS));
++                                      p->state != state);
+             break;
+         default:
+-            gdprintk(XENLOG_ERR, "Weird HVM iorequest state %d.\n", p->state);
++            gdprintk(XENLOG_ERR, "Weird HVM iorequest state %u\n", state);
+             domain_crash(v->domain);
+             return; /* bail */
+         }

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -117,6 +117,11 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://xsa-152-some-pmu-and-profiling-hypercalls-log-without-rate-limiting.patch;patch=1 \
     file://xsa-153-populate-on-demand-balloon-size-inaccuracy-can-crash-guests.patch;patch=1 \
     file://xsa-156-cpu-lockup-during-exception-delivery.patch;patch=1 \
+    file://xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch;patch=1 \
+    file://xsa-159-XENMEM_exchange-error-handling-issues.patch;patch=1 \
+    file://xsa-160-libxl-leak-of-pv-kernel-and-initrd-on-error.patch;patch=1 \
+    file://xsa-165-information-leak-in-legacy-x86-FPU-XMM-initialization.patch;patch=1 \
+    file://xsa-166-ioreq-handling-possibly-susceptible-to-multiple-read-issue.patch;patch=1 \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_3.18.25.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_3.18.25.bb
@@ -4,8 +4,8 @@ PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
 
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel"
 
-SRC_URI[kernel.md5sum] = "30cfa07084f3ef3709b350ed5f7f01b0"
-SRC_URI[kernel.sha256sum] = "e05ea8886382e4a61945bb433d430d0e230cb6c0ce0c503303138d017350346a"
+SRC_URI[kernel.md5sum] = "cba99443d2d72f078c197b39e5fbf017"
+SRC_URI[kernel.sha256sum] = "a0e6807d299a30ac374d90fecb5473d6f741d29c477b2923d181dfd53a305e52"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 

--- a/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
+++ b/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
@@ -41,6 +41,12 @@ SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.t
     file://pciback-restrictive-attr.patch;patch=1 \
     file://thorough-reset-interface-to-pciback-s-sysfs.patch;patch=1 \
     file://xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch;patch=1 \
+    file://xsa-155-qsb-023-add-RING_COPY_RESPONSE.patch;patch=1 \
+    file://xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch;patch=1 \
+    file://xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch;patch=1 \
+    file://xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch;patch=1 \
+    file://xsa-155-qsb-023-xen-blkfront-make-local-copy-of-response-before-usin.patch;patch=1 \
+    file://xsa-155-qsb-023-xen-blkfront-prepare-request-locally-only-then-put-i.patch;patch=1 \
     file://xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch;patch=1 \
     file://defconfig \
     "

--- a/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
+++ b/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
@@ -40,6 +40,8 @@ SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.t
     file://xenstore-no-read-vs-write-atomicity.patch;patch=1 \
     file://pciback-restrictive-attr.patch;patch=1 \
     file://thorough-reset-interface-to-pciback-s-sysfs.patch;patch=1 \
+    file://xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch;patch=1 \
+    file://xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch;patch=1 \
     file://defconfig \
     "
 

--- a/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
+++ b/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
@@ -39,12 +39,12 @@ SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.t
     file://hvc-kgdb-fix.patch;patch=1 \
     file://xenstore-no-read-vs-write-atomicity.patch;patch=1 \
     file://pciback-restrictive-attr.patch;patch=1 \
-    file://0002-Add-thorough-reset-interface-to-pciback-s-sysfs.patch;patch=1 \
+    file://thorough-reset-interface-to-pciback-s-sysfs.patch;patch=1 \
     file://defconfig \
     "
 
-SRC_URI[kernel.md5sum] = "30cfa07084f3ef3709b350ed5f7f01b0"
-SRC_URI[kernel.sha256sum] = "e05ea8886382e4a61945bb433d430d0e230cb6c0ce0c503303138d017350346a"
+SRC_URI[kernel.md5sum] = "cba99443d2d72f078c197b39e5fbf017"
+SRC_URI[kernel.sha256sum] = "a0e6807d299a30ac374d90fecb5473d6f741d29c477b2923d181dfd53a305e52"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 

--- a/recipes-kernel/linux/3.18/patches/extra-mt-input-devices.patch
+++ b/recipes-kernel/linux/3.18/patches/extra-mt-input-devices.patch
@@ -34,11 +34,11 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-3.18.24/drivers/hid/hid-ids.h
+Index: linux-3.18.25/drivers/hid/hid-ids.h
 ===================================================================
---- linux-3.18.24.orig/drivers/hid/hid-ids.h	2015-12-04 18:43:11.224882392 +0100
-+++ linux-3.18.24/drivers/hid/hid-ids.h	2015-12-04 18:45:11.640086617 +0100
-@@ -923,6 +923,7 @@
+--- linux-3.18.25.orig/drivers/hid/hid-ids.h	2015-12-18 16:55:42.544633721 +0100
++++ linux-3.18.25/drivers/hid/hid-ids.h	2015-12-18 16:55:44.624604992 +0100
+@@ -927,6 +927,7 @@
  #define USB_VENDOR_ID_TURBOX		0x062a
  #define USB_DEVICE_ID_TURBOX_KEYBOARD	0x0201
  #define USB_DEVICE_ID_TURBOX_TOUCHSCREEN_MOSART	0x7100
@@ -46,10 +46,10 @@ Index: linux-3.18.24/drivers/hid/hid-ids.h
  
  #define USB_VENDOR_ID_TWINHAN		0x6253
  #define USB_DEVICE_ID_TWINHAN_IR_REMOTE	0x0100
-Index: linux-3.18.24/drivers/hid/hid-multitouch.c
+Index: linux-3.18.25/drivers/hid/hid-multitouch.c
 ===================================================================
---- linux-3.18.24.orig/drivers/hid/hid-multitouch.c	2015-12-04 18:43:11.211549221 +0100
-+++ linux-3.18.24/drivers/hid/hid-multitouch.c	2015-12-04 18:45:11.773418332 +0100
+--- linux-3.18.25.orig/drivers/hid/hid-multitouch.c	2015-12-18 16:55:42.544633721 +0100
++++ linux-3.18.25/drivers/hid/hid-multitouch.c	2015-12-18 16:55:44.624604992 +0100
 @@ -1223,6 +1223,9 @@
  	{ .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
  		MT_USB_DEVICE(USB_VENDOR_ID_TURBOX,

--- a/recipes-kernel/linux/3.18/patches/pci-pt-flr.patch
+++ b/recipes-kernel/linux/3.18/patches/pci-pt-flr.patch
@@ -39,10 +39,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-3.18.24/drivers/pci/pci.c
+Index: linux-3.18.25/drivers/pci/pci.c
 ===================================================================
---- linux-3.18.24.orig/drivers/pci/pci.c	2015-12-04 18:45:24.583262761 +0100
-+++ linux-3.18.24/drivers/pci/pci.c	2015-12-04 18:45:26.183243342 +0100
+--- linux-3.18.25.orig/drivers/pci/pci.c	2015-12-18 16:55:51.924504163 +0100
++++ linux-3.18.25/drivers/pci/pci.c	2015-12-18 16:55:52.501162864 +0100
 @@ -3354,6 +3354,10 @@
  
  	rc = pci_parent_bus_reset(dev, probe);
@@ -54,11 +54,11 @@ Index: linux-3.18.24/drivers/pci/pci.c
  	return rc;
  }
  
-Index: linux-3.18.24/drivers/pci/quirks.c
+Index: linux-3.18.25/drivers/pci/quirks.c
 ===================================================================
---- linux-3.18.24.orig/drivers/pci/quirks.c	2015-12-04 18:43:05.791615053 +0100
-+++ linux-3.18.24/drivers/pci/quirks.c	2015-12-04 18:45:26.326574935 +0100
-@@ -3352,10 +3352,15 @@
+--- linux-3.18.25.orig/drivers/pci/quirks.c	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/pci/quirks.c	2015-12-18 16:55:52.501162864 +0100
+@@ -3361,10 +3361,15 @@
  	void __iomem *mmio_base;
  	unsigned long timeout;
  	u32 val;
@@ -74,7 +74,7 @@ Index: linux-3.18.24/drivers/pci/quirks.c
  	mmio_base = pci_iomap(dev, 0, 0);
  	if (!mmio_base)
  		return -ENOMEM;
-@@ -3386,7 +3391,10 @@
+@@ -3395,7 +3400,10 @@
  	iowrite32(0x00000002, mmio_base + NSDE_PWR_STATE);
  
  	pci_iounmap(dev, mmio_base);
@@ -86,10 +86,10 @@ Index: linux-3.18.24/drivers/pci/quirks.c
  }
  
  /*
-Index: linux-3.18.24/drivers/xen/xen-pciback/pci_stub.c
+Index: linux-3.18.25/drivers/xen/xen-pciback/pci_stub.c
 ===================================================================
---- linux-3.18.24.orig/drivers/xen/xen-pciback/pci_stub.c	2015-12-04 18:43:05.808281517 +0100
-+++ linux-3.18.24/drivers/xen/xen-pciback/pci_stub.c	2015-12-04 18:45:26.426573720 +0100
+--- linux-3.18.25.orig/drivers/xen/xen-pciback/pci_stub.c	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/xen/xen-pciback/pci_stub.c	2015-12-18 16:55:52.501162864 +0100
 @@ -403,10 +403,13 @@
  	if (!dev_data->pci_saved_state)
  		dev_err(&dev->dev, "Could not store PCI conf saved state!\n");

--- a/recipes-kernel/linux/3.18/patches/thorough-reset-interface-to-pciback-s-sysfs.patch
+++ b/recipes-kernel/linux/3.18/patches/thorough-reset-interface-to-pciback-s-sysfs.patch
@@ -163,10 +163,10 @@ PATCHES
  drivers/xen/xen-pciback/pci_stub.c | 338 ++++++++++++++++++++++++++++++++++---
  1 file changed, 312 insertions(+), 26 deletions(-)
 
-Index: linux-3.18.24/drivers/xen/xen-pciback/pci_stub.c
+Index: linux-3.18.25/drivers/xen/xen-pciback/pci_stub.c
 ===================================================================
---- linux-3.18.24.orig/drivers/xen/xen-pciback/pci_stub.c	2015-12-04 18:45:51.449603190 +0100
-+++ linux-3.18.24/drivers/xen/xen-pciback/pci_stub.c	2015-12-04 18:45:52.986251197 +0100
+--- linux-3.18.25.orig/drivers/xen/xen-pciback/pci_stub.c	2015-12-18 16:56:03.744340893 +0100
++++ linux-3.18.25/drivers/xen/xen-pciback/pci_stub.c	2015-12-18 16:56:04.131002218 +0100
 @@ -100,10 +100,9 @@
  
  	xen_unregister_device_domain_owner(dev);
@@ -565,10 +565,10 @@ Index: linux-3.18.24/drivers/xen/xen-pciback/pci_stub.c
  	if (err)
  		pcistub_exit();
  
-Index: linux-3.18.24/drivers/pci/pci.c
+Index: linux-3.18.25/drivers/pci/pci.c
 ===================================================================
---- linux-3.18.24.orig/drivers/pci/pci.c	2015-12-04 18:45:26.183243342 +0100
-+++ linux-3.18.24/drivers/pci/pci.c	2015-12-04 18:45:53.139582669 +0100
+--- linux-3.18.25.orig/drivers/pci/pci.c	2015-12-18 16:55:52.501162864 +0100
++++ linux-3.18.25/drivers/pci/pci.c	2015-12-18 16:56:04.131002218 +0100
 @@ -1142,7 +1142,7 @@
   * @dev: PCI device that we're dealing with
   * @state: Saved state returned from pci_store_saved_state()
@@ -586,11 +586,11 @@ Index: linux-3.18.24/drivers/pci/pci.c
  
  /**
   * pci_load_and_free_saved_state - Reload the save state pointed to by state,
-Index: linux-3.18.24/include/linux/pci.h
+Index: linux-3.18.25/include/linux/pci.h
 ===================================================================
---- linux-3.18.24.orig/include/linux/pci.h	2015-12-04 18:42:54.188422656 +0100
-+++ linux-3.18.24/include/linux/pci.h	2015-12-04 18:45:53.226248283 +0100
-@@ -1007,6 +1007,8 @@
+--- linux-3.18.25.orig/include/linux/pci.h	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/include/linux/pci.h	2015-12-18 16:56:04.131002218 +0100
+@@ -1011,6 +1011,8 @@
  int pci_save_state(struct pci_dev *dev);
  void pci_restore_state(struct pci_dev *dev);
  struct pci_saved_state *pci_store_saved_state(struct pci_dev *dev);

--- a/recipes-kernel/linux/3.18/patches/usbback-base.patch
+++ b/recipes-kernel/linux/3.18/patches/usbback-base.patch
@@ -36,10 +36,10 @@ Toolstack in general.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-3.18.24/drivers/usb/Kconfig
+Index: linux-3.18.25/drivers/usb/Kconfig
 ===================================================================
---- linux-3.18.24.orig/drivers/usb/Kconfig	2015-12-04 18:42:57.858378079 +0100
-+++ linux-3.18.24/drivers/usb/Kconfig	2015-12-04 18:45:44.939682241 +0100
+--- linux-3.18.25.orig/drivers/usb/Kconfig	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/usb/Kconfig	2015-12-18 16:56:00.137724046 +0100
 @@ -94,6 +94,17 @@
  
  source "drivers/usb/usbip/Kconfig"
@@ -58,20 +58,20 @@ Index: linux-3.18.24/drivers/usb/Kconfig
  endif
  
  source "drivers/usb/musb/Kconfig"
-Index: linux-3.18.24/drivers/usb/Makefile
+Index: linux-3.18.25/drivers/usb/Makefile
 ===================================================================
---- linux-3.18.24.orig/drivers/usb/Makefile	2015-12-04 18:42:57.925043935 +0100
-+++ linux-3.18.24/drivers/usb/Makefile	2015-12-04 18:45:45.073013957 +0100
+--- linux-3.18.25.orig/drivers/usb/Makefile	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/usb/Makefile	2015-12-18 16:56:00.137724046 +0100
 @@ -62,3 +62,5 @@
  obj-$(CONFIG_USB_COMMON)	+= common/
  
  obj-$(CONFIG_USBIP_CORE)	+= usbip/
 +
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) += xen-usbback/
-Index: linux-3.18.24/drivers/usb/core/Makefile
+Index: linux-3.18.25/drivers/usb/core/Makefile
 ===================================================================
---- linux-3.18.24.orig/drivers/usb/core/Makefile	2015-12-04 18:42:57.891711008 +0100
-+++ linux-3.18.24/drivers/usb/core/Makefile	2015-12-04 18:45:45.139679814 +0100
+--- linux-3.18.25.orig/drivers/usb/core/Makefile	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/usb/core/Makefile	2015-12-18 16:56:00.137724046 +0100
 @@ -6,6 +6,7 @@
  usbcore-y += config.o file.o buffer.o sysfs.o endpoint.o
  usbcore-y += devio.o notify.o generic.o quirks.o devices.o
@@ -80,10 +80,10 @@ Index: linux-3.18.24/drivers/usb/core/Makefile
  
  usbcore-$(CONFIG_PCI)		+= hcd-pci.o
  usbcore-$(CONFIG_ACPI)		+= usb-acpi.o
-Index: linux-3.18.24/drivers/usb/core/dusb.c
+Index: linux-3.18.25/drivers/usb/core/dusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/core/dusb.c	2015-12-04 18:45:45.233012012 +0100
++++ linux-3.18.25/drivers/usb/core/dusb.c	2015-12-18 16:56:00.137724046 +0100
 @@ -0,0 +1,169 @@
 +/*****************************************************************************/
 +
@@ -254,10 +254,10 @@ Index: linux-3.18.24/drivers/usb/core/dusb.c
 +}
 +EXPORT_SYMBOL(dusb_dev_controller_speed);
 +
-Index: linux-3.18.24/drivers/usb/core/hub.c
+Index: linux-3.18.25/drivers/usb/core/hub.c
 ===================================================================
---- linux-3.18.24.orig/drivers/usb/core/hub.c	2015-12-04 18:42:57.908377472 +0100
-+++ linux-3.18.24/drivers/usb/core/hub.c	2015-12-04 18:45:45.289677992 +0100
+--- linux-3.18.25.orig/drivers/usb/core/hub.c	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/usb/core/hub.c	2015-12-18 16:56:00.137724046 +0100
 @@ -1011,6 +1011,15 @@
  	return 0;
  }
@@ -297,18 +297,18 @@ Index: linux-3.18.24/drivers/usb/core/hub.c
  
  			if (!rebind && cintf->dev.driver) {
  				drv = to_usb_driver(cintf->dev.driver);
-Index: linux-3.18.24/drivers/usb/xen-usbback/Makefile
+Index: linux-3.18.25/drivers/usb/xen-usbback/Makefile
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/Makefile	2015-12-04 18:45:45.383010192 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/Makefile	2015-12-18 16:56:00.137724046 +0100
 @@ -0,0 +1,3 @@
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) := usbbk.o
 +
 +usbbk-y	:= usbback.o xenbus.o interface.o vusb.o buffers.o
-Index: linux-3.18.24/drivers/usb/xen-usbback/buffers.c
+Index: linux-3.18.25/drivers/usb/xen-usbback/buffers.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/buffers.c	2015-12-04 18:45:45.473009099 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/buffers.c	2015-12-18 16:56:00.137724046 +0100
 @@ -0,0 +1,422 @@
 +/******************************************************************************
 + * usbback/buffers.c
@@ -732,10 +732,10 @@ Index: linux-3.18.24/drivers/usb/xen-usbback/buffers.c
 +	}
 +}
 +
-Index: linux-3.18.24/drivers/usb/xen-usbback/common.h
+Index: linux-3.18.25/drivers/usb/xen-usbback/common.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/common.h	2015-12-04 18:45:45.519675200 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/common.h	2015-12-18 16:56:00.137724046 +0100
 @@ -0,0 +1,361 @@
 +/*
 + * Copyright (c) Citrix Systems Inc.
@@ -1098,10 +1098,10 @@ Index: linux-3.18.24/drivers/usb/xen-usbback/common.h
 +void dump(uint8_t *buffer, int len);
 +
 +#endif /* __USBIF__BACKEND__COMMON_H__ */
-Index: linux-3.18.24/drivers/usb/xen-usbback/interface.c
+Index: linux-3.18.25/drivers/usb/xen-usbback/interface.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/interface.c	2015-12-04 18:45:45.579674469 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/interface.c	2015-12-18 16:56:00.137724046 +0100
 @@ -0,0 +1,164 @@
 +/******************************************************************************
 + *
@@ -1267,10 +1267,10 @@ Index: linux-3.18.24/drivers/usb/xen-usbback/interface.c
 +	usbif_cachep = kmem_cache_create("usbif_cache", sizeof(usbif_t),
 +					 0, 0, NULL);
 +}
-Index: linux-3.18.24/drivers/usb/xen-usbback/usbback.c
+Index: linux-3.18.25/drivers/usb/xen-usbback/usbback.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/usbback.c	2015-12-04 18:45:45.656340207 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/usbback.c	2015-12-18 16:56:00.141057334 +0100
 @@ -0,0 +1,1269 @@
 +/******************************************************************************
 + *
@@ -2541,10 +2541,10 @@ Index: linux-3.18.24/drivers/usb/xen-usbback/usbback.c
 +module_init(usbif_init);
 +
 +MODULE_LICENSE("Dual BSD/GPL");
-Index: linux-3.18.24/drivers/usb/xen-usbback/vusb.c
+Index: linux-3.18.25/drivers/usb/xen-usbback/vusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/vusb.c	2015-12-04 18:45:45.706339598 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/vusb.c	2015-12-18 16:56:00.141057334 +0100
 @@ -0,0 +1,938 @@
 +/******************************************************************************
 + * usbback/vusb.c
@@ -3484,10 +3484,10 @@ Index: linux-3.18.24/drivers/usb/xen-usbback/vusb.c
 +	}
 +}
 +
-Index: linux-3.18.24/drivers/usb/xen-usbback/xenbus.c
+Index: linux-3.18.25/drivers/usb/xen-usbback/xenbus.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/drivers/usb/xen-usbback/xenbus.c	2015-12-04 18:45:45.756338993 +0100
++++ linux-3.18.25/drivers/usb/xen-usbback/xenbus.c	2015-12-18 16:56:00.141057334 +0100
 @@ -0,0 +1,582 @@
 +/*  Xenbus code for usbif backend
 +    Copyright (C) 2005 Rusty Russell <rusty@rustcorp.com.au>
@@ -4071,10 +4071,10 @@ Index: linux-3.18.24/drivers/usb/xen-usbback/xenbus.c
 +{
 +	return xenbus_register_backend(&usbback_driver);
 +}
-Index: linux-3.18.24/include/linux/dusb.h
+Index: linux-3.18.25/include/linux/dusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/include/linux/dusb.h	2015-12-04 18:45:45.823004848 +0100
++++ linux-3.18.25/include/linux/dusb.h	2015-12-18 16:56:00.141057334 +0100
 @@ -0,0 +1,44 @@
 +/*****************************************************************************/
 +
@@ -4120,10 +4120,10 @@ Index: linux-3.18.24/include/linux/dusb.h
 +extern void usb_device_reenumerate(struct usb_device *udev);
 +
 +#endif
-Index: linux-3.18.24/include/xen/interface/io/usbif.h
+Index: linux-3.18.25/include/xen/interface/io/usbif.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/include/xen/interface/io/usbif.h	2015-12-04 18:45:45.926336928 +0100
++++ linux-3.18.25/include/xen/interface/io/usbif.h	2015-12-18 16:56:00.141057334 +0100
 @@ -0,0 +1,196 @@
 +/******************************************************************************
 + * usbif.h
@@ -4321,10 +4321,10 @@ Index: linux-3.18.24/include/xen/interface/io/usbif.h
 + * indent-tabs-mode: nil
 + * End:
 + */
-Index: linux-3.18.24/include/xen/vusb.h
+Index: linux-3.18.25/include/xen/vusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-3.18.24/include/xen/vusb.h	2015-12-04 18:45:46.026335714 +0100
++++ linux-3.18.25/include/xen/vusb.h	2015-12-18 16:56:00.141057334 +0100
 @@ -0,0 +1,56 @@
 +#ifndef __XEN_VUSB_H__
 +#define __XEN_VUSB_H__
@@ -4382,10 +4382,10 @@ Index: linux-3.18.24/include/xen/vusb.h
 +}
 +
 +#endif /* __XEN_VUSB_H__ */
-Index: linux-3.18.24/drivers/scsi/sr.c
+Index: linux-3.18.25/drivers/scsi/sr.c
 ===================================================================
---- linux-3.18.24.orig/drivers/scsi/sr.c	2015-12-04 18:42:57.841711615 +0100
-+++ linux-3.18.24/drivers/scsi/sr.c	2015-12-04 18:45:46.093001570 +0100
+--- linux-3.18.25.orig/drivers/scsi/sr.c	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/scsi/sr.c	2015-12-18 16:56:00.141057334 +0100
 @@ -264,6 +264,15 @@
  	if (!(clearing & DISK_EVENT_MEDIA_CHANGE))
  		return events;
@@ -4423,11 +4423,11 @@ Index: linux-3.18.24/drivers/scsi/sr.c
  
  	if (cd->device->changed) {
  		events |= DISK_EVENT_MEDIA_CHANGE;
-Index: linux-3.18.24/drivers/usb/host/xhci-pci.c
+Index: linux-3.18.25/drivers/usb/host/xhci-pci.c
 ===================================================================
---- linux-3.18.24.orig/drivers/usb/host/xhci-pci.c	2015-12-04 18:42:57.875044543 +0100
-+++ linux-3.18.24/drivers/usb/host/xhci-pci.c	2015-12-04 18:45:46.196333649 +0100
-@@ -142,6 +142,7 @@
+--- linux-3.18.25.orig/drivers/usb/host/xhci-pci.c	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/usb/host/xhci-pci.c	2015-12-18 16:56:00.141057334 +0100
+@@ -143,6 +143,7 @@
  		 pdev->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI)) {
  		xhci->quirks |= XHCI_PME_STUCK_QUIRK;
  	}
@@ -4435,7 +4435,7 @@ Index: linux-3.18.24/drivers/usb/host/xhci-pci.c
  	if (pdev->vendor == PCI_VENDOR_ID_ETRON &&
  			pdev->device == PCI_DEVICE_ID_EJ168) {
  		xhci->quirks |= XHCI_RESET_ON_RESUME;
-@@ -166,6 +167,11 @@
+@@ -167,6 +168,11 @@
  	if (xhci->quirks & XHCI_RESET_ON_RESUME)
  		xhci_dbg_trace(xhci, trace_xhci_dbg_quirks,
  				"QUIRK: Resetting on resume");

--- a/recipes-kernel/linux/3.18/patches/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
@@ -24,11 +24,6 @@ alter the contents) possibly leading to arbitrary code execution in
 backend.
 
 ################################################################################
-CHANGELOG 
-################################################################################
-Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
-
-################################################################################
 PATCHES 
 ################################################################################
 Index: linux-3.18.25/include/xen/interface/io/ring.h

--- a/recipes-kernel/linux/3.18/patches/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
@@ -1,0 +1,293 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-155 (http://xenbits.xen.org/xsa/advisory-155.html)
+paravirtualized drivers incautious about shared memory contents
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-155.html
+Patches:
+xsa155-linux-xsa155-0001-xen-Add-RING_COPY_REQUEST.patch
+xsa155-linux-xsa155-0002-xen-netback-don-t-use-last-request-to-determine-mini.patch
+xsa155-linux-xsa155-0003-xen-netback-use-RING_COPY_REQUEST-throughout.patch
+xsa155-linux-xsa155-0004-xen-blkback-only-read-request-operation-from-shared-.patch
+xsa155-linux43-0005-xen-blkback-read-from-indirect-descriptors-only-once.patch
+xsa155-linux-xsa155-0006-xen-scsiback-safely-copy-requests.patch
+xsa155-linux-xsa155-0007-xen-pciback-Save-xen_pci_op-commands-before-processi.patch
+         
+The compiler can emit optimizations in the PV backend drivers which can lead to
+double fetch vulnerabilities. Specifically the shared memory between the
+frontend and backend can be fetched twice (during which time the frontend can
+alter the contents) possibly leading to arbitrary code execution in
+backend.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/include/xen/interface/io/ring.h
+===================================================================
+--- linux-3.18.25.orig/include/xen/interface/io/ring.h	2015-12-18 17:30:04.142360552 +0100
++++ linux-3.18.25/include/xen/interface/io/ring.h	2015-12-18 17:30:05.575673740 +0100
+@@ -181,6 +181,20 @@
+ #define RING_GET_REQUEST(_r, _idx)					\
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].req))
+ 
++/*
++ * Get a local copy of a request.
++ *
++ * Use this in preference to RING_GET_REQUEST() so all processing is
++ * done on a local copy that cannot be modified by the other end.
++ *
++ * Note that https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58145 may cause this
++ * to be ineffective where _req is a struct which consists of only bitfields.
++ */
++#define RING_COPY_REQUEST(_r, _idx, _req) do {				\
++	/* Use volatile to force the copy into _req. */			\
++	*(_req) = *(volatile typeof(_req))RING_GET_REQUEST(_r, _idx);	\
++} while (0)
++
+ #define RING_GET_RESPONSE(_r, _idx)					\
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].rsp))
+ 
+Index: linux-3.18.25/drivers/block/xen-blkback/blkback.c
+===================================================================
+--- linux-3.18.25.orig/drivers/block/xen-blkback/blkback.c	2015-12-18 17:29:55.799144485 +0100
++++ linux-3.18.25/drivers/block/xen-blkback/blkback.c	2015-12-18 17:31:01.038227562 +0100
+@@ -861,6 +861,8 @@
+ 		goto unmap;
+ 
+ 	for (n = 0, i = 0; n < nseg; n++) {
++		uint8_t first_sect, last_sect;
++
+ 		if ((n % SEGS_PER_INDIRECT_FRAME) == 0) {
+ 			/* Map indirect segments */
+ 			if (segments)
+@@ -869,14 +871,14 @@
+ 		}
+ 		i = n % SEGS_PER_INDIRECT_FRAME;
+ 		pending_req->segments[n]->gref = segments[i].gref;
+-		seg[n].nsec = segments[i].last_sect -
+-			segments[i].first_sect + 1;
+-		seg[n].offset = (segments[i].first_sect << 9);
+-		if ((segments[i].last_sect >= (PAGE_SIZE >> 9)) ||
+-		    (segments[i].last_sect < segments[i].first_sect)) {
++		first_sect = READ_ONCE(segments[i].first_sect);
++		last_sect = READ_ONCE(segments[i].last_sect);
++		if (last_sect >= (PAGE_SIZE >> 9) || last_sect < first_sect) {
+ 			rc = -EINVAL;
+ 			goto unmap;
+ 		}
++		seg[n].nsec = last_sect - first_sect + 1;
++		seg[n].offset = first_sect << 9;
+ 		preq->nr_sects += seg[n].nsec;
+ 	}
+ 
+Index: linux-3.18.25/drivers/block/xen-blkback/common.h
+===================================================================
+--- linux-3.18.25.orig/drivers/block/xen-blkback/common.h	2015-12-18 17:29:56.189139004 +0100
++++ linux-3.18.25/drivers/block/xen-blkback/common.h	2015-12-18 17:30:59.054922102 +0100
+@@ -391,8 +391,8 @@
+ 					struct blkif_x86_32_request *src)
+ {
+ 	int i, n = BLKIF_MAX_SEGMENTS_PER_REQUEST, j;
+-	dst->operation = src->operation;
+-	switch (src->operation) {
++	dst->operation = READ_ONCE(src->operation);
++	switch (dst->operation) {
+ 	case BLKIF_OP_READ:
+ 	case BLKIF_OP_WRITE:
+ 	case BLKIF_OP_WRITE_BARRIER:
+@@ -439,8 +439,8 @@
+ 					struct blkif_x86_64_request *src)
+ {
+ 	int i, n = BLKIF_MAX_SEGMENTS_PER_REQUEST, j;
+-	dst->operation = src->operation;
+-	switch (src->operation) {
++	dst->operation = READ_ONCE(src->operation);
++	switch (dst->operation) {
+ 	case BLKIF_OP_READ:
+ 	case BLKIF_OP_WRITE:
+ 	case BLKIF_OP_WRITE_BARRIER:
+Index: linux-3.18.25/drivers/net/xen-netback/netback.c
+===================================================================
+--- linux-3.18.25.orig/drivers/net/xen-netback/netback.c	2015-12-18 17:29:57.069126636 +0100
++++ linux-3.18.25/drivers/net/xen-netback/netback.c	2015-12-18 17:30:56.134963140 +0100
+@@ -288,18 +288,18 @@
+ 						 struct netrx_pending_operations *npo)
+ {
+ 	struct xenvif_rx_meta *meta;
+-	struct xen_netif_rx_request *req;
++	struct xen_netif_rx_request req;
+ 
+-	req = RING_GET_REQUEST(&queue->rx, queue->rx.req_cons++);
++	RING_COPY_REQUEST(&queue->rx, queue->rx.req_cons++, &req);
+ 
+ 	meta = npo->meta + npo->meta_prod++;
+ 	meta->gso_type = XEN_NETIF_GSO_TYPE_NONE;
+ 	meta->gso_size = 0;
+ 	meta->size = 0;
+-	meta->id = req->id;
++	meta->id = req.id;
+ 
+ 	npo->copy_off = 0;
+-	npo->copy_gref = req->gref;
++	npo->copy_gref = req.gref;
+ 
+ 	return meta;
+ }
+@@ -450,7 +450,7 @@
+ 	struct xenvif *vif = netdev_priv(skb->dev);
+ 	int nr_frags = skb_shinfo(skb)->nr_frags;
+ 	int i;
+-	struct xen_netif_rx_request *req;
++	struct xen_netif_rx_request req;
+ 	struct xenvif_rx_meta *meta;
+ 	unsigned char *data;
+ 	int head = 1;
+@@ -471,15 +471,15 @@
+ 
+ 	/* Set up a GSO prefix descriptor, if necessary */
+ 	if ((1 << gso_type) & vif->gso_prefix_mask) {
+-		req = RING_GET_REQUEST(&queue->rx, queue->rx.req_cons++);
++		RING_COPY_REQUEST(&queue->rx, queue->rx.req_cons++, &req);
+ 		meta = npo->meta + npo->meta_prod++;
+ 		meta->gso_type = gso_type;
+ 		meta->gso_size = skb_shinfo(skb)->gso_size;
+ 		meta->size = 0;
+-		meta->id = req->id;
++		meta->id = req.id;
+ 	}
+ 
+-	req = RING_GET_REQUEST(&queue->rx, queue->rx.req_cons++);
++	RING_COPY_REQUEST(&queue->rx, queue->rx.req_cons++, &req);
+ 	meta = npo->meta + npo->meta_prod++;
+ 
+ 	if ((1 << gso_type) & vif->gso_mask) {
+@@ -491,9 +491,9 @@
+ 	}
+ 
+ 	meta->size = 0;
+-	meta->id = req->id;
++	meta->id = req.id;
+ 	npo->copy_off = 0;
+-	npo->copy_gref = req->gref;
++	npo->copy_gref = req.gref;
+ 
+ 	data = skb->data;
+ 	while (data < skb_tail_pointer(skb)) {
+@@ -809,9 +809,7 @@
+ 	 * Allow a burst big enough to transmit a jumbo packet of up to 128kB.
+ 	 * Otherwise the interface can seize up due to insufficient credit.
+ 	 */
+-	max_burst = RING_GET_REQUEST(&queue->tx, queue->tx.req_cons)->size;
+-	max_burst = min(max_burst, 131072UL);
+-	max_burst = max(max_burst, queue->credit_bytes);
++	max_burst = max(131072UL, queue->credit_bytes);
+ 
+ 	/* Take care that adding a new chunk of credit doesn't wrap to zero. */
+ 	max_credit = queue->remaining_credit + queue->credit_bytes;
+@@ -840,7 +838,7 @@
+ 		spin_unlock_irqrestore(&queue->response_lock, flags);
+ 		if (cons == end)
+ 			break;
+-		txp = RING_GET_REQUEST(&queue->tx, cons++);
++		RING_COPY_REQUEST(&queue->tx, cons++, txp);
+ 	} while (1);
+ 	queue->tx.req_cons = cons;
+ }
+@@ -907,8 +905,7 @@
+ 		if (drop_err)
+ 			txp = &dropped_tx;
+ 
+-		memcpy(txp, RING_GET_REQUEST(&queue->tx, cons + slots),
+-		       sizeof(*txp));
++		RING_COPY_REQUEST(&queue->tx, cons + slots, txp);
+ 
+ 		/* If the guest submitted a frame >= 64 KiB then
+ 		 * first->size overflowed and following slots will
+@@ -1260,8 +1257,7 @@
+ 			return -EBADR;
+ 		}
+ 
+-		memcpy(&extra, RING_GET_REQUEST(&queue->tx, cons),
+-		       sizeof(extra));
++		RING_COPY_REQUEST(&queue->tx, cons, &extra);
+ 		if (unlikely(!extra.type ||
+ 			     extra.type >= XEN_NETIF_EXTRA_TYPE_MAX)) {
+ 			queue->tx.req_cons = ++cons;
+@@ -1397,7 +1393,7 @@
+ 
+ 		idx = queue->tx.req_cons;
+ 		rmb(); /* Ensure that we see the request before we copy it. */
+-		memcpy(&txreq, RING_GET_REQUEST(&queue->tx, idx), sizeof(txreq));
++		RING_COPY_REQUEST(&queue->tx, idx, &txreq);
+ 
+ 		/* Credit-based scheduling. */
+ 		if (txreq.size > queue->remaining_credit &&
+Index: linux-3.18.25/drivers/xen/xen-pciback/pciback.h
+===================================================================
+--- linux-3.18.25.orig/drivers/xen/xen-pciback/pciback.h	2015-12-18 17:29:54.979156011 +0100
++++ linux-3.18.25/drivers/xen/xen-pciback/pciback.h	2015-12-18 17:31:04.464846070 +0100
+@@ -37,6 +37,7 @@
+ 	struct xen_pci_sharedinfo *sh_info;
+ 	unsigned long flags;
+ 	struct work_struct op_work;
++	struct xen_pci_op op;
+ };
+ 
+ struct xen_pcibk_dev_data {
+Index: linux-3.18.25/drivers/xen/xen-pciback/pciback_ops.c
+===================================================================
+--- linux-3.18.25.orig/drivers/xen/xen-pciback/pciback_ops.c	2015-12-18 17:29:54.979156011 +0100
++++ linux-3.18.25/drivers/xen/xen-pciback/pciback_ops.c	2015-12-21 15:28:25.115529706 +0100
+@@ -298,9 +298,11 @@
+ 		container_of(data, struct xen_pcibk_device, op_work);
+ 	struct pci_dev *dev;
+ 	struct xen_pcibk_dev_data *dev_data = NULL;
+-	struct xen_pci_op *op = &pdev->sh_info->op;
++	struct xen_pci_op *op = &pdev->op;
+ 	int test_intx = 0;
+ 
++	*op = pdev->sh_info->op;
++	barrier();
+ 	dev = xen_pcibk_get_pci_dev(pdev, op->domain, op->bus, op->devfn);
+ 
+ 	if (dev == NULL)
+@@ -342,6 +344,17 @@
+ 		if ((dev_data->enable_intx != test_intx))
+ 			xen_pcibk_control_isr(dev, 0 /* no reset */);
+ 	}
++	pdev->sh_info->op.err = op->err;
++	pdev->sh_info->op.value = op->value;
++#ifdef CONFIG_PCI_MSI
++	if (op->cmd == XEN_PCI_OP_enable_msix && op->err == 0) {
++		unsigned int i;
++
++		for (i = 0; i < op->value; i++)
++			pdev->sh_info->op.msix_entries[i].vector =
++				op->msix_entries[i].vector;
++	}
++#endif
+ 	/* Tell the driver domain that we're done. */
+ 	wmb();
+ 	clear_bit(_XEN_PCIF_active, (unsigned long *)&pdev->sh_info->flags);
+Index: linux-3.18.25/drivers/xen/xen-scsiback.c
+===================================================================
+--- linux-3.18.25.orig/drivers/xen/xen-scsiback.c	2015-12-18 17:29:55.469149124 +0100
++++ linux-3.18.25/drivers/xen/xen-scsiback.c	2015-12-21 15:29:01.241696843 +0100
+@@ -737,7 +737,7 @@
+ 		if (!pending_req)
+ 			return 1;
+ 
+-		ring_req = *RING_GET_REQUEST(ring, rc);
++		RING_COPY_REQUEST(ring, rc, &ring_req);
+ 		ring->req_cons = ++rc;
+ 
+ 		err = prepare_pending_reqs(info, &ring_req, pending_req);

--- a/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-add-RING_COPY_RESPONSE.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-add-RING_COPY_RESPONSE.patch
@@ -1,0 +1,53 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+QSB-023 (https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-023-2015)
+XSA-155 additional patches for the Xen network and block frontends from Qubes
+OS Project.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: https://github.com/QubesOS/qubes-linux-kernel/tree/stable-3.18/patches.xen
+Patch: xsa155-linux-0008-xen-Add-RING_COPY_RESPONSE.patch
+
+Using RING_GET_RESPONSE() on a shared ring is easy to use incorrectly
+(i.e., by not considering that the other end may alter the data in the
+shared ring while it is being inspected).  Safe usage of a response
+generally requires taking a local copy.
+
+Provide a RING_COPY_RESPONSE() macro to use instead of
+RING_GET_RESPONSE() and an open-coded memcpy().  This takes care of
+ensuring that the copy is done correctly regardless of any possible
+compiler optimizations.
+
+Use a volatile source to prevent the compiler from reordering or
+omitting the copy.
+
+################################################################################
+PATCHES 
+################################################################################
+--- a/include/xen/interface/io/ring.h
++++ b/include/xen/interface/io/ring.h
+@@ -198,6 +198,20 @@ struct __name##_back_ring {						\
+ #define RING_GET_RESPONSE(_r, _idx)					\
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].rsp))
+ 
++/*
++ * Get a local copy of a response.
++ *
++ * Use this in preference to RING_GET_RESPONSE() so all processing is
++ * done on a local copy that cannot be modified by the other end.
++ *
++ * Note that https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58145 may cause this
++ * to be ineffective where _rsp is a struct which consists of only bitfields.
++ */
++#define RING_COPY_RESPONSE(_r, _idx, _rsp) do {				\
++	/* Use volatile to force the copy into _rsp. */			\
++	*(_rsp) = *(volatile typeof(_rsp))RING_GET_RESPONSE(_r, _idx);	\
++} while (0)
++
+ /* Loop termination condition: Would the specified index overflow the ring? */
+ #define RING_REQUEST_CONS_OVERFLOW(_r, _cons)				\
+     (((_cons) - (_r)->rsp_prod_pvt) >= RING_SIZE(_r))
+

--- a/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-blkfront-make-local-copy-of-response-before-usin.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-blkfront-make-local-copy-of-response-before-usin.patch
@@ -1,0 +1,114 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+QSB-023 (https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-023-2015)
+XSA-155 additional patches for the Xen network and block frontends from Qubes
+OS Project.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: https://github.com/QubesOS/qubes-linux-kernel/tree/stable-3.18/patches.xen
+Patch: xsa155-linux312-0012-xen-blkfront-make-local-copy-of-response-before-usin.patch
+
+Data on the shared page can be changed at any time by the backend. Make
+a local copy, which is no longer controlled by the backend. And only
+then access it.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/block/xen-blkfront.c
+===================================================================
+--- linux-3.18.25.orig/drivers/block/xen-blkfront.c	2015-12-15 18:45:27.000000000 +0100
++++ linux-3.18.25/drivers/block/xen-blkfront.c	2015-12-22 15:09:48.830291194 +0100
+@@ -1113,7 +1113,7 @@
+ static irqreturn_t blkif_interrupt(int irq, void *dev_id)
+ {
+ 	struct request *req;
+-	struct blkif_response *bret;
++	struct blkif_response bret;
+ 	RING_IDX i, rp;
+ 	unsigned long flags;
+ 	struct blkfront_info *info = (struct blkfront_info *)dev_id;
+@@ -1133,8 +1133,8 @@
+ 	for (i = info->ring.rsp_cons; i != rp; i++) {
+ 		unsigned long id;
+ 
+-		bret = RING_GET_RESPONSE(&info->ring, i);
+-		id   = bret->id;
++		RING_COPY_RESPONSE(&info->ring, i, &bret);
++		id   = bret.id;
+ 		/*
+ 		 * The backend has messed up and given us an id that we would
+ 		 * never have given to it (we stamp it up to BLK_RING_SIZE -
+@@ -1142,29 +1142,29 @@
+ 		 */
+ 		if (id >= BLK_RING_SIZE) {
+ 			WARN(1, "%s: response to %s has incorrect id (%ld)\n",
+-			     info->gd->disk_name, op_name(bret->operation), id);
++			     info->gd->disk_name, op_name(bret.operation), id);
+ 			/* We can't safely get the 'struct request' as
+ 			 * the id is busted. */
+ 			continue;
+ 		}
+ 		req  = info->shadow[id].request;
+ 
+-		if (bret->operation != BLKIF_OP_DISCARD)
+-			blkif_completion(&info->shadow[id], info, bret);
++		if (bret.operation != BLKIF_OP_DISCARD)
++			blkif_completion(&info->shadow[id], info, &bret);
+ 
+ 		if (add_id_to_freelist(info, id)) {
+ 			WARN(1, "%s: response to %s (id %ld) couldn't be recycled!\n",
+-			     info->gd->disk_name, op_name(bret->operation), id);
++			     info->gd->disk_name, op_name(bret.operation), id);
+ 			continue;
+ 		}
+ 
+-		error = (bret->status == BLKIF_RSP_OKAY) ? 0 : -EIO;
+-		switch (bret->operation) {
++		error = (bret.status == BLKIF_RSP_OKAY) ? 0 : -EIO;
++		switch (bret.operation) {
+ 		case BLKIF_OP_DISCARD:
+-			if (unlikely(bret->status == BLKIF_RSP_EOPNOTSUPP)) {
++			if (unlikely(bret.status == BLKIF_RSP_EOPNOTSUPP)) {
+ 				struct request_queue *rq = info->rq;
+ 				printk(KERN_WARNING "blkfront: %s: %s op failed\n",
+-					   info->gd->disk_name, op_name(bret->operation));
++					   info->gd->disk_name, op_name(bret.operation));
+ 				error = -EOPNOTSUPP;
+ 				info->feature_discard = 0;
+ 				info->feature_secdiscard = 0;
+@@ -1175,15 +1175,15 @@
+ 			break;
+ 		case BLKIF_OP_FLUSH_DISKCACHE:
+ 		case BLKIF_OP_WRITE_BARRIER:
+-			if (unlikely(bret->status == BLKIF_RSP_EOPNOTSUPP)) {
++			if (unlikely(bret.status == BLKIF_RSP_EOPNOTSUPP)) {
+ 				printk(KERN_WARNING "blkfront: %s: %s op failed\n",
+-				       info->gd->disk_name, op_name(bret->operation));
++				       info->gd->disk_name, op_name(bret.operation));
+ 				error = -EOPNOTSUPP;
+ 			}
+-			if (unlikely(bret->status == BLKIF_RSP_ERROR &&
++			if (unlikely(bret.status == BLKIF_RSP_ERROR &&
+ 				     info->shadow[id].req.u.rw.nr_segments == 0)) {
+ 				printk(KERN_WARNING "blkfront: %s: empty %s op failed\n",
+-				       info->gd->disk_name, op_name(bret->operation));
++				       info->gd->disk_name, op_name(bret.operation));
+ 				error = -EOPNOTSUPP;
+ 			}
+ 			if (unlikely(error)) {
+@@ -1196,9 +1196,9 @@
+ 			/* fall through */
+ 		case BLKIF_OP_READ:
+ 		case BLKIF_OP_WRITE:
+-			if (unlikely(bret->status != BLKIF_RSP_OKAY))
++			if (unlikely(bret.status != BLKIF_RSP_OKAY))
+ 				dev_dbg(&info->xbdev->dev, "Bad return from blkdev data "
+-					"request: %x\n", bret->status);
++					"request: %x\n", bret.status);
+ 
+ 			__blk_end_request_all(req, error);
+ 			break;

--- a/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-blkfront-prepare-request-locally-only-then-put-i.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-blkfront-prepare-request-locally-only-then-put-i.patch
@@ -1,0 +1,147 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+QSB-023 (https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-023-2015)
+XSA-155 additional patches for the Xen network and block frontends from Qubes
+OS Project.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: https://github.com/QubesOS/qubes-linux-kernel/tree/stable-3.18/patches.xen
+Patch: xsa155-linux318-0013-xen-blkfront-prepare-request-locally-only-then-put-i.patch 
+
+Do not reuse data which theoretically might be already modified by the
+backend. This is mostly about private copy of the request
+(info->shadow[id].req) - make sure the request saved there is really the
+one just filled.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/block/xen-blkfront.c
+===================================================================
+--- linux-3.18.25.orig/drivers/block/xen-blkfront.c	2015-12-22 15:09:48.830291194 +0100
++++ linux-3.18.25/drivers/block/xen-blkfront.c	2015-12-22 15:11:37.349169528 +0100
+@@ -389,7 +389,7 @@
+ static int blkif_queue_request(struct request *req)
+ {
+ 	struct blkfront_info *info = req->rq_disk->private_data;
+-	struct blkif_request *ring_req;
++	struct blkif_request ring_req;
+ 	unsigned long id;
+ 	unsigned int fsect, lsect;
+ 	int i, ref, n;
+@@ -434,42 +434,42 @@
+ 		new_persistent_gnts = 0;
+ 
+ 	/* Fill out a communications ring structure. */
+-	ring_req = RING_GET_REQUEST(&info->ring, info->ring.req_prod_pvt);
++	RING_COPY_REQUEST(&info->ring, info->ring.req_prod_pvt, &ring_req);
+ 	id = get_id_from_freelist(info);
+ 	info->shadow[id].request = req;
+ 
+ 	if (unlikely(req->cmd_flags & (REQ_DISCARD | REQ_SECURE))) {
+-		ring_req->operation = BLKIF_OP_DISCARD;
+-		ring_req->u.discard.nr_sectors = blk_rq_sectors(req);
+-		ring_req->u.discard.id = id;
+-		ring_req->u.discard.sector_number = (blkif_sector_t)blk_rq_pos(req);
++		ring_req.operation = BLKIF_OP_DISCARD;
++		ring_req.u.discard.nr_sectors = blk_rq_sectors(req);
++		ring_req.u.discard.id = id;
++		ring_req.u.discard.sector_number = (blkif_sector_t)blk_rq_pos(req);
+ 		if ((req->cmd_flags & REQ_SECURE) && info->feature_secdiscard)
+-			ring_req->u.discard.flag = BLKIF_DISCARD_SECURE;
++			ring_req.u.discard.flag = BLKIF_DISCARD_SECURE;
+ 		else
+-			ring_req->u.discard.flag = 0;
++			ring_req.u.discard.flag = 0;
+ 	} else {
+ 		BUG_ON(info->max_indirect_segments == 0 &&
+ 		       req->nr_phys_segments > BLKIF_MAX_SEGMENTS_PER_REQUEST);
+ 		BUG_ON(info->max_indirect_segments &&
+ 		       req->nr_phys_segments > info->max_indirect_segments);
+ 		nseg = blk_rq_map_sg(req->q, req, info->shadow[id].sg);
+-		ring_req->u.rw.id = id;
++		ring_req.u.rw.id = id;
+ 		if (nseg > BLKIF_MAX_SEGMENTS_PER_REQUEST) {
+ 			/*
+ 			 * The indirect operation can only be a BLKIF_OP_READ or
+ 			 * BLKIF_OP_WRITE
+ 			 */
+ 			BUG_ON(req->cmd_flags & (REQ_FLUSH | REQ_FUA));
+-			ring_req->operation = BLKIF_OP_INDIRECT;
+-			ring_req->u.indirect.indirect_op = rq_data_dir(req) ?
++			ring_req.operation = BLKIF_OP_INDIRECT;
++			ring_req.u.indirect.indirect_op = rq_data_dir(req) ?
+ 				BLKIF_OP_WRITE : BLKIF_OP_READ;
+-			ring_req->u.indirect.sector_number = (blkif_sector_t)blk_rq_pos(req);
+-			ring_req->u.indirect.handle = info->handle;
+-			ring_req->u.indirect.nr_segments = nseg;
++			ring_req.u.indirect.sector_number = (blkif_sector_t)blk_rq_pos(req);
++			ring_req.u.indirect.handle = info->handle;
++			ring_req.u.indirect.nr_segments = nseg;
+ 		} else {
+-			ring_req->u.rw.sector_number = (blkif_sector_t)blk_rq_pos(req);
+-			ring_req->u.rw.handle = info->handle;
+-			ring_req->operation = rq_data_dir(req) ?
++			ring_req.u.rw.sector_number = (blkif_sector_t)blk_rq_pos(req);
++			ring_req.u.rw.handle = info->handle;
++			ring_req.operation = rq_data_dir(req) ?
+ 				BLKIF_OP_WRITE : BLKIF_OP_READ;
+ 			if (req->cmd_flags & (REQ_FLUSH | REQ_FUA)) {
+ 				/*
+@@ -479,15 +479,15 @@
+ 				 * way.  (It's also a FLUSH+FUA, since it is
+ 				 * guaranteed ordered WRT previous writes.)
+ 				 */
+-				ring_req->operation = info->flush_op;
++				ring_req.operation = info->flush_op;
+ 			}
+-			ring_req->u.rw.nr_segments = nseg;
++			ring_req.u.rw.nr_segments = nseg;
+ 		}
+ 		for_each_sg(info->shadow[id].sg, sg, nseg, i) {
+ 			fsect = sg->offset >> 9;
+ 			lsect = fsect + (sg->length >> 9) - 1;
+ 
+-			if ((ring_req->operation == BLKIF_OP_INDIRECT) &&
++			if ((ring_req.operation == BLKIF_OP_INDIRECT) &&
+ 			    (i % SEGS_PER_INDIRECT_FRAME == 0)) {
+ 				unsigned long uninitialized_var(pfn);
+ 
+@@ -508,7 +508,7 @@
+ 				gnt_list_entry = get_grant(&gref_head, pfn, info);
+ 				info->shadow[id].indirect_grants[n] = gnt_list_entry;
+ 				segments = kmap_atomic(pfn_to_page(gnt_list_entry->pfn));
+-				ring_req->u.indirect.indirect_grefs[n] = gnt_list_entry->gref;
++				ring_req.u.indirect.indirect_grefs[n] = gnt_list_entry->gref;
+ 			}
+ 
+ 			gnt_list_entry = get_grant(&gref_head, page_to_pfn(sg_page(sg)), info);
+@@ -541,8 +541,8 @@
+ 				kunmap_atomic(bvec_data);
+ 				kunmap_atomic(shared_data);
+ 			}
+-			if (ring_req->operation != BLKIF_OP_INDIRECT) {
+-				ring_req->u.rw.seg[i] =
++			if (ring_req.operation != BLKIF_OP_INDIRECT) {
++				ring_req.u.rw.seg[i] =
+ 						(struct blkif_request_segment) {
+ 							.gref       = ref,
+ 							.first_sect = fsect,
+@@ -560,10 +560,13 @@
+ 			kunmap_atomic(segments);
+ 	}
+ 
++	/* make the request available to the backend */
++	*RING_GET_REQUEST(&info->ring, info->ring.req_prod_pvt) = ring_req;
++	wmb();
+ 	info->ring.req_prod_pvt++;
+ 
+ 	/* Keep a private copy so we can reissue requests when recovering. */
+-	info->shadow[id].req = *ring_req;
++	info->shadow[id].req = ring_req;
+ 
+ 	if (new_persistent_gnts)
+ 		gnttab_free_grant_references(gref_head);

--- a/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch
@@ -1,0 +1,31 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+QSB-023 (https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-023-2015)
+XSA-155 additional patches for the Xen network and block frontends from Qubes
+OS Project.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: https://github.com/QubesOS/qubes-linux-kernel/tree/stable-3.18/patches.xen
+Patch: xsa155-linux-0011-xen-netfront-add-range-check-for-Tx-response-id.patch
+
+Tx response ID is fetched from shared page, so make sure it is sane
+before using it as an array index.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/net/xen-netfront.c
+===================================================================
+--- linux-3.18.25.orig/drivers/net/xen-netfront.c	2015-12-22 15:07:51.708167142 +0100
++++ linux-3.18.25/drivers/net/xen-netfront.c	2015-12-22 15:08:49.197573727 +0100
+@@ -413,6 +413,7 @@
+ 				continue;
+ 
+ 			id  = txrsp.id;
++			BUG_ON(id >= NET_TX_RING_SIZE);
+ 			skb = queue->tx_skbs[id].skb;
+ 			if (unlikely(gnttab_query_foreign_access(
+ 				queue->grant_tx_ref[id]) != 0)) {

--- a/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch
@@ -1,0 +1,175 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+QSB-023 (https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-023-2015)
+XSA-155 additional patches for the Xen network and block frontends from Qubes
+OS Project.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: https://github.com/QubesOS/qubes-linux-kernel/tree/stable-3.18/patches.xen
+Patch: xsa155-linux318-0009-xen-netfront-copy-response-out-of-shared-buffer-befo.patch
+
+Make local copy of the response, otherwise backend might modify it while
+frontend is already processing it - leading to time of check / time of
+use issue.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/net/xen-netfront.c
+===================================================================
+--- linux-3.18.25.orig/drivers/net/xen-netfront.c	2015-12-22 15:05:11.866481941 +0100
++++ linux-3.18.25/drivers/net/xen-netfront.c	2015-12-22 15:06:15.202495868 +0100
+@@ -406,13 +406,13 @@
+ 		rmb(); /* Ensure we see responses up to 'rp'. */
+ 
+ 		for (cons = queue->tx.rsp_cons; cons != prod; cons++) {
+-			struct xen_netif_tx_response *txrsp;
++			struct xen_netif_tx_response txrsp;
+ 
+-			txrsp = RING_GET_RESPONSE(&queue->tx, cons);
+-			if (txrsp->status == XEN_NETIF_RSP_NULL)
++			RING_COPY_RESPONSE(&queue->tx, cons, &txrsp);
++			if (txrsp.status == XEN_NETIF_RSP_NULL)
+ 				continue;
+ 
+-			id  = txrsp->id;
++			id  = txrsp.id;
+ 			skb = queue->tx_skbs[id].skb;
+ 			if (unlikely(gnttab_query_foreign_access(
+ 				queue->grant_tx_ref[id]) != 0)) {
+@@ -748,7 +748,7 @@
+ 			     RING_IDX rp)
+ 
+ {
+-	struct xen_netif_extra_info *extra;
++	struct xen_netif_extra_info extra;
+ 	struct device *dev = &queue->info->netdev->dev;
+ 	RING_IDX cons = queue->rx.rsp_cons;
+ 	int err = 0;
+@@ -764,24 +764,23 @@
+ 			break;
+ 		}
+ 
+-		extra = (struct xen_netif_extra_info *)
+-			RING_GET_RESPONSE(&queue->rx, ++cons);
++		RING_COPY_RESPONSE(&queue->rx, ++cons, &extra);
+ 
+-		if (unlikely(!extra->type ||
+-			     extra->type >= XEN_NETIF_EXTRA_TYPE_MAX)) {
++		if (unlikely(!extra.type ||
++			     extra.type >= XEN_NETIF_EXTRA_TYPE_MAX)) {
+ 			if (net_ratelimit())
+ 				dev_warn(dev, "Invalid extra type: %d\n",
+-					extra->type);
++					extra.type);
+ 			err = -EINVAL;
+ 		} else {
+-			memcpy(&extras[extra->type - 1], extra,
+-			       sizeof(*extra));
++			memcpy(&extras[extra.type - 1], &extra,
++			       sizeof(extra));
+ 		}
+ 
+ 		skb = xennet_get_rx_skb(queue, cons);
+ 		ref = xennet_get_rx_ref(queue, cons);
+ 		xennet_move_rx_slot(queue, skb, ref);
+-	} while (extra->flags & XEN_NETIF_EXTRA_FLAG_MORE);
++	} while (extra.flags & XEN_NETIF_EXTRA_FLAG_MORE);
+ 
+ 	queue->rx.rsp_cons = cons;
+ 	return err;
+@@ -791,28 +790,28 @@
+ 				struct netfront_rx_info *rinfo, RING_IDX rp,
+ 				struct sk_buff_head *list)
+ {
+-	struct xen_netif_rx_response *rx = &rinfo->rx;
++	struct xen_netif_rx_response rx = rinfo->rx;
+ 	struct xen_netif_extra_info *extras = rinfo->extras;
+ 	struct device *dev = &queue->info->netdev->dev;
+ 	RING_IDX cons = queue->rx.rsp_cons;
+ 	struct sk_buff *skb = xennet_get_rx_skb(queue, cons);
+ 	grant_ref_t ref = xennet_get_rx_ref(queue, cons);
+-	int max = MAX_SKB_FRAGS + (rx->status <= RX_COPY_THRESHOLD);
++	int max = MAX_SKB_FRAGS + (rx.status <= RX_COPY_THRESHOLD);
+ 	int slots = 1;
+ 	int err = 0;
+ 	unsigned long ret;
+ 
+-	if (rx->flags & XEN_NETRXF_extra_info) {
++	if (rx.flags & XEN_NETRXF_extra_info) {
+ 		err = xennet_get_extras(queue, extras, rp);
+ 		cons = queue->rx.rsp_cons;
+ 	}
+ 
+ 	for (;;) {
+-		if (unlikely(rx->status < 0 ||
+-			     rx->offset + rx->status > PAGE_SIZE)) {
++		if (unlikely(rx.status < 0 ||
++			     rx.offset + rx.status > PAGE_SIZE)) {
+ 			if (net_ratelimit())
+ 				dev_warn(dev, "rx->offset: %x, size: %u\n",
+-					 rx->offset, rx->status);
++					 rx.offset, rx.status);
+ 			xennet_move_rx_slot(queue, skb, ref);
+ 			err = -EINVAL;
+ 			goto next;
+@@ -826,7 +825,7 @@
+ 		if (ref == GRANT_INVALID_REF) {
+ 			if (net_ratelimit())
+ 				dev_warn(dev, "Bad rx response id %d.\n",
+-					 rx->id);
++					 rx.id);
+ 			err = -EINVAL;
+ 			goto next;
+ 		}
+@@ -839,7 +838,7 @@
+ 		__skb_queue_tail(list, skb);
+ 
+ next:
+-		if (!(rx->flags & XEN_NETRXF_more_data))
++		if (!(rx.flags & XEN_NETRXF_more_data))
+ 			break;
+ 
+ 		if (cons + slots == rp) {
+@@ -849,7 +848,7 @@
+ 			break;
+ 		}
+ 
+-		rx = RING_GET_RESPONSE(&queue->rx, cons + slots);
++		RING_COPY_RESPONSE(&queue->rx, cons + slots, &rx);
+ 		skb = xennet_get_rx_skb(queue, cons + slots);
+ 		ref = xennet_get_rx_ref(queue, cons + slots);
+ 		slots++;
+@@ -905,9 +904,9 @@
+ 	struct sk_buff *nskb;
+ 
+ 	while ((nskb = __skb_dequeue(list))) {
+-		struct xen_netif_rx_response *rx =
+-			RING_GET_RESPONSE(&queue->rx, ++cons);
++		struct xen_netif_rx_response rx;
+ 		skb_frag_t *nfrag = &skb_shinfo(nskb)->frags[0];
++		RING_COPY_RESPONSE(&queue->rx, ++cons, &rx);
+ 
+ 		if (shinfo->nr_frags == MAX_SKB_FRAGS) {
+ 			unsigned int pull_to = NETFRONT_SKB_CB(skb)->pull_to;
+@@ -918,7 +917,7 @@
+ 		BUG_ON(shinfo->nr_frags >= MAX_SKB_FRAGS);
+ 
+ 		skb_add_rx_frag(skb, shinfo->nr_frags, skb_frag_page(nfrag),
+-				rx->offset, rx->status, PAGE_SIZE);
++				rx.offset, rx.status, PAGE_SIZE);
+ 
+ 		skb_shinfo(nskb)->nr_frags = 0;
+ 		kfree_skb(nskb);
+@@ -1015,7 +1014,7 @@
+ 	i = queue->rx.rsp_cons;
+ 	work_done = 0;
+ 	while ((i != rp) && (work_done < budget)) {
+-		memcpy(rx, RING_GET_RESPONSE(&queue->rx, i), sizeof(*rx));
++		RING_COPY_RESPONSE(&queue->rx, i, rx);
+ 		memset(extras, 0, sizeof(rinfo.extras));
+ 
+ 		err = xennet_get_responses(queue, &rinfo, rp, &tmpq);

--- a/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch
@@ -1,0 +1,47 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+QSB-023 (https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-023-2015)
+XSA-155 additional patches for the Xen network and block frontends from Qubes
+OS Project.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: https://github.com/QubesOS/qubes-linux-kernel/tree/stable-3.18/patches.xen
+Patch: xsa155-linux318-0010-xen-netfront-do-not-use-data-already-exposed-to-back.patch
+
+Backend may freely modify anything on shared page, so use data which was
+supposed to be written there, instead of reading it back from the shared
+page.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/net/xen-netfront.c
+===================================================================
+--- linux-3.18.25.orig/drivers/net/xen-netfront.c	2015-12-22 15:06:54.122094546 +0100
++++ linux-3.18.25/drivers/net/xen-netfront.c	2015-12-22 15:07:15.328542483 +0100
+@@ -457,6 +457,7 @@
+ 	int frags = skb_shinfo(skb)->nr_frags;
+ 	unsigned int offset = offset_in_page(data);
+ 	unsigned int len = skb_headlen(skb);
++	unsigned int size;
+ 	unsigned int id;
+ 	grant_ref_t ref;
+ 	int i;
+@@ -464,10 +465,11 @@
+ 	/* While the header overlaps a page boundary (including being
+ 	   larger than a page), split it it into page-sized chunks. */
+ 	while (len > PAGE_SIZE - offset) {
+-		tx->size = PAGE_SIZE - offset;
++		size = PAGE_SIZE - offset;
++		tx->size = size;
+ 		tx->flags |= XEN_NETTXF_more_data;
+-		len -= tx->size;
+-		data += tx->size;
++		len -= size;
++		data += size;
+ 		offset = 0;
+ 
+ 		id = get_id_from_freelist(&queue->tx_skb_freelist, queue->tx_skbs);

--- a/recipes-kernel/linux/3.18/patches/xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch
@@ -1,0 +1,178 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-157 (http://xenbits.xen.org/xsa/advisory-157.html)
+Linux pciback missing sanity checks leading to crash
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-157.html
+Patches:
+xsa157-0001-xen-pciback-Return-error-on-XEN_PCI_OP_enable_msi-wh.patch
+xsa157-0002-xen-pciback-Return-error-on-XEN_PCI_OP_enable_msix-w.patch
+xsa157-0003-xen-pciback-Do-not-install-an-IRQ-handler-for-MSI-in.patch
+xsa157-0004-xen-pciback-For-XEN_PCI_OP_disable_msi-x-only-disabl.patch
+xsa157-0005-xen-pciback-Don-t-allow-MSI-X-ops-if-PCI_COMMAND_MEM.patch
+
+Xen PCI backend driver does not perform proper sanity checks on the device's
+state.
+
+Which in turn allows the generic MSI code (called by Xen PCI backend) to be
+called incorrectly leading to hitting BUG conditions or causing NULL pointer
+exceptions in the MSI code.  (CVE-2015-8551)
+
+The guest sequence of:
+ a) XEN_PCI_OP_enable_msi
+ b) XEN_PCI_OP_enable_msi
+ c) XEN_PCI_OP_disable_msi
+results in hitting an BUG_ON condition in the msi.c code.
+
+To exploit this the guest can craft specific sequence of XEN_PCI_OP_*
+operations which will trigger this.
+
+Furthermore the frontend can also craft an continous stream of
+XEN_PCI_OP_enable_msi which will trigger an continous stream of WARN() messages
+triggered by the MSI code leading to the logging in the initial domain to
+exhaust disk space.  (CVE-2015-8552)
+
+Lastly there is also missing check to verify whether the device has memory
+decoding enabled set at the start of the day leading the initial domain
+"accesses to the respective MMIO or I/O port ranges would - - on PCI Express
+devices - [which can] lead to Unsupported Request responses.  The treatment of
+such errors is platform specific." (from XSA-120).  Note that if XSA-120
+'addendum' patch (re CVE-2015-8553) has been applied this particular sub-issue
+is not exploitable.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/xen/xen-pciback/pciback_ops.c
+===================================================================
+--- linux-3.18.25.orig/drivers/xen/xen-pciback/pciback_ops.c	2015-12-18 17:31:04.464846070 +0100
++++ linux-3.18.25/drivers/xen/xen-pciback/pciback_ops.c	2015-12-18 17:56:58.186338548 +0100
+@@ -70,6 +70,13 @@
+ 		enable ? "enable" : "disable");
+ 
+ 	if (enable) {
++		/*
++		 * The MSI or MSI-X should not have an IRQ handler. Otherwise
++		 * if the guest terminates we BUG_ON in free_msi_irqs.
++		 */
++		if (dev->msi_enabled || dev->msix_enabled)
++			goto out;
++
+ 		rc = request_irq(dev_data->irq,
+ 				xen_pcibk_guest_interrupt, IRQF_SHARED,
+ 				dev_data->irq_name, dev);
+@@ -144,7 +151,12 @@
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: enable MSI\n", pci_name(dev));
+ 
+-	status = pci_enable_msi(dev);
++	if (dev->msi_enabled)
++		status = -EALREADY;
++	else if (dev->msix_enabled)
++		status = -ENXIO;
++	else
++		status = pci_enable_msi(dev);
+ 
+ 	if (status) {
+ 		pr_warn_ratelimited("%s: error enabling MSI for guest %u: err %d\n",
+@@ -173,20 +185,23 @@
+ int xen_pcibk_disable_msi(struct xen_pcibk_device *pdev,
+ 			  struct pci_dev *dev, struct xen_pci_op *op)
+ {
+-	struct xen_pcibk_dev_data *dev_data;
+-
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: disable MSI\n",
+ 		       pci_name(dev));
+-	pci_disable_msi(dev);
+ 
++	if (dev->msi_enabled) {
++		struct xen_pcibk_dev_data *dev_data;
++
++		pci_disable_msi(dev);
++
++		dev_data = pci_get_drvdata(dev);
++		if (dev_data)
++			dev_data->ack_intr = 1;
++	}
+ 	op->value = dev->irq ? xen_pirq_from_irq(dev->irq) : 0;
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: MSI: %d\n", pci_name(dev),
+ 			op->value);
+-	dev_data = pci_get_drvdata(dev);
+-	if (dev_data)
+-		dev_data->ack_intr = 1;
+ 	return 0;
+ }
+ 
+@@ -197,13 +212,26 @@
+ 	struct xen_pcibk_dev_data *dev_data;
+ 	int i, result;
+ 	struct msix_entry *entries;
++	u16 cmd;
+ 
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: enable MSI-X\n",
+ 		       pci_name(dev));
++
+ 	if (op->value > SH_INFO_MAX_VEC)
+ 		return -EINVAL;
+ 
++	if (dev->msix_enabled)
++		return -EALREADY;
++
++	/*
++	 * PCI_COMMAND_MEMORY must be enabled, otherwise we may not be able
++	 * to access the BARs where the MSI-X entries reside.
++	 */
++	pci_read_config_word(dev, PCI_COMMAND, &cmd);
++	if (dev->msi_enabled || !(cmd & PCI_COMMAND_MEMORY))
++		return -ENXIO;
++
+ 	entries = kmalloc(op->value * sizeof(*entries), GFP_KERNEL);
+ 	if (entries == NULL)
+ 		return -ENOMEM;
+@@ -245,23 +273,27 @@
+ int xen_pcibk_disable_msix(struct xen_pcibk_device *pdev,
+ 			   struct pci_dev *dev, struct xen_pci_op *op)
+ {
+-	struct xen_pcibk_dev_data *dev_data;
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: disable MSI-X\n",
+ 			pci_name(dev));
+-	pci_disable_msix(dev);
+ 
++	if (dev->msix_enabled) {
++		struct xen_pcibk_dev_data *dev_data;
++
++		pci_disable_msix(dev);
++
++		dev_data = pci_get_drvdata(dev);
++		if (dev_data)
++			dev_data->ack_intr = 1;
++	}
+ 	/*
+ 	 * SR-IOV devices (which don't have any legacy IRQ) have
+ 	 * an undefined IRQ value of zero.
+ 	 */
+ 	op->value = dev->irq ? xen_pirq_from_irq(dev->irq) : 0;
+ 	if (unlikely(verbose_request))
+-		printk(KERN_DEBUG DRV_NAME ": %s: MSI-X: %d\n", pci_name(dev),
+-			op->value);
+-	dev_data = pci_get_drvdata(dev);
+-	if (dev_data)
+-		dev_data->ack_intr = 1;
++		printk(KERN_DEBUG DRV_NAME ": %s: MSI-X: %d\n",
++		       pci_name(dev), op->value);
+ 	return 0;
+ }
+ #endif

--- a/recipes-kernel/linux/3.18/patches/xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch
+++ b/recipes-kernel/linux/3.18/patches/xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch
@@ -45,11 +45,6 @@ such errors is platform specific." (from XSA-120).  Note that if XSA-120
 is not exploitable.
 
 ################################################################################
-CHANGELOG 
-################################################################################
-Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
-
-################################################################################
 PATCHES 
 ################################################################################
 Index: linux-3.18.25/drivers/xen/xen-pciback/pciback_ops.c

--- a/recipes-kernel/linux/4.1/linux-openxt_4.1.13.bb
+++ b/recipes-kernel/linux/4.1/linux-openxt_4.1.13.bb
@@ -40,6 +40,8 @@ SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.t
     file://xenstore-no-read-vs-write-atomicity.patch;patch=1 \
     file://pciback-restrictive-attr.patch;patch=1 \
     file://thorough-reset-interface-to-pciback-s-sysfs.patch;patch=1 \
+    file://xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch;patch=1 \
+    file://xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch;patch=1 \
     file://defconfig \
     "
 

--- a/recipes-kernel/linux/4.1/patches/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
+++ b/recipes-kernel/linux/4.1/patches/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
@@ -1,0 +1,293 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-155 (http://xenbits.xen.org/xsa/advisory-155.html)
+paravirtualized drivers incautious about shared memory contents
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-155.html
+Patches:
+xsa155-linux-xsa155-0001-xen-Add-RING_COPY_REQUEST.patch
+xsa155-linux-xsa155-0002-xen-netback-don-t-use-last-request-to-determine-mini.patch
+xsa155-linux-xsa155-0003-xen-netback-use-RING_COPY_REQUEST-throughout.patch
+xsa155-linux-xsa155-0004-xen-blkback-only-read-request-operation-from-shared-.patch
+xsa155-linux43-0005-xen-blkback-read-from-indirect-descriptors-only-once.patch
+xsa155-linux-xsa155-0006-xen-scsiback-safely-copy-requests.patch
+xsa155-linux-xsa155-0007-xen-pciback-Save-xen_pci_op-commands-before-processi.patch
+         
+The compiler can emit optimizations in the PV backend drivers which can lead to
+double fetch vulnerabilities. Specifically the shared memory between the
+frontend and backend can be fetched twice (during which time the frontend can
+alter the contents) possibly leading to arbitrary code execution in
+backend.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-4.1.13/include/xen/interface/io/ring.h
+===================================================================
+--- linux-4.1.13.orig/include/xen/interface/io/ring.h	2015-12-21 14:35:10.823746936 +0100
++++ linux-4.1.13/include/xen/interface/io/ring.h	2015-12-21 14:35:12.330392414 +0100
+@@ -181,6 +181,20 @@
+ #define RING_GET_REQUEST(_r, _idx)					\
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].req))
+ 
++/*
++ * Get a local copy of a request.
++ *
++ * Use this in preference to RING_GET_REQUEST() so all processing is
++ * done on a local copy that cannot be modified by the other end.
++ *
++ * Note that https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58145 may cause this
++ * to be ineffective where _req is a struct which consists of only bitfields.
++ */
++#define RING_COPY_REQUEST(_r, _idx, _req) do {				\
++	/* Use volatile to force the copy into _req. */			\
++	*(_req) = *(volatile typeof(_req))RING_GET_REQUEST(_r, _idx);	\
++} while (0)
++
+ #define RING_GET_RESPONSE(_r, _idx)					\
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].rsp))
+ 
+Index: linux-4.1.13/drivers/block/xen-blkback/blkback.c
+===================================================================
+--- linux-4.1.13.orig/drivers/block/xen-blkback/blkback.c	2015-12-21 14:37:24.431867530 +0100
++++ linux-4.1.13/drivers/block/xen-blkback/blkback.c	2015-12-21 14:37:39.044995257 +0100
+@@ -943,6 +943,8 @@
+ 		goto unmap;
+ 
+ 	for (n = 0, i = 0; n < nseg; n++) {
++		uint8_t first_sect, last_sect;
++
+ 		if ((n % SEGS_PER_INDIRECT_FRAME) == 0) {
+ 			/* Map indirect segments */
+ 			if (segments)
+@@ -951,14 +953,14 @@
+ 		}
+ 		i = n % SEGS_PER_INDIRECT_FRAME;
+ 		pending_req->segments[n]->gref = segments[i].gref;
+-		seg[n].nsec = segments[i].last_sect -
+-			segments[i].first_sect + 1;
+-		seg[n].offset = (segments[i].first_sect << 9);
+-		if ((segments[i].last_sect >= (PAGE_SIZE >> 9)) ||
+-		    (segments[i].last_sect < segments[i].first_sect)) {
++		first_sect = READ_ONCE(segments[i].first_sect);
++		last_sect = READ_ONCE(segments[i].last_sect);
++		if (last_sect >= (PAGE_SIZE >> 9) || last_sect < first_sect) {
+ 			rc = -EINVAL;
+ 			goto unmap;
+ 		}
++		seg[n].nsec = last_sect - first_sect + 1;
++		seg[n].offset = first_sect << 9;
+ 		preq->nr_sects += seg[n].nsec;
+ 	}
+ 
+Index: linux-4.1.13/drivers/block/xen-blkback/common.h
+===================================================================
+--- linux-4.1.13.orig/drivers/block/xen-blkback/common.h	2015-12-21 14:37:24.455200535 +0100
++++ linux-4.1.13/drivers/block/xen-blkback/common.h	2015-12-21 14:37:37.485017207 +0100
+@@ -397,8 +397,8 @@
+ 					struct blkif_x86_32_request *src)
+ {
+ 	int i, n = BLKIF_MAX_SEGMENTS_PER_REQUEST, j;
+-	dst->operation = src->operation;
+-	switch (src->operation) {
++	dst->operation = READ_ONCE(src->operation);
++	switch (dst->operation) {
+ 	case BLKIF_OP_READ:
+ 	case BLKIF_OP_WRITE:
+ 	case BLKIF_OP_WRITE_BARRIER:
+@@ -445,8 +445,8 @@
+ 					struct blkif_x86_64_request *src)
+ {
+ 	int i, n = BLKIF_MAX_SEGMENTS_PER_REQUEST, j;
+-	dst->operation = src->operation;
+-	switch (src->operation) {
++	dst->operation = READ_ONCE(src->operation);
++	switch (dst->operation) {
+ 	case BLKIF_OP_READ:
+ 	case BLKIF_OP_WRITE:
+ 	case BLKIF_OP_WRITE_BARRIER:
+Index: linux-4.1.13/drivers/net/xen-netback/netback.c
+===================================================================
+--- linux-4.1.13.orig/drivers/net/xen-netback/netback.c	2015-12-21 14:37:24.505199831 +0100
++++ linux-4.1.13/drivers/net/xen-netback/netback.c	2015-12-21 14:37:35.351713889 +0100
+@@ -247,18 +247,18 @@
+ 						 struct netrx_pending_operations *npo)
+ {
+ 	struct xenvif_rx_meta *meta;
+-	struct xen_netif_rx_request *req;
++	struct xen_netif_rx_request req;
+ 
+-	req = RING_GET_REQUEST(&queue->rx, queue->rx.req_cons++);
++	RING_COPY_REQUEST(&queue->rx, queue->rx.req_cons++, &req);
+ 
+ 	meta = npo->meta + npo->meta_prod++;
+ 	meta->gso_type = XEN_NETIF_GSO_TYPE_NONE;
+ 	meta->gso_size = 0;
+ 	meta->size = 0;
+-	meta->id = req->id;
++	meta->id = req.id;
+ 
+ 	npo->copy_off = 0;
+-	npo->copy_gref = req->gref;
++	npo->copy_gref = req.gref;
+ 
+ 	return meta;
+ }
+@@ -370,7 +370,7 @@
+ 	struct xenvif *vif = netdev_priv(skb->dev);
+ 	int nr_frags = skb_shinfo(skb)->nr_frags;
+ 	int i;
+-	struct xen_netif_rx_request *req;
++	struct xen_netif_rx_request req;
+ 	struct xenvif_rx_meta *meta;
+ 	unsigned char *data;
+ 	int head = 1;
+@@ -389,15 +389,15 @@
+ 
+ 	/* Set up a GSO prefix descriptor, if necessary */
+ 	if ((1 << gso_type) & vif->gso_prefix_mask) {
+-		req = RING_GET_REQUEST(&queue->rx, queue->rx.req_cons++);
++		RING_COPY_REQUEST(&queue->rx, queue->rx.req_cons++, &req);
+ 		meta = npo->meta + npo->meta_prod++;
+ 		meta->gso_type = gso_type;
+ 		meta->gso_size = skb_shinfo(skb)->gso_size;
+ 		meta->size = 0;
+-		meta->id = req->id;
++		meta->id = req.id;
+ 	}
+ 
+-	req = RING_GET_REQUEST(&queue->rx, queue->rx.req_cons++);
++	RING_COPY_REQUEST(&queue->rx, queue->rx.req_cons++, &req);
+ 	meta = npo->meta + npo->meta_prod++;
+ 
+ 	if ((1 << gso_type) & vif->gso_mask) {
+@@ -409,9 +409,9 @@
+ 	}
+ 
+ 	meta->size = 0;
+-	meta->id = req->id;
++	meta->id = req.id;
+ 	npo->copy_off = 0;
+-	npo->copy_gref = req->gref;
++	npo->copy_gref = req.gref;
+ 
+ 	data = skb->data;
+ 	while (data < skb_tail_pointer(skb)) {
+@@ -630,9 +630,7 @@
+ 	 * Allow a burst big enough to transmit a jumbo packet of up to 128kB.
+ 	 * Otherwise the interface can seize up due to insufficient credit.
+ 	 */
+-	max_burst = RING_GET_REQUEST(&queue->tx, queue->tx.req_cons)->size;
+-	max_burst = min(max_burst, 131072UL);
+-	max_burst = max(max_burst, queue->credit_bytes);
++	max_burst = max(131072UL, queue->credit_bytes);
+ 
+ 	/* Take care that adding a new chunk of credit doesn't wrap to zero. */
+ 	max_credit = queue->remaining_credit + queue->credit_bytes;
+@@ -662,7 +660,7 @@
+ 		spin_unlock_irqrestore(&queue->response_lock, flags);
+ 		if (cons == end)
+ 			break;
+-		txp = RING_GET_REQUEST(&queue->tx, cons++);
++		RING_COPY_REQUEST(&queue->tx, cons++, txp);
+ 	} while (1);
+ 	queue->tx.req_cons = cons;
+ }
+@@ -729,8 +727,7 @@
+ 		if (drop_err)
+ 			txp = &dropped_tx;
+ 
+-		memcpy(txp, RING_GET_REQUEST(&queue->tx, cons + slots),
+-		       sizeof(*txp));
++		RING_COPY_REQUEST(&queue->tx, cons + slots, txp);
+ 
+ 		/* If the guest submitted a frame >= 64 KiB then
+ 		 * first->size overflowed and following slots will
+@@ -1076,8 +1073,7 @@
+ 			return -EBADR;
+ 		}
+ 
+-		memcpy(&extra, RING_GET_REQUEST(&queue->tx, cons),
+-		       sizeof(extra));
++		RING_COPY_REQUEST(&queue->tx, cons, &extra);
+ 		if (unlikely(!extra.type ||
+ 			     extra.type >= XEN_NETIF_EXTRA_TYPE_MAX)) {
+ 			queue->tx.req_cons = ++cons;
+@@ -1211,7 +1207,7 @@
+ 
+ 		idx = queue->tx.req_cons;
+ 		rmb(); /* Ensure that we see the request before we copy it. */
+-		memcpy(&txreq, RING_GET_REQUEST(&queue->tx, idx), sizeof(txreq));
++		RING_COPY_REQUEST(&queue->tx, idx, &txreq);
+ 
+ 		/* Credit-based scheduling. */
+ 		if (txreq.size > queue->remaining_credit &&
+Index: linux-4.1.13/drivers/xen/xen-pciback/pciback.h
+===================================================================
+--- linux-4.1.13.orig/drivers/xen/xen-pciback/pciback.h	2015-12-21 14:37:24.385201520 +0100
++++ linux-4.1.13/drivers/xen/xen-pciback/pciback.h	2015-12-21 14:37:42.364948543 +0100
+@@ -37,6 +37,7 @@
+ 	struct xen_pci_sharedinfo *sh_info;
+ 	unsigned long flags;
+ 	struct work_struct op_work;
++	struct xen_pci_op op;
+ };
+ 
+ struct xen_pcibk_dev_data {
+Index: linux-4.1.13/drivers/xen/xen-pciback/pciback_ops.c
+===================================================================
+--- linux-4.1.13.orig/drivers/xen/xen-pciback/pciback_ops.c	2015-12-21 14:37:24.385201520 +0100
++++ linux-4.1.13/drivers/xen/xen-pciback/pciback_ops.c	2015-12-21 14:37:42.364948543 +0100
+@@ -298,9 +298,11 @@
+ 		container_of(data, struct xen_pcibk_device, op_work);
+ 	struct pci_dev *dev;
+ 	struct xen_pcibk_dev_data *dev_data = NULL;
+-	struct xen_pci_op *op = &pdev->sh_info->op;
++	struct xen_pci_op *op = &pdev->op;
+ 	int test_intx = 0;
+ 
++	*op = pdev->sh_info->op;
++	barrier();
+ 	dev = xen_pcibk_get_pci_dev(pdev, op->domain, op->bus, op->devfn);
+ 
+ 	if (dev == NULL)
+@@ -342,6 +344,17 @@
+ 		if ((dev_data->enable_intx != test_intx))
+ 			xen_pcibk_control_isr(dev, 0 /* no reset */);
+ 	}
++	pdev->sh_info->op.err = op->err;
++	pdev->sh_info->op.value = op->value;
++#ifdef CONFIG_PCI_MSI
++	if (op->cmd == XEN_PCI_OP_enable_msix && op->err == 0) {
++		unsigned int i;
++
++		for (i = 0; i < op->value; i++)
++			pdev->sh_info->op.msix_entries[i].vector =
++				op->msix_entries[i].vector;
++	}
++#endif
+ 	/* Tell the driver domain that we're done. */
+ 	wmb();
+ 	clear_bit(_XEN_PCIF_active, (unsigned long *)&pdev->sh_info->flags);
+Index: linux-4.1.13/drivers/xen/xen-scsiback.c
+===================================================================
+--- linux-4.1.13.orig/drivers/xen/xen-scsiback.c	2015-12-21 14:37:24.408534525 +0100
++++ linux-4.1.13/drivers/xen/xen-scsiback.c	2015-12-21 14:37:40.568307156 +0100
+@@ -732,7 +732,7 @@
+ 		if (!pending_req)
+ 			return 1;
+ 
+-		ring_req = *RING_GET_REQUEST(ring, rc);
++		RING_COPY_REQUEST(ring, rc, &ring_req);
+ 		ring->req_cons = ++rc;
+ 
+ 		err = prepare_pending_reqs(info, &ring_req, pending_req);

--- a/recipes-kernel/linux/4.1/patches/xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch
+++ b/recipes-kernel/linux/4.1/patches/xsa-157-linux-pciback-missing-sanity-checks-leading-to-crash.patch
@@ -1,0 +1,178 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-157 (http://xenbits.xen.org/xsa/advisory-157.html)
+Linux pciback missing sanity checks leading to crash
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-157.html
+Patches:
+xsa157-0001-xen-pciback-Return-error-on-XEN_PCI_OP_enable_msi-wh.patch
+xsa157-0002-xen-pciback-Return-error-on-XEN_PCI_OP_enable_msix-w.patch
+xsa157-0003-xen-pciback-Do-not-install-an-IRQ-handler-for-MSI-in.patch
+xsa157-0004-xen-pciback-For-XEN_PCI_OP_disable_msi-x-only-disabl.patch
+xsa157-0005-xen-pciback-Don-t-allow-MSI-X-ops-if-PCI_COMMAND_MEM.patch
+
+Xen PCI backend driver does not perform proper sanity checks on the device's
+state.
+
+Which in turn allows the generic MSI code (called by Xen PCI backend) to be
+called incorrectly leading to hitting BUG conditions or causing NULL pointer
+exceptions in the MSI code.  (CVE-2015-8551)
+
+The guest sequence of:
+ a) XEN_PCI_OP_enable_msi
+ b) XEN_PCI_OP_enable_msi
+ c) XEN_PCI_OP_disable_msi
+results in hitting an BUG_ON condition in the msi.c code.
+
+To exploit this the guest can craft specific sequence of XEN_PCI_OP_*
+operations which will trigger this.
+
+Furthermore the frontend can also craft an continous stream of
+XEN_PCI_OP_enable_msi which will trigger an continous stream of WARN() messages
+triggered by the MSI code leading to the logging in the initial domain to
+exhaust disk space.  (CVE-2015-8552)
+
+Lastly there is also missing check to verify whether the device has memory
+decoding enabled set at the start of the day leading the initial domain
+"accesses to the respective MMIO or I/O port ranges would - - on PCI Express
+devices - [which can] lead to Unsupported Request responses.  The treatment of
+such errors is platform specific." (from XSA-120).  Note that if XSA-120
+'addendum' patch (re CVE-2015-8553) has been applied this particular sub-issue
+is not exploitable.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-4.1.13/drivers/xen/xen-pciback/pciback_ops.c
+===================================================================
+--- linux-4.1.13.orig/drivers/xen/xen-pciback/pciback_ops.c	2015-12-21 14:37:42.364948543 +0100
++++ linux-4.1.13/drivers/xen/xen-pciback/pciback_ops.c	2015-12-21 14:43:49.789809843 +0100
+@@ -70,6 +70,13 @@
+ 		enable ? "enable" : "disable");
+ 
+ 	if (enable) {
++		/*
++		 * The MSI or MSI-X should not have an IRQ handler. Otherwise
++		 * if the guest terminates we BUG_ON in free_msi_irqs.
++		 */
++		if (dev->msi_enabled || dev->msix_enabled)
++			goto out;
++
+ 		rc = request_irq(dev_data->irq,
+ 				xen_pcibk_guest_interrupt, IRQF_SHARED,
+ 				dev_data->irq_name, dev);
+@@ -144,7 +151,12 @@
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: enable MSI\n", pci_name(dev));
+ 
+-	status = pci_enable_msi(dev);
++	if (dev->msi_enabled)
++		status = -EALREADY;
++	else if (dev->msix_enabled)
++		status = -ENXIO;
++	else
++		status = pci_enable_msi(dev);
+ 
+ 	if (status) {
+ 		pr_warn_ratelimited("%s: error enabling MSI for guest %u: err %d\n",
+@@ -173,20 +185,23 @@
+ int xen_pcibk_disable_msi(struct xen_pcibk_device *pdev,
+ 			  struct pci_dev *dev, struct xen_pci_op *op)
+ {
+-	struct xen_pcibk_dev_data *dev_data;
+-
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: disable MSI\n",
+ 		       pci_name(dev));
+-	pci_disable_msi(dev);
+ 
++	if (dev->msi_enabled) {
++		struct xen_pcibk_dev_data *dev_data;
++
++		pci_disable_msi(dev);
++
++		dev_data = pci_get_drvdata(dev);
++		if (dev_data)
++			dev_data->ack_intr = 1;
++	}
+ 	op->value = dev->irq ? xen_pirq_from_irq(dev->irq) : 0;
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: MSI: %d\n", pci_name(dev),
+ 			op->value);
+-	dev_data = pci_get_drvdata(dev);
+-	if (dev_data)
+-		dev_data->ack_intr = 1;
+ 	return 0;
+ }
+ 
+@@ -197,13 +212,26 @@
+ 	struct xen_pcibk_dev_data *dev_data;
+ 	int i, result;
+ 	struct msix_entry *entries;
++	u16 cmd;
+ 
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: enable MSI-X\n",
+ 		       pci_name(dev));
++
+ 	if (op->value > SH_INFO_MAX_VEC)
+ 		return -EINVAL;
+ 
++	if (dev->msix_enabled)
++		return -EALREADY;
++
++	/*
++	 * PCI_COMMAND_MEMORY must be enabled, otherwise we may not be able
++	 * to access the BARs where the MSI-X entries reside.
++	 */
++	pci_read_config_word(dev, PCI_COMMAND, &cmd);
++	if (dev->msi_enabled || !(cmd & PCI_COMMAND_MEMORY))
++		return -ENXIO;
++
+ 	entries = kmalloc(op->value * sizeof(*entries), GFP_KERNEL);
+ 	if (entries == NULL)
+ 		return -ENOMEM;
+@@ -245,23 +273,27 @@
+ int xen_pcibk_disable_msix(struct xen_pcibk_device *pdev,
+ 			   struct pci_dev *dev, struct xen_pci_op *op)
+ {
+-	struct xen_pcibk_dev_data *dev_data;
+ 	if (unlikely(verbose_request))
+ 		printk(KERN_DEBUG DRV_NAME ": %s: disable MSI-X\n",
+ 			pci_name(dev));
+-	pci_disable_msix(dev);
+ 
++	if (dev->msix_enabled) {
++		struct xen_pcibk_dev_data *dev_data;
++
++		pci_disable_msix(dev);
++
++		dev_data = pci_get_drvdata(dev);
++		if (dev_data)
++			dev_data->ack_intr = 1;
++	}
+ 	/*
+ 	 * SR-IOV devices (which don't have any legacy IRQ) have
+ 	 * an undefined IRQ value of zero.
+ 	 */
+ 	op->value = dev->irq ? xen_pirq_from_irq(dev->irq) : 0;
+ 	if (unlikely(verbose_request))
+-		printk(KERN_DEBUG DRV_NAME ": %s: MSI-X: %d\n", pci_name(dev),
+-			op->value);
+-	dev_data = pci_get_drvdata(dev);
+-	if (dev_data)
+-		dev_data->ack_intr = 1;
++		printk(KERN_DEBUG DRV_NAME ": %s: MSI-X: %d\n",
++		       pci_name(dev), op->value);
+ 	return 0;
+ }
+ #endif

--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch
@@ -1,0 +1,90 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-155 (http://xenbits.xen.org/xsa/advisory-155.html)
+paravirtualized drivers incautious about shared memory contents
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-155.html
+Patches:
+xsa155-qemu-qdisk-double-access.patch
+xsa155-qemu-xenfb.patch
+
+The compiler can emit optimizations in the PV backend drivers which can lead to
+double fetch vulnerabilities. Specifically the shared memory between the
+frontend and backend can be fetched twice (during which time the frontend can
+alter the contents) possibly leading to arbitrary code execution in
+backend.
+
+Malicious guest administrators can cause denial of service.  If driver domains
+are not in use, the impact can be a host crash, or privilege escalation.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: qemu-1.4.0/hw/xen_blkif.h
+===================================================================
+--- qemu-1.4.0.orig/hw/xen_blkif.h	2013-02-16 00:05:35.000000000 +0100
++++ qemu-1.4.0/hw/xen_blkif.h	2015-12-18 17:41:52.735738816 +0100
+@@ -79,8 +79,10 @@
+ 	dst->handle = src->handle;
+ 	dst->id = src->id;
+ 	dst->sector_number = src->sector_number;
+-	if (n > src->nr_segments)
+-		n = src->nr_segments;
++	/* prevent the compiler from optimizing the code and using src->nr_segments instead */
++	xen_mb();
++	if (n > dst->nr_segments)
++		n = dst->nr_segments;
+ 	for (i = 0; i < n; i++)
+ 		dst->seg[i] = src->seg[i];
+ }
+@@ -94,8 +96,10 @@
+ 	dst->handle = src->handle;
+ 	dst->id = src->id;
+ 	dst->sector_number = src->sector_number;
+-	if (n > src->nr_segments)
+-		n = src->nr_segments;
++	/* prevent the compiler from optimizing the code and using src->nr_segments instead */
++	xen_mb();
++	if (n > dst->nr_segments)
++		n = dst->nr_segments;
+ 	for (i = 0; i < n; i++)
+ 		dst->seg[i] = src->seg[i];
+ }
+Index: qemu-1.4.0/hw/xenfb.c
+===================================================================
+--- qemu-1.4.0.orig/hw/xenfb.c	2015-12-18 17:44:36.090111599 +0100
++++ qemu-1.4.0/hw/xenfb.c	2015-12-18 17:44:43.846669353 +0100
+@@ -798,18 +798,20 @@
+ 
+ static void xenfb_handle_events(struct XenFB *xenfb)
+ {
+-    uint32_t prod, cons;
++    uint32_t prod, cons, out_cons;
+     struct xenfb_page *page = xenfb->c.page;
+ 
+     prod = page->out_prod;
+-    if (prod == page->out_cons)
++    out_cons = page->out_cons;
++    if (prod == out_cons)
+ 	return;
+     xen_rmb();		/* ensure we see ring contents up to prod */
+-    for (cons = page->out_cons; cons != prod; cons++) {
++    for (cons = out_cons; cons != prod; cons++) {
+ 	union xenfb_out_event *event = &XENFB_OUT_RING_REF(page, cons);
++        uint8_t type = event->type;
+ 	int x, y, w, h;
+ 
+-	switch (event->type) {
++	switch (type) {
+ 	case XENFB_TYPE_UPDATE:
+ 	    if (xenfb->up_count == UP_QUEUE)
+ 		xenfb->up_fullscreen = 1;

--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-162-heap-buffer-overflow-vulnerability-in-pcnet-emulator.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-162-heap-buffer-overflow-vulnerability-in-pcnet-emulator.patch
@@ -1,0 +1,57 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-162 (http://xenbits.xen.org/xsa/advisory-162.html)
+heap buffer overflow vulnerability in pcnet emulator
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-162.html
+Patches: xsa162-qemuu-4.3.patch
+
+The AMD PC-Net II emulator(hw/net/pcnet.c), while receiving packets in loopback
+mode, appends CRC code to the receive buffer. If the data size given is same as
+the buffer size(4096), the appended CRC code overwrites 4 bytes after the
+s->buffer, making the adjacent 's->irq' object point to a new location.
+
+################################################################################
+CHANGELOG 
+################################################################################
+Added in OpenXT, Xen 4.3.4 patch-queue: Eric Chanudet <chanudete@ainfosec.com>
+
+################################################################################
+PATCHES 
+################################################################################
+Index: qemu-1.4.0/hw/pcnet.c
+===================================================================
+--- qemu-1.4.0.orig/hw/pcnet.c	2015-12-14 13:36:38.708012218 +0100
++++ qemu-1.4.0/hw/pcnet.c	2015-12-18 18:11:43.067263486 +0100
+@@ -1103,7 +1103,7 @@
+                 uint32_t fcs = ~0;
+                 uint8_t *p = src;
+ 
+-                while (p != &src[size-4])
++                while (p != &src[size])
+                     CRC(fcs, *p++);
+                 crc_err = (*(uint32_t *)p != htonl(fcs));
+             }
+@@ -1252,12 +1252,13 @@
+         bcnt = 4096 - GET_FIELD(tmd.length, TMDL, BCNT);
+ 
+         /* if multi-tmd packet outsizes s->buffer then skip it silently.
+-           Note: this is not what real hw does */
+-        if (s->xmit_pos + bcnt > sizeof(s->buffer)) {
+-           s->xmit_pos = -1;
+-           goto txdone;
++         * Note: this is not what real hw does.
++         * Last four bytes of s->buffer are used to store CRC FCS code.
++         */
++        if (s->xmit_pos + bcnt > sizeof(s->buffer) - 4) {
++            s->xmit_pos = -1;
++            goto txdone;
+         }
+-
+         s->phys_mem_read(s->dma_opaque, PHYSADDR(s, tmd.tbadr),
+                          s->buffer + s->xmit_pos, bcnt, CSR_BSWP(s));
+         s->xmit_pos += bcnt;

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -57,6 +57,8 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://xsa-138-qemu-heap-overflow-flaw-while-processing-certain-atapi-commands.patch;patch=1 \
             file://xsa-139-use-after-free-in-qemu-xen-block-unplug-protocol.patch;patch=1 \
             file://xsa-140-qemu-leak-of-uninitialized-heap-memory-in-rtl8139-device-model.patch;patch=1 \
+            file://xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch;patch=1 \
+            file://xsa-162-heap-buffer-overflow-vulnerability-in-pcnet-emulator.patch;patch=1 \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"


### PR DESCRIPTION
Upgrade Linux 3.18 kernels to 3.18.25.

Add XSA-155, XSA-157, XSA-159, XSA-160, XSA-162, XSA-165 and XSA-166 to Xen, QEMU and Linux (3.18 and 4.1) patch-queues.