### PR TITLE
Stable 5 linux 4.1 missing bits

### DIFF
--- a/recipes-kernel/linux/4.1/defconfigs/xenclient-dom0/defconfig
+++ b/recipes-kernel/linux/4.1/defconfigs/xenclient-dom0/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.1.10 Kernel Configuration
+# Linux/x86 4.1.13 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -1688,8 +1688,9 @@ CONFIG_I2C_I801=y
 #
 # I2C system bus drivers (mostly embedded / system-on-chip)
 #
-# CONFIG_I2C_DESIGNWARE_PLATFORM is not set
-# CONFIG_I2C_DESIGNWARE_PCI is not set
+CONFIG_I2C_DESIGNWARE_CORE=m
+CONFIG_I2C_DESIGNWARE_PLATFORM=m
+CONFIG_I2C_DESIGNWARE_PCI=m
 # CONFIG_I2C_EG20T is not set
 # CONFIG_I2C_OCORES is not set
 # CONFIG_I2C_PCA_PLATFORM is not set

--- a/recipes-kernel/linux/4.1/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.1/patches/usbback-base.patch
@@ -38,8 +38,8 @@ PATCHES
 ################################################################################
 Index: linux-4.1.13/drivers/usb/Kconfig
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/Kconfig	2016-02-27 17:26:36.842894789 +0100
-+++ linux-4.1.13/drivers/usb/Kconfig	2016-02-27 18:08:20.673611419 +0100
+--- linux-4.1.13.orig/drivers/usb/Kconfig	2016-02-29 12:09:05.157671459 +0100
++++ linux-4.1.13/drivers/usb/Kconfig	2016-02-29 12:09:46.737074206 +0100
 @@ -94,6 +94,17 @@
  
  source "drivers/usb/usbip/Kconfig"
@@ -60,8 +60,8 @@ Index: linux-4.1.13/drivers/usb/Kconfig
  source "drivers/usb/musb/Kconfig"
 Index: linux-4.1.13/drivers/usb/Makefile
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/Makefile	2016-02-27 17:26:36.842894789 +0100
-+++ linux-4.1.13/drivers/usb/Makefile	2016-02-27 18:08:20.673611419 +0100
+--- linux-4.1.13.orig/drivers/usb/Makefile	2016-02-29 12:09:05.157671459 +0100
++++ linux-4.1.13/drivers/usb/Makefile	2016-02-29 12:09:46.737074206 +0100
 @@ -62,3 +62,5 @@
  obj-$(CONFIG_USB_COMMON)	+= common/
  
@@ -70,8 +70,8 @@ Index: linux-4.1.13/drivers/usb/Makefile
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) += xen-usbback/
 Index: linux-4.1.13/drivers/usb/core/Makefile
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/core/Makefile	2016-02-27 17:26:36.842894789 +0100
-+++ linux-4.1.13/drivers/usb/core/Makefile	2016-02-27 18:08:20.673611419 +0100
+--- linux-4.1.13.orig/drivers/usb/core/Makefile	2016-02-29 12:09:05.157671459 +0100
++++ linux-4.1.13/drivers/usb/core/Makefile	2016-02-29 12:09:46.737074206 +0100
 @@ -6,6 +6,7 @@
  usbcore-y += config.o file.o buffer.o sysfs.o endpoint.o
  usbcore-y += devio.o notify.o generic.o quirks.o devices.o
@@ -83,7 +83,7 @@ Index: linux-4.1.13/drivers/usb/core/Makefile
 Index: linux-4.1.13/drivers/usb/core/dusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/core/dusb.c	2016-02-27 18:08:20.673611419 +0100
++++ linux-4.1.13/drivers/usb/core/dusb.c	2016-02-29 12:09:46.737074206 +0100
 @@ -0,0 +1,169 @@
 +/*****************************************************************************/
 +
@@ -256,8 +256,8 @@ Index: linux-4.1.13/drivers/usb/core/dusb.c
 +
 Index: linux-4.1.13/drivers/usb/core/hub.c
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/core/hub.c	2016-02-27 17:26:39.782852917 +0100
-+++ linux-4.1.13/drivers/usb/core/hub.c	2016-02-27 18:08:20.673611419 +0100
+--- linux-4.1.13.orig/drivers/usb/core/hub.c	2016-02-29 12:09:05.157671459 +0100
++++ linux-4.1.13/drivers/usb/core/hub.c	2016-02-29 12:09:46.740407497 +0100
 @@ -1011,6 +1011,15 @@
  	return 0;
  }
