### PR TITLE
QA warnings: Linker

### DIFF
--- a/recipes-devtools/ocaml/ocaml-cross/config.patch
+++ b/recipes-devtools/ocaml/ocaml-cross/config.patch
@@ -18,7 +18,7 @@ index aa514f1..3d6a9c6 100755
 -      mksharedlib="$bytecc -shared"
 +      if [[ -z $mksharedliboption ]]; then
 +	  mksharedlib="$bytecc -shared"
-+	  mksharedlibrpath="-Wl,-rpath,"
++	  mksharedlibrpath="-Wl,-rpath-link,"
 +      else
 +	  mksharedlib="$mksharedliboption"
 +	  mksharedlibrpath="-rpath "

--- a/recipes-devtools/ocaml/ocaml-cross/remove-absolute-linker-path-from-lib.patch
+++ b/recipes-devtools/ocaml/ocaml-cross/remove-absolute-linker-path-from-lib.patch
@@ -1,0 +1,59 @@
+###############################################################################
+SHORT DESCRIPTION
+###############################################################################
+Source: http://caml.inria.fr/mantis/view.php?id=5943
+
+###############################################################################
+LONG DESCRIPTION
+###############################################################################
+Link time paths should not be added to the RPATH (run-time-path) of the dynamic
+object built in most cases. With OE, it ends up having RPATH with build-machine
+absolute path (-L) in it, which is very wrong.
+
+This patch adds -elfmode option, to have the default ELF linker behaviour: not
+include the link-time search path to the RPATH.
+
+###############################################################################
+PATCHES
+###############################################################################
+Index: git/tools/ocamlmklib.mlp
+===================================================================
+--- git.orig/tools/ocamlmklib.mlp	2016-02-24 15:37:58.557488630 +0100
++++ git/tools/ocamlmklib.mlp	2016-02-24 15:40:52.268754425 +0100
+@@ -21,6 +21,7 @@
+ and caml_libs = ref []      (* -cclib to pass to ocamlc, ocamlopt *)
+ and caml_opts = ref []      (* -ccopt to pass to ocamlc, ocamlopt *)
+ and dynlink = ref supports_shared_libraries
++and elfmode = ref false     (* do not add C link lib path to run-time path *)
+ and failsafe = ref false    (* whether to fall back on static build only *)
+ and c_libs = ref []         (* libs to pass to mksharedlib and ocamlc -cclib *)
+ and c_opts = ref []      (* options to pass to mksharedlib and ocamlc -ccopt *)
+@@ -84,8 +85,9 @@
+       c_libs := s :: !c_libs
+     else if starts_with s "-L" then
+      (c_opts := s :: !c_opts;
+-      let l = chop_prefix s "-L" in
+-      if not (Filename.is_relative l) then rpath := l :: !rpath)
++      if not !elfmode then
++      (let l = chop_prefix s "-L" in
++       if not (Filename.is_relative l) then rpath := l :: !rpath))
+     else if s = "-ocamlc" then
+       ocamlc := next_arg ()
+     else if s = "-ocamlopt" then
+@@ -96,6 +98,8 @@
+       output_c := next_arg()
+     else if s = "-dllpath" || s = "-R" || s = "-rpath" then
+       rpath := next_arg() :: !rpath
++    else if s = "-elfmode" then
++      elfmode := true
+     else if starts_with s "-R" then
+       rpath := chop_prefix s "-R" :: !rpath
+     else if s = "-Wl,-rpath" then
+@@ -136,6 +140,7 @@
+   -ccopt <opt>   C option passed to ocamlc -a or ocamlopt -a only
+   -custom        disable dynamic loading
+   -dllpath <dir> Add <dir> to the run-time search path for DLLs
++  -elfmode       Do not add link-time search path to run-time path
+   -F<dir>        Specify a framework directory (MacOSX)
+   -framework <name>    Use framework <name> (MacOSX)
+   -help          Print this help message and exit

--- a/recipes-devtools/ocaml/ocaml-cross_git.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_git.bb
@@ -10,6 +10,7 @@ SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/ocaml.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
            file://0007-Fix-ocamlopt-w.r.t.-binutils-2.21.patch;patch=1 \
 	   file://config.patch \
+           file://remove-absolute-linker-path-from-lib.patch \
 "
 
 inherit xenclient

--- a/recipes-devtools/ocaml/ocaml-dbus_0.24.bb
+++ b/recipes-devtools/ocaml/ocaml-dbus_0.24.bb
@@ -31,9 +31,9 @@ FILES_${PN}-dbg = "${ocamllibdir}/dbus/.debug/*"
 
 do_compile() {
 	oe_runmake \
-		OCAMLC="ocamlc -cc '${CC}'" \
-		OCAMLOPT="ocamlopt -cc '${CC}'" \
-		OCAMLMKLIB="ocamlmklib -L'${STAGING_DIR_TARGET}/lib' -L'${STAGING_DIR_TARGET}/usr/lib'"
+		OCAMLC="ocamlc -cc '${CC} -fPIC'" \
+		OCAMLOPT="ocamlopt -cc '${CC} -fPIC'" \
+		OCAMLMKLIB="ocamlmklib -elfmode -L'${STAGING_DIR_TARGET}/lib' -L'${STAGING_DIR_TARGET}/usr/lib'"
 
 }
 

--- a/recipes-openxt/blktap/blktap_git.bb
+++ b/recipes-openxt/blktap/blktap_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv2"
 DEPENDS = "openssl xen-tools libaio util-linux libicbinn-resolved"
 LIC_FILES_CHKSUM="file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
-RDEPENDS_${PN} += "glibc-gconv-utf-16"
+RDEPENDS_${PN} += "glibc-gconv-utf-16 bash"
 
 PV = "0+git${SRCPV}"
 
@@ -15,7 +15,7 @@ S = "${WORKDIR}/git"
 # Makefile doesn't generate hash in libs.. todo: check that all is ok
 INSANE_SKIP_${PN} = "1"
 
-CFLAGS += "-DVHD_LOCKING -fPIC -pie -Wno-maybe-uninitialized"
+CFLAGS += "-DVHD_LOCKING -Wno-maybe-uninitialized"
 EXTRA_OEMAKE += "CROSS_COMPILE=${HOST_PREFIX}"
 
 inherit xenclient


### PR DESCRIPTION
Blktap does not need to override -fPIC.

OCAML-cross should generate position-independent code.
RPATH should not store absolute path from the build environment. Someone made a patch for that (http://caml.inria.fr/mantis/view.php?id=5943) as it is apparently not default.