### PR TITLE
[usbback] Prevent usbback from trashing kernel memory. [OXT-481]

### DIFF
--- a/recipes-kernel/linux/3.11/patches/usbback-base.patch
+++ b/recipes-kernel/linux/3.11/patches/usbback-base.patch
@@ -2347,7 +2347,7 @@ index 0000000..3f6bff2
 +
 +	for (i = 0; i < mmap_pages; i++) {
 +		pending_segments[i].grant_handle = USBBACK_INVALID_HANDLE;
-+		pending_pages[i] = alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
++		pending_pages[i] = alloc_page(GFP_KERNEL);
 +		if (pending_pages[i] == NULL)
 +			goto out_of_memory;
 +		pending_segments[i].page = pending_pages[i];

--- a/recipes-kernel/linux/3.18/patches/usbback-base.patch
+++ b/recipes-kernel/linux/3.18/patches/usbback-base.patch
@@ -2498,7 +2498,7 @@ Index: linux-3.18.25/drivers/usb/xen-usbback/usbback.c
 +
 +	for (i = 0; i < mmap_pages; i++) {
 +		pending_segments[i].grant_handle = USBBACK_INVALID_HANDLE;
-+		pending_pages[i] = alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
++		pending_pages[i] = alloc_page(GFP_KERNEL);
 +		if (pending_pages[i] == NULL)
 +			goto out_of_memory;
 +		pending_segments[i].page = pending_pages[i];

--- a/recipes-kernel/linux/4.1/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.1/patches/usbback-base.patch
@@ -2496,7 +2496,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 +
 +	for (i = 0; i < mmap_pages; i++) {
 +		pending_segments[i].grant_handle = USBBACK_INVALID_HANDLE;
-+		pending_pages[i] = alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
++		pending_pages[i] = alloc_page(GFP_KERNEL);
 +		if (pending_pages[i] == NULL)
 +			goto out_of_memory;
 +		pending_segments[i].page = pending_pages[i];


### PR DESCRIPTION
This driver currently calls alloc_page() with flags that may return
lowmem *and* highmem pages. Throughout the remaining code,
pfn_to_kaddr() is used to produce virtual addresses for those pages, but
this function only produces valid addresses for lowmem pages. Calling it
for highmem pages produces an incorrect address that frequently lies
within the vmalloc range, potentially resulting in trashing another
piece of kernel memory. Requesting only lowmem pages prevents this from
happening.