@@ -300,7 +300,7 @@ Index: linux-4.1.13/drivers/usb/core/hub.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/Makefile
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/Makefile	2016-02-27 18:08:20.673611419 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/Makefile	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,3 @@
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) := usbbk.o
 +
@@ -308,7 +308,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/Makefile
 Index: linux-4.1.13/drivers/usb/xen-usbback/buffers.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/buffers.c	2016-02-27 18:08:20.673611419 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/buffers.c	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,422 @@
 +/******************************************************************************
 + * usbback/buffers.c
@@ -735,7 +735,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/buffers.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/common.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/common.h	2016-02-27 18:08:20.673611419 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/common.h	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,361 @@
 +/*
 + * Copyright (c) Citrix Systems Inc.
@@ -1101,7 +1101,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/common.h
 Index: linux-4.1.13/drivers/usb/xen-usbback/interface.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/interface.c	2016-02-27 18:08:20.676944704 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/interface.c	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,164 @@
 +/******************************************************************************
 + *
@@ -1270,8 +1270,8 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/interface.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/usbback.c	2016-02-27 18:08:20.676944704 +0100
-@@ -0,0 +1,1267 @@
++++ linux-4.1.13/drivers/usb/xen-usbback/usbback.c	2016-02-29 13:21:51.878787619 +0100
+@@ -0,0 +1,1268 @@
 +/******************************************************************************
 + *
 + * Back-end of the driver for virtual block devices. This portion of the
@@ -1365,7 +1365,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 +				 usbif_request_t *req,
 +				 pending_req_t *pending_req);
 +static void make_response(usbif_t *usbif, u64 id, int actual_length,
-+	int startframe, int status);
++	int startframe, int status, int error_count);
 +
 +/******************************************************************
 + * misc small helpers
@@ -1925,7 +1925,8 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 +
 +	fast_flush_area(pending_req);
 +	make_response(usbif, pending_req->id, urb->actual_length,
-+		urb->start_frame, get_usb_status(status));
++		urb->start_frame, get_usb_status(status),
++		(pending_req->type == USBIF_T_ISOC) ? urb->error_count : 0);
 +	usbif_put(pending_req->usbif);
 +
 +	/*
@@ -2005,41 +2006,41 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 +		if (!usbif_request_type_valid(&req)) {
 +			debug_print(LOG_LVL_ERROR, "%s: type %d not valid\n",
 +				__FUNCTION__, usbif_request_type(&req));
-+			make_response(usbif, req.id, 0, 0, USBIF_RSP_ERROR);
++			make_response(usbif, req.id, 0, 0, USBIF_RSP_ERROR, 0);
 +			free_req(pending_req);
 +		} else if (usbif_request_reset(&req)) {
 +			int ret = vusb_reset_device(&usbif->vusb)
 +					? USBIF_RSP_ERROR : USBIF_RSP_OKAY;
 +
-+			make_response(usbif, req.id, 0, 0, ret);
++			make_response(usbif, req.id, 0, 0, ret, 0);
 +			free_req(pending_req);
 +		} else if (usbif_request_cycle_port(&req)) {
 +			vusb_cycle_port(&usbif->vusb);
 +
-+			make_response(usbif, req.id, 0, 0, USBIF_RSP_OKAY);
++			make_response(usbif, req.id, 0, 0, USBIF_RSP_OKAY, 0);
 +			free_req(pending_req);
 +		} else if (usbif_request_abort_pipe(&req)) {
 +			int ret = vusb_flush_endpoint(&usbif->vusb, &req)
 +					? USBIF_RSP_ERROR : USBIF_RSP_OKAY;
 +
-+			make_response(usbif, req.id, 0, 0, ret);
++			make_response(usbif, req.id, 0, 0, ret, 0);
 +			free_req(pending_req);
 +		} else if (usbif_request_get_frame(&req)) {
 +			int frame = usb_get_current_frame_number(usbif->vusb.usbdev);
 +
 +			if (frame >= 0)
-+				make_response(usbif, req.id, 0, frame, 0);
++				make_response(usbif, req.id, 0, frame, 0, 0);
 +			else
-+				make_response(usbif, req.id, 0, 0, USBIF_RSP_ERROR);
++				make_response(usbif, req.id, 0, 0, USBIF_RSP_ERROR, 0);
 +			free_req(pending_req);
 +		} else if (usbif_request_get_speed(&req)) {
 +			make_response(usbif, req.id, 0,
-+				vusb_get_speed(&usbif->vusb), 0);
++				vusb_get_speed(&usbif->vusb), 0, 0);
 +			free_req(pending_req);
 +		} else if (usbif_request_cancel(&req)) {
 +			cancel_urb(&usbif->vusb.anchor, *((u64*)(&req.u.data[0])));
 +
-+			make_response(usbif, req.id, 0, 0, USBIF_RSP_OKAY);
++			make_response(usbif, req.id, 0, 0, USBIF_RSP_OKAY, 0);
 +			free_req(pending_req);
 +		} else
 +			dispatch_usb_io(usbif, &req, pending_req);
@@ -2390,7 +2391,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 + fail_flush:
 +	fast_flush_area(pending_req);
 + fail_response:
-+	make_response(usbif, req->id, 0, 0, get_usb_status(ret));
++	make_response(usbif, req->id, 0, 0, get_usb_status(ret), 0);
 +	urb = pending_req->urb;
 +	free_req(pending_req);
 +	usb_free_urb(urb);
@@ -2404,7 +2405,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 +
 +
 +static void make_response(usbif_t *usbif, u64 id, int actual_length,
-+	int data, int status)
++	int data, int status, int error_count)
 +{
 +	usbif_response_t  resp;
 +	unsigned long     flags;
@@ -2542,7 +2543,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/vusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/vusb.c	2016-02-27 18:11:37.117446575 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/vusb.c	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,938 @@
 +/******************************************************************************
 + * usbback/vusb.c
@@ -3485,7 +3486,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/vusb.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/xenbus.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/xenbus.c	2016-02-27 18:08:20.676944704 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/xenbus.c	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,582 @@
 +/*  Xenbus code for usbif backend
 +    Copyright (C) 2005 Rusty Russell <rusty@rustcorp.com.au>
@@ -4072,7 +4073,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/xenbus.c
 Index: linux-4.1.13/include/linux/dusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/include/linux/dusb.h	2016-02-27 18:08:20.676944704 +0100
++++ linux-4.1.13/include/linux/dusb.h	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,44 @@
 +/*****************************************************************************/
 +
