### PR TITLE
Move labeling of /boot/system to selinux-load.sh.

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
@@ -154,12 +154,6 @@ boot_root() {
     mount --bind /proc /root/proc
     mount --move /sys /root/sys
 
-    # set selinux contexts for /boot/system on firstboot
-    if [ -f /root$FIRSTBOOT_FLAG ]; then
-        POL_NAME=$(sed -n 's&^[[:space:]]*SELINUXTYPE[[:space:]]*=[[:space:]]*\([A-Za-z0-9_-]\+\)[[:space:]]*$&\1&p' /root/etc/selinux/config)
-        echo "initramfs: setting file contexts for boot partition"
-        setfiles /root/etc/selinux/$POL_NAME/contexts/files/file_contexts /root/boot/system
-    fi
     exec switch_root -c /dev/console /root /sbin/selinux-load.sh ${INIT:-$DEFINIT}
 }
 

--- a/recipes-security/selinux/selinux-load/selinux-load.sh
+++ b/recipes-security/selinux/selinux-load/selinux-load.sh
@@ -27,5 +27,6 @@ if [ $? -eq 3 ]; then
 fi
 
 [ -x ${RESTORECON} ] && ${RESTORECON} -r /dev
+[ -f /boot/system/firstboot -a -x ${RESTORECON} ] && ${RESTORECON} -r /boot/system
 
 exec "$@"


### PR DESCRIPTION
There is no reason to do it prior to the switch_root, and
evidently this was not working correctly.  At the least, it would
have required passing -r /root to setfiles for an alternate root,
and even then it did not appear to work for some reason.  Just take
it to selinux-load.sh, where we can do it after loading policy
and use restorecon instead.

OXT-463

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>