### PR TITLE
Fix test for unlabeled files.

### DIFF
--- a/classes/selinux-image.bbclass
+++ b/classes/selinux-image.bbclass
@@ -1,4 +1,4 @@
-DEPENDS += "policycoreutils-native"
+DEPENDS += "policycoreutils-native attr-native"
 IMAGE_INSTALL += " \
     libselinux-bin \
     policycoreutils-loadpolicy \
@@ -36,12 +36,7 @@ selinux_set_labels () {
 
 	bbdebug 2 "searching for files and dirs w/o an SELinux context in rootfs: ${IMAGE_ROOTFS}"
 	find ${IMAGE_ROOTFS} 2> /dev/null | while read ITEM; do
-		if [ -d "${ITEM}" ]; then
-			SELABEL="$(ls -Zd "${ITEM}" | awk '{print $1}')"
-		else
-			SELABEL="$(ls -Z "${ITEM}" | awk '{print $1}')"
-		fi
-		if [ "xXx${SELABEL}" = "xXx?" ]; then
+	        if ! getfattr -h -n security.selinux ${ITEM} > /dev/null; then
 			bbwarn "no SELinux label on file: ${ITEM}"
 		fi
 	done


### PR DESCRIPTION
The old test relied on ls -Z to check for unlabeled files.
However, commit 7e6b232828130514fd38091a34e29a4c3c12f105
(selinux: Fix do_install failures on libsepol/libselinux) added
a dependency on coreutils-native to ensure support for ln --relative,
and coreutils-native is built without SELinux support, so ls -Z
was always reporting "?".  It doesn't appear to be supported to
build coreutils-native with SELinux support as this creates a
dependency loop.  So just switch the test to use getfattr instead
(and we already have attr-native as a dependency).  Unfortunately
this also has some false positives due to the handling of hard links
by upstream pseudo xattr support, but at least it isn't every file.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>