@@ -4121,7 +4122,7 @@ Index: linux-4.1.13/include/linux/dusb.h
 Index: linux-4.1.13/include/xen/interface/io/usbif.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/include/xen/interface/io/usbif.h	2016-02-27 18:08:20.676944704 +0100
++++ linux-4.1.13/include/xen/interface/io/usbif.h	2016-02-29 13:11:30.454281115 +0100
 @@ -0,0 +1,196 @@
 +/******************************************************************************
 + * usbif.h
@@ -4221,7 +4222,7 @@ Index: linux-4.1.13/include/xen/interface/io/usbif.h
 +        grant_ref_t     gref[USBIF_MAX_SEGMENTS_PER_REQUEST];
 +        uint8_t         data[sizeof(grant_ref_t)*USBIF_MAX_SEGMENTS_PER_REQUEST];
 +    } u;
-+    uint32_t            pad;
++    uint32_t            error_count;    /* total ISOCH error count */
 +};
 +typedef struct usbif_request usbif_request_t;
 +
@@ -4322,7 +4323,7 @@ Index: linux-4.1.13/include/xen/interface/io/usbif.h
 Index: linux-4.1.13/include/xen/vusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/include/xen/vusb.h	2016-02-27 18:08:20.676944704 +0100
++++ linux-4.1.13/include/xen/vusb.h	2016-02-29 12:09:46.740407497 +0100
 @@ -0,0 +1,56 @@
 +#ifndef __XEN_VUSB_H__
 +#define __XEN_VUSB_H__
@@ -4382,8 +4383,8 @@ Index: linux-4.1.13/include/xen/vusb.h
 +#endif /* __XEN_VUSB_H__ */
 Index: linux-4.1.13/drivers/scsi/sr.c
 ===================================================================
---- linux-4.1.13.orig/drivers/scsi/sr.c	2016-02-27 17:26:36.842894789 +0100
-+++ linux-4.1.13/drivers/scsi/sr.c	2016-02-27 18:08:20.676944704 +0100
+--- linux-4.1.13.orig/drivers/scsi/sr.c	2016-02-29 12:09:05.157671459 +0100
++++ linux-4.1.13/drivers/scsi/sr.c	2016-02-29 12:09:46.740407497 +0100
 @@ -264,6 +264,15 @@
  	if (!(clearing & DISK_EVENT_MEDIA_CHANGE))
  		return events;
