### PR TITLE
xenclient-licenses : Fix the path searched for control files.

### DIFF
--- a/classes/xenclient-licences.bbclass
+++ b/classes/xenclient-licences.bbclass
@@ -34,7 +34,14 @@ python do_licences() {
 
         package = {}
 
+        # Supply an empty default value for optional field:
+        package['Homepage'] = ''
+
         for line in file:
+            if line and line[0] == ' ':
+                # Only take the first line of multi-line fields
+                continue
+
             key, value = split_re.split(line.rstrip(), 1)
             if key in fields:
                 package[key] = value

--- a/classes/xenclient-licences.bbclass
+++ b/classes/xenclient-licences.bbclass
@@ -23,9 +23,9 @@ python do_licences() {
 
     split_re = re.compile(': ')
 
-    # Read package info from the /usr/lib/opkg/info directory within the image
+    # Read package info from the /var/lib/opkg/info directory within the image
 
-    info_dir = d.getVar('IMAGE_ROOTFS', d, 1) + '/usr/lib/opkg/info'
+    info_dir = d.getVar('IMAGE_ROOTFS', d, 1) + '/var/lib/opkg/info'
 
     packages = []
 

--- a/recipes-core/images/xenclient-sysroot-image.bb
+++ b/recipes-core/images/xenclient-sysroot-image.bb
@@ -1,6 +1,7 @@
 # XenClient sysroot image
 
 include xenclient-image-common.inc
+IMAGE_FEATURES += "package-management"
 
 COMPATIBLE_MACHINE = "(xenclient-dom0)"
 


### PR DESCRIPTION
The directory containing package metadata information has moved
from /usr into /var in the current dom0 filesystem. This change
updates the licence collection step search path.

refs OXT-460