### PR TITLE
Make dom0 default to SELinux enforcing.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20140311/config
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20140311/config
@@ -1,2 +1,2 @@
-SELINUX=permissive
+SELINUX=enforcing
 SELINUXTYPE=xc_policy


### PR DESCRIPTION
This change restores dom0 to SELinux enforcing by default,
as it used to be prior to the jethro merge.  Depends on the dom0
policy fixes.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>