### PR TITLE
Fix syslinux build/QA warningss

### DIFF
--- a/recipes-devtools/syslinux/syslinux/no-strip.patch
+++ b/recipes-devtools/syslinux/syslinux/no-strip.patch
@@ -1,0 +1,26 @@
+Index: syslinux-4.04/mtools/Makefile
+===================================================================
+--- syslinux-4.04.orig/mtools/Makefile	2011-04-18 23:24:17.000000000 +0200
++++ syslinux-4.04/mtools/Makefile	2016-02-16 12:16:19.203026860 +0100
+@@ -4,7 +4,7 @@
+ OPTFLAGS = -g -Os
+ INCLUDES = -I. -I.. -I../libfat -I../libinstaller
+ CFLAGS	 = $(GCCWARN) -D_FILE_OFFSET_BITS=64 $(OPTFLAGS) $(INCLUDES)
+-LDFLAGS	 = -s
++LDFLAGS	 =
+ 
+ SRCS     = syslinux.c \
+ 	   ../libinstaller/fat.c \
+Index: syslinux-4.04/utils/Makefile
+===================================================================
+--- syslinux-4.04.orig/utils/Makefile	2011-04-18 23:24:17.000000000 +0200
++++ syslinux-4.04/utils/Makefile	2016-02-16 12:16:27.876262742 +0100
+@@ -18,7 +18,7 @@
+ include $(topdir)/MCONFIG
+ 
+ CFLAGS   = $(GCCWARN) -Os -fomit-frame-pointer -D_FILE_OFFSET_BITS=64
+-LDFLAGS  = -O2 -s
++LDFLAGS  = -O2
+ 
+ TARGETS	 = mkdiskimage isohybrid gethostip memdiskfind
+ TARGETS += isohybrid.pl  # about to be obsoleted

--- a/recipes-devtools/syslinux/syslinux_4.04.bb
+++ b/recipes-devtools/syslinux/syslinux_4.04.bb
@@ -12,6 +12,7 @@ PR = "r0xc0"
 
 SRC_URI = "${KERNELORG_MIRROR}/linux/utils/boot/syslinux/syslinux-${PV}.tar.bz2 \
            file://avoid-using-kernel-ext2-header.patch;patch=1 \
+           file://no-strip.patch;patch=1 \
 "
 SRC_URI[md5sum] = "a3936208767eb7ced65320abe2e33a10"
 SRC_URI[sha256sum] = "e186a21cb1b3b1874f253df21546e8d0595d803bd6a60f38cfafbc10bee90e0b"
@@ -41,20 +42,32 @@ do_install() {
 	oe_runmake install INSTALLROOT="${D}"
 }
 
-PACKAGES =+ " \
-	${PN}-extlinux \
-	${PN}-isohybrid \
-	${PN}-isolinux \
-	${PN}-mboot \
-	${PN}-mbr \
-	${PN}-pxelinux \
+PACKAGES += " \
+        ${PN}-nomtools \
+        ${PN}-extlinux \
+        ${PN}-isohybrid \
+        ${PN}-isolinux \
+        ${PN}-mboot \
+        ${PN}-mbr \
+        ${PN}-pxelinux \
+        ${PN}-chain \
+        ${PN}-misc \
 "
 
+RDEPENDS_${PN} += "mtools"
+RDEPENDS_${PN}-nomtools += "libext2fs"
+RDEPENDS_${PN}-misc += "perl"
+
 FILES_${PN} = "${bindir}/syslinux"
+FILES_${PN}-nomtools = "${bindir}/syslinux-nomtools"
 FILES_${PN}-extlinux = "${base_sbindir}/extlinux"
 FILES_${PN}-isohybrid = "${bindir}/isohybrid"
 FILES_${PN}-isolinux = "${datadir}/${PN}/isolinux.bin"
 FILES_${PN}-mboot = "${datadir}/${PN}/mboot.c32"
 FILES_${PN}-mbr = "${datadir}/${PN}/mbr.bin"
 FILES_${PN}-pxelinux = "${datadir}/${PN}/pxelinux.0"
-FILES_${PN}-dev += "${datadir}/${PN}/com32"
+FILES_${PN}-chain = "${datadir}/${BPN}/chain.c32"
+FILES_${PN}-dev += "${datadir}/${BPN}/com32/lib*${SOLIBS} ${datadir}/${BPN}/com32/include ${datadir}/${BPN}/com32/com32.ld"
+FILES_${PN}-staticdev += "${datadir}/${BPN}/com32/lib*.a ${libdir}/${BPN}/com32/lib*.a"
+FILES_${PN}-misc = "${datadir}/${BPN}/* ${libdir}/${BPN}/* ${bindir}/*"
+


### PR DESCRIPTION
Packaging was incomplete, so add split packages for things left-over,
move static libraries in -staticdev and append PACKAGES to avoid globing
-dev/-staticdev/etc in -misc.
