### PR TITLE
[linux-4.4] Add missing commit.

### DIFF
--- a/recipes-kernel/linux/4.4/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.4/patches/usbback-base.patch
@@ -2498,7 +2498,7 @@ Index: linux-4.4/drivers/usb/xen-usbback/usbback.c
 +
 +	for (i = 0; i < mmap_pages; i++) {
 +		pending_segments[i].grant_handle = USBBACK_INVALID_HANDLE;
-+		pending_pages[i] = alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
++		pending_pages[i] = alloc_page(GFP_KERNEL);
 +		if (pending_pages[i] == NULL)
 +			goto out_of_memory;
 +		pending_segments[i].page = pending_pages[i];


### PR DESCRIPTION
Commit 7048bea53ef8ad3e22a79800dae6d2c5d5fdd36f fixed OXT-481, but
never made it into stable-5.