### PR TITLE
QA warnings: Packaging

### DIFF
--- a/recipes-devtools/ghc-libs/ghc-haxml_1.20.2.bb
+++ b/recipes-devtools/ghc-libs/ghc-haxml_1.20.2.bb
@@ -9,3 +9,8 @@ DESCRIPTION = "XML library for ghc"
 LICENSE = "LGPLv3 & GPLv3"
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=b84b8bea272e7357c5c7fe6f255ba732"
 GHC_PN = "HaXml"
+
+INSANE_SKIP_${PN}-utils = "already-stripped"
+
+FILES_${PN}-utils += "${bindir}/*"
+

--- a/recipes-devtools/ghc-libs/ghc-hunit_1.2.4.2.bb
+++ b/recipes-devtools/ghc-libs/ghc-hunit_1.2.4.2.bb
@@ -7,3 +7,9 @@ DESCRIPTION = "unit testing"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM="file://LICENSE;md5=4d036bff24e7f9e1a7a9012fbe91bb35"
 GHC_PN = "HUnit"
+
+INSANE_SKIP_${PN}-dev = "already-stripped"
+
+FILES_${PN}-dev += " ${bindir}/*-tests"
+FILES_${PN}-doc += " ${datadir}/HUnit-${PV}/*"
+

--- a/recipes-devtools/ghc-libs/ghc-lib-common.inc
+++ b/recipes-devtools/ghc-libs/ghc-lib-common.inc
@@ -30,7 +30,7 @@ python() {
 
 
 FILES_${PN} = "/usr/lib/libH*.so"
-FILES_${PN}-dbg = "/usr/lib/ghc-local/*/.debug/"
+FILES_${PN}-dbg = "/usr/lib/ghc-local/*/.debug/ /usr/lib/.debug/* /usr/src/debug/*"
 FILES_${PN}-dev = "/usr/lib/ghc-local/"
 
 #do_stage() {

--- a/recipes-devtools/ocaml/ocaml-camomile/ocaml-camomile-destdir.patch
+++ b/recipes-devtools/ocaml/ocaml-camomile/ocaml-camomile-destdir.patch
@@ -1,5 +1,7 @@
---- a/Makefile.in	2012-04-03 17:58:54.400046240 +0000
-+++ b/Makefile.in	2012-04-03 18:02:09.632051180 +0000
+Index: camomile-0.8.1/Makefile.in
+===================================================================
+--- camomile-0.8.1.orig/Makefile.in	2010-07-08 07:57:50.000000000 +0200
++++ camomile-0.8.1/Makefile.in	2016-02-24 19:57:17.623840470 +0100
 @@ -406,19 +406,20 @@
  	if [ -f camomile.cma ]; then files="camomile.cma $$files"; fi&& \
  	if [ -f camomile.cmxa ]; then files="camomile.cmxa $$files"; fi&& \
@@ -16,6 +18,9 @@
 -	mkdir -p '$(DATADIR)'/camomile/charmaps
 -	cp -f charmaps/*.mar '$(DATADIR)'/camomile/charmaps || true
 -	mkdir -p '$(DATADIR)'/camomile/mappings
+-	cp -f mappings/*.mar '$(DATADIR)'/camomile/mappings || true
+-	mkdir -p '$(DATADIR)'/camomile/locales
+-	cp -f locales/*.mar '$(DATADIR)'/camomile/locales || true
 +	mkdir -p '$(DESTDIR)$(DATADIR)'
 +	mkdir -p '$(DESTDIR)$(DATADIR)'/camomile
 +	mkdir -p '$(DESTDIR)$(DATADIR)'/camomile/database
@@ -23,9 +28,7 @@
 +	mkdir -p '$(DESTDIR)$(DATADIR)'/camomile/charmaps
 +	cp -f charmaps/*.mar '$(DESTDIR)$(DATADIR)'/camomile/charmaps || true
 +	mkdir -p '$(DESTDIR)$(DATADIR)'/camomile/mappings
- 	cp -f mappings/*.mar '$(DATADIR)'/camomile/mappings || true
--	mkdir -p '$(DATADIR)'/camomile/locales
--	cp -f locales/*.mar '$(DATADIR)'/camomile/locales || true
++	cp -f mappings/*.mar '$(DESTDIR)$(DATADIR)'/camomile/mappings || true
 +	mkdir -p '$(DESTDIR)$(DATADIR)'/camomile/locales
 +	cp -f locales/*.mar '$(DESTDIR)$(DATADIR)'/camomile/locales || true
  

--- a/recipes-devtools/ocaml/ocaml-camomile_0.8.1.bb
+++ b/recipes-devtools/ocaml/ocaml-camomile_0.8.1.bb
@@ -16,7 +16,18 @@ SRC_URI = "http://downloads.sourceforge.net/project/camomile/camomile/0.8.1/camo
 
 S = "${WORKDIR}/camomile-${PV}"
 
-RDEPENDS_${PN}-dev = ""
+FILES_${PN} = "${ocamllibdir}/camomile/*${SOLIBS}   \
+               /usr/share/camomile/charmaps/*       \
+               /usr/share/camomile/database/*       \
+               /usr/share/camomile/locales/*        \
+               /usr/share/camomile/mappings/*       \
+               "
+FILES_${PN}-dev = "${ocamllibdir}/camomile/*${SOLIBSDEV}    \
+                   ${ocamllibdir}/camomile/*.cm*            \
+                   ${ocamllibdir}/camomile/META             \
+                   "
+FILES_${PN}-staticdev = "${ocamllibdir}/camomile"
+FILES_${PN}-dbg = "${ocamllibdir}/camomile/.debug/*"
 
 do_configure() {
     ./configure --prefix=${prefix} --bindir=${bindir} --libdir=${libdir} --datadir=${datadir}

--- a/recipes-devtools/ocaml/ocaml-dbus_0.24.bb
+++ b/recipes-devtools/ocaml/ocaml-dbus_0.24.bb
@@ -18,9 +18,16 @@ SRC_URI = "http://projects.snarc.org/ocaml-dbus/download/ocaml_dbus-${PV}.tar.bz
 	   file://fix-multithread.patch;patch=1 \
 "
 
-RDEPENDS_${PN}-dev = ""
-
 PARALLEL_MAKE = ""
+
+FILES_${PN} = "${ocamllibdir}/dbus/*${SOLIBS} \
+               "
+FILES_${PN}-dev = "${ocamllibdir}/dbus/*${SOLIBSDEV}  \
+                   ${ocamllibdir}/dbus/*.cm*          \
+                   ${ocamllibdir}/dbus/META           \
+                  "
+FILES_${PN}-staticdev = "${ocamllibdir}/dbus/*.a"
+FILES_${PN}-dbg = "${ocamllibdir}/dbus/.debug/*"
 
 do_compile() {
 	oe_runmake \

--- a/recipes-extended/xen/xen.bb
+++ b/recipes-extended/xen/xen.bb
@@ -2,6 +2,9 @@ require xen.inc
 
 PROVIDES = "xen"
 
+PACKAGES += "${PN}-efi"
+
+FILES_${PN}-efi = "/usr/lib64/efi/*"
 FILES_${PN}-dbg += "/boot/xen*syms*"
 FILES_${PN} += "/boot"
 

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -74,11 +74,13 @@ FILES_${PN} += "/usr/share/qemu/keymaps/en-us       \
                 /usr/share/qemu/keymaps/commons     \
                 /usr/share/qemu/keymaps/modifiers   \
                 "
+FILES_${PN}-dbg += "/usr/lib/.debug/* /usr/libexec/.debug/*"
 FILES_${PN}-extra-keymaps = "/usr/share/qemu/keymaps/*"
 FILES_${PN}-extra-roms = "/usr/share/qemu/*"
 INSANE_SKIP_${PN}-extra-roms = "arch"
+FILES_${PN}-utils = "/usr/libexec/*"
 
-PACKAGES += "${PN}-extra-keymaps ${PN}-extra-roms"
+PACKAGES += "${PN}-extra-keymaps ${PN}-extra-roms ${PN}-utils"
 
 CFLAGS_append = " -Wno-unused-parameter -Wno-unused-local-typedefs"
 

--- a/recipes-openxt/xclibs/udbus_git.bb
+++ b/recipes-openxt/xclibs/udbus_git.bb
@@ -11,3 +11,5 @@ PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 S = "${WORKDIR}/git/udbus"
+
+FILES_${PN}-doc += "/usr/share/${PN}-0.2"

--- a/recipes-security/selinux/libsemanage_2.4.bbappend
+++ b/recipes-security/selinux/libsemanage_2.4.bbappend
@@ -1,0 +1,6 @@
+PACKAGE_BEFORE_PN = "${PN}-utils"
+
+FILES_${PN}-utils = "/usr/libexec/selinux/*"
+
+RDEPENDS_${PN}-utils = "python"
+

--- a/recipes-security/selinux/qemu-wrappers_1.0.bb
+++ b/recipes-security/selinux/qemu-wrappers_1.0.bb
@@ -6,14 +6,15 @@ SRC_URI = "file://qemu-dm_alt.c	\
            file://qemu-dm-wrapper_alt"
 
 S = "${WORKDIR}"
-FILES_${PN} += " /usr/share/xenclient/qemu-dm-wrapper_alt	\
-                 /usr/lib/xen/bin/qemu-dm_alt "
+FILES_${PN} += " ${datadir}/xenclient/qemu-dm-wrapper_alt	\
+                 ${libdir}/xen/bin/qemu-dm_alt "
+FILES_${PN}-dbg += "${libdir}/xen/bin/.debug/*"
 
 ASNEEDED = ""
 
 inherit autotools-brokensep
 
 do_install_append() {
-        install -m 755 -d ${D}/usr/share/xenclient/
-        install -m 755 ${WORKDIR}/qemu-dm-wrapper_alt ${D}/usr/share/xenclient/qemu-dm-wrapper_alt
+        install -m 755 -d ${D}${datadir}/xenclient/
+        install -m 755 ${WORKDIR}/qemu-dm-wrapper_alt ${D}${datadir}/xenclient/qemu-dm-wrapper_alt
 }


### PR DESCRIPTION
This is only a starting effort to fix packaging in many of the xenclient-oe layer packages.

It makes a lots of noise mostly, making it harder to find important things in the output. So, deal with what is built in a better way:

- Split things into different packages (e.g, -dbg, -utils, -dev),
- do not leave things behind,
- try to make sure everything is where it belongs,
- Haskell binaries are stripped, silence the warnings about it,
- Missing RDEPENDS here and there...

