### PR TITLE
Drop legacy cruft from refpolicy recipe.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs_2.20140311.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20140311.bbappend
@@ -197,9 +197,7 @@ POLICY_MLS_CATS = "256"
 
 S = "${WORKDIR}/refpolicy"
 
-FILES_${PN} += "/selinux ${sysconfdir}/selinux ${datadir}/selinux/*/*.bz2"
-
-EXTRA_OEMAKE += ' -j 1 BINDIR="${STAGING_BINDIR_NATIVE}" SETFILES=true '
+FILES_${PN} += "${sysconfdir}/selinux"
 
 # Just explicitly define the policy
 POL_TYPE = "xc_policy"
@@ -207,7 +205,6 @@ POL_TYPE = "xc_policy"
 #POL_TYPE = "${@get_poltype(conf_file)}"
 
 do_install_append() {
-        install -d ${D}/selinux
         install -d ${D}/etc/selinux
         install -m 644 ${WORKDIR}/config ${D}/etc/selinux/config
 }


### PR DESCRIPTION
Linux 3.0 introduced /sys/fs/selinux as the preferred mount point
for selinuxfs instead of /selinux, so /selinux is no longer needed.

There are no ${datadir}/selinux/*/*.bz2 files to package, and this
directory is handled by the meta-selinux refpolicy recipe anyway, so
drop it.

The EXTRA_OEMAKE flags seem be some legacy of older recipes; removing
them seems to have no effect.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>