### PR TITLE
Fix dmi product_uuid endianness for SMBIOS >= 2.6

### DIFF
--- a/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
+++ b/recipes-kernel/linux/3.18/linux-openxt_3.18.25.bb
@@ -10,6 +10,7 @@ PV_MINOR = "${@"${PV}".split('.', 3)[1]}"
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:${THISDIR}/defconfigs:"
 SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel \
     file://bp-xen-pv-guest-pat-support.patch;patch=1 \
+    file://bp-dmi-scan-uuid-fix-endianess-for-smbios.patch;patch=1 \
     file://bridge-carrier-follow-prio0.patch;patch=1 \
     file://privcmd-mmapnocache-ioctl.patch;patch=1 \
     file://xenkbd-tablet-resolution.patch;patch=1 \

--- a/recipes-kernel/linux/3.18/patches/bp-dmi-scan-uuid-fix-endianess-for-smbios.patch
+++ b/recipes-kernel/linux/3.18/patches/bp-dmi-scan-uuid-fix-endianess-for-smbios.patch
@@ -1,0 +1,55 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Backport ff4319d to fix UUID endianness for SMBIOS >= 2.6
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Original commit:
+https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/commit/?id=ff4319dc7cd58c92b389960e375038335d157a60
+
+The dmi_ver wasn't updated correctly before the dmi_decode method run to save
+the uuid.
+
+That resulted in "dmidecode -s system-uuid" and
+/sys/class/dmi/id/product_uuid disagreeing. The latter was buggy and this
+fixes it.
+
+################################################################################
+REMOVAL 
+################################################################################
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Upstream with Linux 4.4 and later.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-3.18.25/drivers/firmware/dmi_scan.c
+===================================================================
+--- linux-3.18.25.orig/drivers/firmware/dmi_scan.c	2016-01-25 18:47:48.558323968 +0100
++++ linux-3.18.25/drivers/firmware/dmi_scan.c	2016-01-25 18:51:35.361723759 +0100
+@@ -493,6 +493,7 @@
+ 			dmi_ver = smbios_ver;
+ 		else
+ 			dmi_ver = (buf[14] & 0xF0) << 4 | (buf[14] & 0x0F);
++		dmi_ver <<= 8;
+ 		dmi_num = (buf[13] << 8) | buf[12];
+ 		dmi_len = (buf[7] << 8) | buf[6];
+ 		dmi_base = (buf[11] << 24) | (buf[10] << 16) |
+@@ -501,10 +502,10 @@
+ 		if (dmi_walk_early(dmi_decode) == 0) {
+ 			if (smbios_ver) {
+ 				pr_info("SMBIOS %d.%d present.\n",
+-				       dmi_ver >> 8, dmi_ver & 0xFF);
++					dmi_ver >> 16, (dmi_ver >> 8) & 0xFF);
+ 			} else {
+ 				pr_info("Legacy DMI %d.%d present.\n",
+-				       dmi_ver >> 8, dmi_ver & 0xFF);
++					dmi_ver >> 16, (dmi_ver >> 8) & 0xFF);
+ 			}
+ 			dmi_format_ids(dmi_ids_string, sizeof(dmi_ids_string));
+ 			printk(KERN_DEBUG "DMI: %s\n", dmi_ids_string);

--- a/recipes-kernel/linux/4.1/linux-openxt_4.1.13.bb
+++ b/recipes-kernel/linux/4.1/linux-openxt_4.1.13.bb
@@ -9,6 +9,7 @@ PV_MINOR = "${@"${PV}".split('.', 3)[1]}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:${THISDIR}/defconfigs:"
 SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel \
+    file://bp-dmi-scan-uuid-fix-endianess-for-smbios.patch;patch=1 \
     file://bridge-carrier-follow-prio0.patch;patch=1 \
     file://privcmd-mmapnocache-ioctl.patch;patch=1 \
     file://usb-mass-storage-no-autobind.patch;patch=1 \

--- a/recipes-kernel/linux/4.1/patches/bp-dmi-scan-uuid-fix-endianess-for-smbios.patch
+++ b/recipes-kernel/linux/4.1/patches/bp-dmi-scan-uuid-fix-endianess-for-smbios.patch
@@ -1,0 +1,57 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Backport ff4319d to fix UUID endianness for SMBIOS >= 2.6
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Original commit:
+https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/commit/?id=ff4319dc7cd58c92b389960e375038335d157a60
+
+The dmi_ver wasn't updated correctly before the dmi_decode method run to save
+the uuid.
+
+That resulted in "dmidecode -s system-uuid" and
+/sys/class/dmi/id/product_uuid disagreeing. The latter was buggy and this
+fixes it.
+
+################################################################################
+REMOVAL 
+################################################################################
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Upstream with Linux 4.4 and later.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: linux-4.1.13/drivers/firmware/dmi_scan.c
+===================================================================
+--- linux-4.1.13.orig/drivers/firmware/dmi_scan.c	2016-01-25 18:57:19.800094998 +0100
++++ linux-4.1.13/drivers/firmware/dmi_scan.c	2016-01-25 19:00:52.507030488 +0100
+@@ -508,6 +508,7 @@
+ 			dmi_ver = smbios_ver;
+ 		else
+ 			dmi_ver = (buf[14] & 0xF0) << 4 | (buf[14] & 0x0F);
++		dmi_ver <<= 8;
+ 		dmi_num = get_unaligned_le16(buf + 12);
+ 		dmi_len = get_unaligned_le16(buf + 6);
+ 		dmi_base = get_unaligned_le32(buf + 8);
+@@ -515,12 +516,11 @@
+ 		if (dmi_walk_early(dmi_decode) == 0) {
+ 			if (smbios_ver) {
+ 				pr_info("SMBIOS %d.%d present.\n",
+-				       dmi_ver >> 8, dmi_ver & 0xFF);
++					dmi_ver >> 16, (dmi_ver >> 8) & 0xFF);
+ 			} else {
+ 				pr_info("Legacy DMI %d.%d present.\n",
+-				       dmi_ver >> 8, dmi_ver & 0xFF);
++					dmi_ver >> 16, (dmi_ver >> 8) & 0xFF);
+ 			}
+-			dmi_ver <<= 8;
+ 			dmi_format_ids(dmi_ids_string, sizeof(dmi_ids_string));
+ 			printk(KERN_DEBUG "DMI: %s\n", dmi_ids_string);
+ 			return 0;


### PR DESCRIPTION
Backport ff4319d to fix UUID endianness for SMBIOS >= 2.6

For test installations, product_uuid is used as passphrase to cipher /config. This regression broke upgrade to Linux 3.18 for OpenXT installs using Linux 3.11.