### PR TITLE
QA warnings: Licences

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bb
@@ -4,7 +4,7 @@ SECTION = "kernel"
 # Notes:
 # Based on the OE one but with the new git repository
 
-LICENSE = "Intel"
+LICENSE = "Proprietary"
 
 LIC_FILES_CHKSUM = "file://LICENCE.iwlwifi_firmware;md5=3fd842911ea93c29cd32679aa23e1c88"
 

--- a/recipes-openxt/acms/acms.bb
+++ b/recipes-openxt/acms/acms.bb
@@ -20,7 +20,7 @@ SRC_URI[bdw.md5sum] = "f40771addcb12c82b44c2ad53dbbe994"
 SRC_URI[bdw.sha256sum] = "3057efadd6bcf9ddf192c6aa027cc28e07ae6997a5c0037ef1fa09e8938893f0"
 
 PR="r3"
-LICENSE = "IntelSINIT"
+LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://GM45_GS45_PM45-SINIT_51/license.txt;md5=60d123634e0b94f8c425003389e64bda \
                     file://Q45_Q43-SINIT_51/license.txt;md5=60d123634e0b94f8c425003389e64bda \
                     file://Q35-SINIT_51/license.txt;md5=60d123634e0b94f8c425003389e64bda \


### PR DESCRIPTION
Those licenses are "Proprietary", we could make them available in the layer as well. Also there is more than one license applying to those packages.