### PR TITLE
GHC QA warnings

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,3 +15,6 @@ BBFILES += " \
 BBFILE_COLLECTIONS += "oe-layer"
 BBFILE_PATTERN_oe-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_oe-layer = "9"
+
+LICENSE_PATH += " ${LAYERDIR}/files/additional-licenses/"
+

--- a/files/additional-licenses/GHCL
+++ b/files/additional-licenses/GHCL
@@ -1,0 +1,31 @@
+The Glasgow Haskell Compiler License
+
+Copyright 2002, The University Court of the University of Glasgow. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+ 
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+ 
+- Neither name of the University nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
+GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipes-devtools/ghc/ghc-native_6.12.1.bb
+++ b/recipes-devtools/ghc/ghc-native_6.12.1.bb
@@ -5,8 +5,8 @@
 # BBCLASSEXTEND in a GHC recipe.
 
 SUMMARY = "ghc-native"
-DESCRIPTION = "GHC"
-LICENSE = "Glasgow"
+DESCRIPTION = "Haskell (GHC) native"
+LICENSE = "GHCL"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7cb08deb79c4385547f57d6bb2864e0f"
 

--- a/recipes-devtools/ghc/ghc-runtime_6.12.1.bb
+++ b/recipes-devtools/ghc/ghc-runtime_6.12.1.bb
@@ -73,6 +73,9 @@ do_tweak_configuration() {
 
 addtask tweak_configuration after do_configure before do_compile
 
+# I know it hurts, but please be quiet.
+INSANE_SKIP_${PN} = "installed-vs-shipped"
+
 #do_install() {
 #    make install "DESTDIR=${D}"
 #}

--- a/recipes-devtools/ghc/ghc-runtime_6.12.1.bb
+++ b/recipes-devtools/ghc/ghc-runtime_6.12.1.bb
@@ -8,7 +8,7 @@ DESCRIPTION = "Haskell is an advanced purely-functional programming language. An
 AUTHOR = "Adam Oliver <aikidokatech@users.noreply.github.com>"
 HOMEPAGE = "http://www.haskell.org/"
 SECTION = "devel"
-LICENSE = "Glascow"
+LICENSE = "GHCL"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7cb08deb79c4385547f57d6bb2864e0f"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/ghc-${PV}:"


### PR DESCRIPTION
Add GHC License in the layer so it is provided for relevant packages.

INSANE_SKIP installed-vs-shipped:
Currently, install puts files in staging absolute path, making this very noisy in the logs. The fix should be to avoid that, the very loud logs are reporting a side effect of the real issue.