@@ -4423,8 +4424,8 @@ Index: linux-4.1.13/drivers/scsi/sr.c
  		events |= DISK_EVENT_MEDIA_CHANGE;
 Index: linux-4.1.13/drivers/usb/host/xhci-pci.c
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/host/xhci-pci.c	2016-02-27 17:26:36.842894789 +0100
-+++ linux-4.1.13/drivers/usb/host/xhci-pci.c	2016-02-27 18:08:20.676944704 +0100
+--- linux-4.1.13.orig/drivers/usb/host/xhci-pci.c	2016-02-29 12:09:05.157671459 +0100
++++ linux-4.1.13/drivers/usb/host/xhci-pci.c	2016-02-29 12:09:46.740407497 +0100
 @@ -143,6 +143,7 @@
  		 pdev->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI)) {
  		xhci->quirks |= XHCI_PME_STUCK_QUIRK;

--- a/recipes-kernel/linux/4.1/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.1/patches/usbback-base.patch
@@ -38,8 +38,8 @@ PATCHES
 ################################################################################
 Index: linux-4.1.13/drivers/usb/Kconfig
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/Kconfig	2015-11-17 15:37:41.197361905 +0100
-+++ linux-4.1.13/drivers/usb/Kconfig	2015-11-17 15:39:14.096264922 +0100
+--- linux-4.1.13.orig/drivers/usb/Kconfig	2016-02-27 17:26:36.842894789 +0100
++++ linux-4.1.13/drivers/usb/Kconfig	2016-02-27 18:08:20.673611419 +0100
 @@ -94,6 +94,17 @@
  
  source "drivers/usb/usbip/Kconfig"
@@ -60,8 +60,8 @@ Index: linux-4.1.13/drivers/usb/Kconfig
  source "drivers/usb/musb/Kconfig"
 Index: linux-4.1.13/drivers/usb/Makefile
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/Makefile	2015-11-17 15:37:41.264027784 +0100
-+++ linux-4.1.13/drivers/usb/Makefile	2015-11-17 15:39:14.239596561 +0100
+--- linux-4.1.13.orig/drivers/usb/Makefile	2016-02-27 17:26:36.842894789 +0100
++++ linux-4.1.13/drivers/usb/Makefile	2016-02-27 18:08:20.673611419 +0100
 @@ -62,3 +62,5 @@
  obj-$(CONFIG_USB_COMMON)	+= common/
  
@@ -70,8 +70,8 @@ Index: linux-4.1.13/drivers/usb/Makefile
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) += xen-usbback/
 Index: linux-4.1.13/drivers/usb/core/Makefile
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/core/Makefile	2015-11-17 15:37:41.234028138 +0100
-+++ linux-4.1.13/drivers/usb/core/Makefile	2015-11-17 15:39:14.322928911 +0100
+--- linux-4.1.13.orig/drivers/usb/core/Makefile	2016-02-27 17:26:36.842894789 +0100
++++ linux-4.1.13/drivers/usb/core/Makefile	2016-02-27 18:08:20.673611419 +0100
 @@ -6,6 +6,7 @@
  usbcore-y += config.o file.o buffer.o sysfs.o endpoint.o
  usbcore-y += devio.o notify.o generic.o quirks.o devices.o
@@ -83,7 +83,7 @@ Index: linux-4.1.13/drivers/usb/core/Makefile
 Index: linux-4.1.13/drivers/usb/core/dusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/core/dusb.c	2015-11-17 15:39:14.422927730 +0100
++++ linux-4.1.13/drivers/usb/core/dusb.c	2016-02-27 18:08:20.673611419 +0100
 @@ -0,0 +1,169 @@
 +/*****************************************************************************/
 +
@@ -256,8 +256,8 @@ Index: linux-4.1.13/drivers/usb/core/dusb.c
 +
 Index: linux-4.1.13/drivers/usb/core/hub.c
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/core/hub.c	2015-11-17 15:38:46.726588127 +0100
-+++ linux-4.1.13/drivers/usb/core/hub.c	2015-11-17 15:39:15.806244724 +0100
+--- linux-4.1.13.orig/drivers/usb/core/hub.c	2016-02-27 17:26:39.782852917 +0100
++++ linux-4.1.13/drivers/usb/core/hub.c	2016-02-27 18:08:20.673611419 +0100
 @@ -1011,6 +1011,15 @@
  	return 0;
  }
