### PR TITLE
[conf] xenclient-customtasks

### DIFF
--- a/classes/xenclient-customtask.bbclass
+++ b/classes/xenclient-customtask.bbclass
@@ -1,57 +1,27 @@
-# This class contains convenience tasks for working with XenClient
+#
+# Convenience tasks for corner cases.
+#
 
-# makeclean:
-# Run "make clean" and remove the do_compile stamp if it exists
-
-__do_xcmakeclean() {
+__makeclean() {
     oe_runmake clean
 }
-
-FORCE_REBUILD_TASK_WHITELIST = "do_fetch do_unpack do_unpack_xc_repos do_patch do_apply_patchqueue do_populate_lic do_configure"
-
 python do_makeclean() {
-    from bb import note
-    note("Running make clean")
-    try:
-        bb.build.exec_func("__do_xcmakeclean", d)
-    except bb.build.FuncFailed:
-        pass
+    workdir = d.getVar('B', True)
+    makefiles = [ '/Makefile', '/GNUmakefile', '/makefile' ]
+    if reduce(lambda x, y: x or os.path.exists(workdir + y), makefiles, False):
+        bb.build.exec_func('__makeclean', d)
+        bb.build.write_taint('do_compile' , d)
+        sstate_clean_cachefiles(d)
 }
-python do_force_rebuild() {
-    from bb import note,build
-    from os import unlink, listdir
-    from glob import glob
+addtask do_makeclean
+do_makeclean[nostamp] = "1"
+do_makeclean[doc] = "Run `make clean', if applicable and mark do_compile as tainted."
 
-    # clean stamps...
-    task_whitelist = d.getVar("FORCE_REBUILD_TASK_WHITELIST", True).split()
-    stampglob = bb.data.expand('${STAMP}.*', d)
-    for stamp in glob(stampglob):
-        if stamp.find(".sigdata.") != -1:
-            continue
-        task = stamp.rsplit(".", 1)[-1]
-        if task in task_whitelist:
-            continue
-        note("Removing compilation stamp %s" % stamp)
-        try:
-            unlink(stamp)
-        except OSError:
-            pass
-    # ...and sstate
+python do_force_rebuild() {
+    bb.build.write_taint('do_compile' , d)
     sstate_clean_cachefiles(d)
 }
-
 addtask do_force_rebuild
-do_force_rebuild[depends] = ""
 do_force_rebuild[nostamp] = "1"
+do_force_rebuild[doc] = "Mark do_compile as tainted, forcing it to be run again."
 
-addtask makeclean
-do_makeclean[depends] = "${PN}:do_force_rebuild"
-do_makeclean[nostamp] = "1"
-
-do_protos() {
-    oe_runmake protos
-}
-
-addtask protos
-do_protos[depends] = ""
-do_protos[nostamp] = "1"


### PR DESCRIPTION
xenclient-customtasks.bbclass introduced two tasks for xenclient
recipes:
- do_force_rebuild: Remove stamps file of any tasks not in a whitelist
    Currently, that will end up doing "bitbake -c clean <target>" in the
    end.
- do_makeclean: Call "oe_runmake clean", and depends on force_rebuild
    making it a bit misleading...

The first really looks like "bitbake -C compile <task>"
I am not sure what the second provides, it is fine to do make clean in
devshell.
