### PR TITLE
Fix labeling of files/directories created on firstboot.

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/firstboot.sh
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/firstboot.sh
@@ -99,6 +99,7 @@ fi
 if [ -r ${INSTALL_CONF}/keyboard.conf ] ; then
     KEYBOARD="$(awk -F\' '/^KEYBOARD=/ { print $2 }' ${INSTALL_CONF}/keyboard.conf)"
     echo "KEYBOARD='${KEYBOARD}'" > /config/keyboard.conf
+    restore /config/keyboard.conf
  
     DEFER_KEYBOARD="$(awk -F\' '/^DEFER_KEYBOARD=/ { print $2 }' ${INSTALL_CONF}/keyboard.conf)"
     if [ "${DEFER_KEYBOARD}" = "true" ]; then
@@ -138,6 +139,7 @@ if [ -r ${INSTALL_CONF}/repo-cert.conf ] ; then
     if [ ! -r /config/repo-cert.conf ] ; then
         ALLOW_DEV_REPO_CERT="$(awk -F\' '/^ALLOW_DEV_REPO_CERT=/ { print $2 }' ${INSTALL_CONF}/repo-cert.conf)"
         echo "ALLOW_DEV_REPO_CERT='${ALLOW_DEV_REPO_CERT}'" > /config/repo-cert.conf
+        restore /config/repo-cert.conf
     fi
     mv -f ${INSTALL_CONF}/repo-cert.conf ${INSTALL_CONF}/repo-cert.conf.DONE
 fi

--- a/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
@@ -210,6 +210,7 @@ PS_FILE=${PS_DIR}/system.data
 TSS_USER="tss"
 if [ ! -s ${PS_FILE} ]; then
     install -m 700 -o ${TSS_USER} -g ${TSS_USER} -d ${PS_DIR}
+    restore ${PS_DIR}
     install -m 600 -o ${TSS_USER} -g ${TSS_USER} ${PS_FILE_SRC} ${PS_FILE}
 fi
 


### PR DESCRIPTION
/boot/system/tpm is created via install -d from init.root-ro.
coreutils install is supposed to look up the proper security context
and assign it but there seems to be a regression for directory creation,
leaving it in the parent directory type.

Several /config files are created by firstboot.sh via shell redirection.
These will default to the type of the parent directory without an explicit
label assignment.

Add restore calls as appropriate (restore is defined as a shell
wrapper for restorecon in /etc/init.d/functions).
The alternative would be to use name-based type transitions in policy,
but explicit restorecon seems more appropriate here given that these
are being created manually by an init script and are essentially one-time
operations.

OXT-486

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>