@@ -274,7 +274,7 @@ Index: linux-4.1.13/drivers/usb/core/hub.c
  enum hub_activation_type {
  	HUB_INIT, HUB_INIT2, HUB_INIT3,		/* INITs must come first */
  	HUB_POST_RESET, HUB_RESUME, HUB_RESET_RESUME,
-@@ -5496,7 +5505,7 @@
+@@ -5495,7 +5504,7 @@
  			struct usb_driver *drv;
  			int unbind = 0;
  
@@ -283,7 +283,7 @@ Index: linux-4.1.13/drivers/usb/core/hub.c
  				drv = to_usb_driver(cintf->dev.driver);
  				if (drv->pre_reset && drv->post_reset)
  					unbind = (drv->pre_reset)(cintf);
-@@ -5517,7 +5526,12 @@
+@@ -5516,7 +5525,12 @@
  		for (i = config->desc.bNumInterfaces - 1; i >= 0; --i) {
  			struct usb_interface *cintf = config->interface[i];
  			struct usb_driver *drv;
@@ -300,7 +300,7 @@ Index: linux-4.1.13/drivers/usb/core/hub.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/Makefile
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/Makefile	2015-11-17 15:39:15.889577075 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/Makefile	2016-02-27 18:08:20.673611419 +0100
 @@ -0,0 +1,3 @@
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) := usbbk.o
 +
@@ -308,7 +308,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/Makefile
 Index: linux-4.1.13/drivers/usb/xen-usbback/buffers.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/buffers.c	2015-11-17 15:39:15.976242719 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/buffers.c	2016-02-27 18:08:20.673611419 +0100
 @@ -0,0 +1,422 @@
 +/******************************************************************************
 + * usbback/buffers.c
@@ -735,7 +735,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/buffers.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/common.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/common.h	2015-11-17 15:39:16.032908717 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/common.h	2016-02-27 18:08:20.673611419 +0100
 @@ -0,0 +1,361 @@
 +/*
 + * Copyright (c) Citrix Systems Inc.
@@ -1101,7 +1101,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/common.h
 Index: linux-4.1.13/drivers/usb/xen-usbback/interface.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/interface.c	2015-11-17 15:39:16.092908009 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/interface.c	2016-02-27 18:08:20.676944704 +0100
 @@ -0,0 +1,164 @@
 +/******************************************************************************
 + *
@@ -1270,7 +1270,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/interface.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/usbback.c	2015-11-17 15:39:16.152907300 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/usbback.c	2016-02-27 18:08:20.676944704 +0100
 @@ -0,0 +1,1267 @@
 +/******************************************************************************
 + *
@@ -2542,7 +2542,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/usbback.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/vusb.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/vusb.c	2015-11-17 15:39:16.219573179 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/vusb.c	2016-02-27 18:11:37.117446575 +0100
 @@ -0,0 +1,938 @@
 +/******************************************************************************
 + * usbback/vusb.c
@@ -3316,7 +3316,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/vusb.c
 +	}
 +
 +	urb->dev = usbdev;
-+	if (!usbif_request_shortok(req))
++	if (!usbif_request_shortok(req) && usbif_request_dir_in(req))
 +		urb->transfer_flags |= URB_SHORT_NOT_OK;
 +
 +	switch((ep->desc.bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)) {
@@ -3485,7 +3485,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/vusb.c
 Index: linux-4.1.13/drivers/usb/xen-usbback/xenbus.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/drivers/usb/xen-usbback/xenbus.c	2015-11-17 15:39:16.286239059 +0100
++++ linux-4.1.13/drivers/usb/xen-usbback/xenbus.c	2016-02-27 18:08:20.676944704 +0100
 @@ -0,0 +1,582 @@
 +/*  Xenbus code for usbif backend
 +    Copyright (C) 2005 Rusty Russell <rusty@rustcorp.com.au>
@@ -4072,7 +4072,7 @@ Index: linux-4.1.13/drivers/usb/xen-usbback/xenbus.c
 Index: linux-4.1.13/include/linux/dusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/include/linux/dusb.h	2015-11-17 15:39:16.352904938 +0100
++++ linux-4.1.13/include/linux/dusb.h	2016-02-27 18:08:20.676944704 +0100
 @@ -0,0 +1,44 @@
 +/*****************************************************************************/
 +
@@ -4121,7 +4121,7 @@ Index: linux-4.1.13/include/linux/dusb.h
 Index: linux-4.1.13/include/xen/interface/io/usbif.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/include/xen/interface/io/usbif.h	2015-11-17 15:39:16.456237050 +0100
++++ linux-4.1.13/include/xen/interface/io/usbif.h	2016-02-27 18:08:20.676944704 +0100
 @@ -0,0 +1,196 @@
 +/******************************************************************************
 + * usbif.h
@@ -4322,7 +4322,7 @@ Index: linux-4.1.13/include/xen/interface/io/usbif.h
 Index: linux-4.1.13/include/xen/vusb.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.1.13/include/xen/vusb.h	2015-11-17 15:39:16.572902340 +0100
++++ linux-4.1.13/include/xen/vusb.h	2016-02-27 18:08:20.676944704 +0100
 @@ -0,0 +1,56 @@
 +#ifndef __XEN_VUSB_H__
 +#define __XEN_VUSB_H__
@@ -4382,8 +4382,8 @@ Index: linux-4.1.13/include/xen/vusb.h
 +#endif /* __XEN_VUSB_H__ */
 Index: linux-4.1.13/drivers/scsi/sr.c
 ===================================================================
---- linux-4.1.13.orig/drivers/scsi/sr.c	2015-11-17 15:37:41.184028729 +0100
-+++ linux-4.1.13/drivers/scsi/sr.c	2015-11-17 15:39:16.642901514 +0100
+--- linux-4.1.13.orig/drivers/scsi/sr.c	2016-02-27 17:26:36.842894789 +0100
++++ linux-4.1.13/drivers/scsi/sr.c	2016-02-27 18:08:20.676944704 +0100
 @@ -264,6 +264,15 @@
  	if (!(clearing & DISK_EVENT_MEDIA_CHANGE))
  		return events;
@@ -4423,8 +4423,8 @@ Index: linux-4.1.13/drivers/scsi/sr.c
  		events |= DISK_EVENT_MEDIA_CHANGE;
 Index: linux-4.1.13/drivers/usb/host/xhci-pci.c
 ===================================================================
---- linux-4.1.13.orig/drivers/usb/host/xhci-pci.c	2015-11-17 15:37:41.217361669 +0100
-+++ linux-4.1.13/drivers/usb/host/xhci-pci.c	2015-11-17 15:39:16.742900334 +0100
+--- linux-4.1.13.orig/drivers/usb/host/xhci-pci.c	2016-02-27 17:26:36.842894789 +0100
++++ linux-4.1.13/drivers/usb/host/xhci-pci.c	2016-02-27 18:08:20.676944704 +0100
 @@ -143,6 +143,7 @@
  		 pdev->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI)) {
  		xhci->quirks |= XHCI_PME_STUCK_QUIRK;

--- a/recipes-kernel/linux/4.1/patches/xenbus-move-otherend-watches-on-relocate.patch
+++ b/recipes-kernel/linux/4.1/patches/xenbus-move-otherend-watches-on-relocate.patch
@@ -35,11 +35,11 @@ Required for service VM network disagregation.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.1.6/drivers/xen/xenbus/xenbus_probe.c
+Index: linux-4.1.13/drivers/xen/xenbus/xenbus_probe.c
 ===================================================================
---- linux-4.1.6.orig/drivers/xen/xenbus/xenbus_probe.c	2015-09-11 15:18:57.427263791 +0200
-+++ linux-4.1.6/drivers/xen/xenbus/xenbus_probe.c	2015-09-11 15:19:52.576514546 +0200
-@@ -545,12 +545,34 @@
+--- linux-4.1.13.orig/drivers/xen/xenbus/xenbus_probe.c	2016-02-27 17:26:37.812880974 +0100
++++ linux-4.1.13/drivers/xen/xenbus/xenbus_probe.c	2016-02-29 12:09:42.240464439 +0100
+@@ -545,12 +545,36 @@
  	return (len == 0) ? i : -ERANGE;
  }
  
@@ -48,6 +48,8 @@ Index: linux-4.1.6/drivers/xen/xenbus/xenbus_probe.c
 +	int err;
 +
 +	/* Only move netdevs. */
++	if (!dev || !dev->dev.driver)
++		return 0;
 +	if (!xenbus_dev_is_vif(dev))
 +		return 0;
 +
@@ -75,7 +77,7 @@ Index: linux-4.1.6/drivers/xen/xenbus/xenbus_probe.c
  
  	if (char_count(node, '/') < 2)
  		return;
-@@ -573,12 +595,20 @@
+@@ -573,12 +597,20 @@
  	if (!root)
  		return;
  


### PR DESCRIPTION
Commits went into 3.18 but were left out of 4.1.
Same as https://github.com/OpenXT/xenclient-oe/pull/224 in stable-5.
