### PR TITLE
libselinux: Apply two upstream fixes required for installer.

### DIFF
--- a/recipes-security/selinux/libselinux/libselinux-mount-procfs-before-check.patch
+++ b/recipes-security/selinux/libselinux/libselinux-mount-procfs-before-check.patch
@@ -1,0 +1,74 @@
+commit 9df498884665d79474b79f0f30d1cd67df11bd3e
+Author: Ben Shelton <ben.shelton@ni.com>
+Date:   Wed Apr 15 15:56:57 2015 -0500
+
+    libselinux: Mount procfs before checking /proc/filesystems
+    
+    In the case where the SELinux security module is not loaded in the
+    kernel and it's early enough in the boot process that /proc has not yet
+    been mounted, selinuxfs_exists() will incorrectly return 1, and
+    selinux_init_load_policy() will print a message like this to the
+    console:
+    
+    Mount failed for selinuxfs on /sys/fs/selinux:  No such file or directory
+    
+    To fix this, mount the procfs before attempting to open
+    /proc/filesystems, and unmount it when done if it was initially not
+    mounted.  This is the same thing that selinux_init_load_policy() does
+    when reading /proc/cmdline.
+    
+    Signed-off-by: Ben Shelton <ben.shelton@ni.com>
+
+Upstream-Status: Accepted
+
+diff --git a/src/init.c b/src/init.c
+index 6d1ef33..179e0d0 100644
+--- a/src/init.c
++++ b/src/init.c
+@@ -11,6 +11,7 @@
+ #include <sys/vfs.h>
+ #include <stdint.h>
+ #include <limits.h>
++#include <sys/mount.h>
+ 
+ #include "dso.h"
+ #include "policy.h"
+@@ -54,15 +55,20 @@ static int verify_selinuxmnt(const char *mnt)
+ 
+ int selinuxfs_exists(void)
+ {
+-	int exists = 0;
++	int exists = 0, mnt_rc = 0;
+ 	FILE *fp = NULL;
+ 	char *buf = NULL;
+ 	size_t len;
+ 	ssize_t num;
+ 
++	mnt_rc = mount("proc", "/proc", "proc", 0, 0);
++
+ 	fp = fopen("/proc/filesystems", "r");
+-	if (!fp)
+-		return 1; /* Fail as if it exists */
++	if (!fp) {
++		exists = 1; /* Fail as if it exists */
++		goto out;
++	}
++
+ 	__fsetlocking(fp, FSETLOCKING_BYCALLER);
+ 
+ 	num = getline(&buf, &len, fp);
+@@ -76,6 +82,14 @@ int selinuxfs_exists(void)
+ 
+ 	free(buf);
+ 	fclose(fp);
++
++out:
++#ifndef MNT_DETACH
++#define MNT_DETACH 2
++#endif
++	if (mnt_rc == 0)
++		umount2("/proc", MNT_DETACH);
++
+ 	return exists;
+ }
+ hidden_def(selinuxfs_exists)

--- a/recipes-security/selinux/libselinux/libselinux-only-mount-proc-if-necessary.patch
+++ b/recipes-security/selinux/libselinux/libselinux-only-mount-proc-if-necessary.patch
@@ -1,0 +1,54 @@
+From 0d9368ee5af662a99cf123407884ba0e42053c68 Mon Sep 17 00:00:00 2001
+From: Stephen Smalley <sds@tycho.nsa.gov>
+Date: Mon, 29 Feb 2016 10:10:55 -0500
+Subject: [PATCH] libselinux: only mount /proc if necessary
+
+Commit 9df498884665d ("libselinux: Mount procfs before checking
+/proc/filesystems") changed selinuxfs_exists() to always try
+mounting /proc before reading /proc/filesystems.  However, this is
+unnecessary if /proc is already mounted and can produce avc denials
+if the process is not allowed to perform the mount.  Check first
+to see if /proc is already present and only try the mount if it is not.
+
+Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
+---
+ src/init.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/init.c b/src/init.c
+index 3db4de0..3530594 100644
+--- a/src/init.c
++++ b/src/init.c
+@@ -12,6 +12,7 @@
+ #include <stdint.h>
+ #include <limits.h>
+ #include <sys/mount.h>
++#include <linux/magic.h>
+ 
+ #include "dso.h"
+ #include "policy.h"
+@@ -57,13 +58,19 @@ static int verify_selinuxmnt(const char *mnt)
+ 
+ int selinuxfs_exists(void)
+ {
+-	int exists = 0, mnt_rc = 0;
++	int exists = 0, mnt_rc = -1, rc;
++	struct statfs sb;
+ 	FILE *fp = NULL;
+ 	char *buf = NULL;
+ 	size_t len;
+ 	ssize_t num;
+ 
+-	mnt_rc = mount("proc", "/proc", "proc", 0, 0);
++	do {
++		rc = statfs("/proc", &sb);
++	} while (rc < 0 && errno == EINTR);
++
++	if (rc == 0 && ((uint32_t)sb.f_type != (uint32_t)PROC_SUPER_MAGIC))
++		mnt_rc = mount("proc", "/proc", "proc", 0, 0);
+ 
+ 	fp = fopen("/proc/filesystems", "r");
+ 	if (!fp) {
+-- 
+2.4.3
+

--- a/recipes-security/selinux/libselinux_2.4.bbappend
+++ b/recipes-security/selinux/libselinux_2.4.bbappend
@@ -5,3 +5,10 @@ PR .= ".1"
 # the host's coreutils, as we'll need to use ln --relative.
 #
 DEPENDS += "attr-native coreutils-native"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://libselinux-mount-procfs-before-check.patch;patch=1 \
+    file://libselinux-only-mount-proc-if-necessary.patch;patch=1 \
+    "


### PR DESCRIPTION
selinux upstream commits 9df4988 and 5a8d8c4.
Otherwise, when switching /etc/selinux/config to enforcing for dom0,
the installer fails when attempting to mount selinuxfs, with:
    Mount failed for selinuxfs on /sys/fs/selinux:  No such file or directory

The scenario is that the installer is booted with selinux=0, but
has the same /etc/selinux/config as dom0, and thus has SELINUX=enforcing
if we make dom0 enforcing.  The expected behavior is that kernel
parameters take precedence (override) the /etc/selinux/config setting,
so this used to work.  When the preferred selinuxfs mount point moved from
/selinux to /sys/fs/selinux (in Linux 3.0), attempting to mount selinuxfs
on a kernel with SELinux disabled (via selinux=0 or via kernel config)
started returning ENOENT rather than ENODEV because the /sys/fs/selinux
mount point is only created by the kernel if SELinux is enabled.  This
then confused libselinux into thinking that the mount failed for some
reason other than SELinux being disabled in the kernel, and caused it
to fail-closed, thereby causing init to exit and the system to panic.
An early fix for this was b3b19fdce, which checked /proc/filesystems
to see if SELinux was disabled (i.e. no selinuxfs entry).  But this
fails if init has not already mounted /proc, which seems to be the case
for sysvinit.

Commit 9df4988 fixed this issue by mounting /proc before reading /proc
filesystems, but triggers unnecessary attempts to mount /proc for other
users of libselinux besides init.  Commit 5a8d8c4 fixed that issue by
making the mounting of /proc conditional on it not already being mounted.

Arguably if the installer is going to run with SELinux disabled, then
it shouldn't have any /etc/selinux/config or other SELinux policy files
present, but that is left to a separate change.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>