### PR TITLE
Avoid iPXE ROM init when not required

### DIFF
--- a/recipes-openxt/seabios/seabios-1.7.5/avoid-iPXE-rom-init-when-not-required.patch
+++ b/recipes-openxt/seabios/seabios-1.7.5/avoid-iPXE-rom-init-when-not-required.patch
@@ -1,0 +1,42 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Work-around to avoid loading the iPXE ROM if we are not trying to netboot.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+When initialising the option ROM, if ROM PNP extensions header product name
+matches "iPXE", do not run the ROM.
+Asking to boot from the network (via the toolstack) will follow a different
+path to boot the BEV type provided and boot from the ROM directly.
+
+################################################################################
+PATCHES
+################################################################################
+Index: seabios-1.7.5/src/optionroms.c
+===================================================================
+--- seabios-1.7.5.orig/src/optionroms.c	2016-02-11 19:01:42.134630229 +0100
++++ seabios-1.7.5/src/optionroms.c	2016-02-11 19:10:47.041930732 +0100
+@@ -132,10 +132,18 @@
+     if (newrom != rom)
+         memmove(newrom, rom, rom->size * 512);
+ 
+-    if (isvga || get_pnp_rom(newrom))
+-        // Only init vga and PnP roms here.
++    struct pnp_data *pnp = get_pnp_rom(newrom);
++    if (isvga || pnp) {
++        if (pnp->productname) {
++            char *productname = (char*)rom + pnp->productname;
++            if (!strcmp(productname, "iPXE")) {
++                dprintf(1, "Ignoring iPXE rom.\n");
++                goto leave;
++            }
++        }
+         callrom(newrom, bdf);
+-
++    }
++leave:
+     return rom_confirm(newrom->size * 512);
+ }
+ 

--- a/recipes-openxt/seabios/seabios_1.7.5.bb
+++ b/recipes-openxt/seabios/seabios_1.7.5.bb
@@ -12,7 +12,8 @@ SRC_URI += "file://openxt-version.patch;patch=1                         \
             file://amd-gpu-support.patch;patch=1                        \
             file://only-boot-selected-devices.patch;patch=1             \
             file://gpu-pt-page-align-sections.patch;patch=1             \
-            file://gcc5.patch;patch=1 \
+            file://gcc5.patch;patch=1                                   \
+            file://avoid-iPXE-rom-init-when-not-required.patch;patch=1  \
             "
 
 SRC_URI += "file://defconfig"


### PR DESCRIPTION
Use the ROM PNP extension header to avoid loading the iPXE ROM
automatically if we have no BEV to boot from it.
