### PR TITLE
grub: mount / and /boot/system as ext3

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
@@ -30,7 +30,7 @@ fi
 
 TBOOT_COMMON_CMD="min_ram=0x2000000 loglvl=all serial=115200,8n1,0x3f8 logging=serial,memory"
 XEN_COMMON_CMD="console=com1 dom0_mem=min:320M,max:320M,320M com1=115200,8n1,pci mbi-video vga=current flask_enforcing=1 loglvl=debug guest_loglvl=debug"
-LINUX_COMMON_CMD="console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0"
+LINUX_COMMON_CMD="console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3"
 
 menuentry "XenClient: Normal" {
 	background_image /grub/booting.png


### PR DESCRIPTION
After the jethro merge, / and /boot/system get mounted as ext2 instead of ext3.
I suspect it is due to a change in busybox, that now somehow defaults to ext2.
According to the man page (http://linux.die.net/man/1/busybox), mount will:

    Mount a filesystem. Filesystem autodetection requires /proc be mounted.

Since the partition are mounted by busybox in the initramfs, /proc is probably missing at that point...

The initscript can use kernel options for choosing the filesystem, so I'm adding those to the Linux command line in Grub.

Maybe at some point we'll want the initscript to be able to figure things out by itself...

Signed-off-by: Jed <lejosnej@ainfosec.com>