### PR TITLE
Make the ndvm default to SELinux enforcing.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20140311/xenclient-ndvm/config
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20140311/xenclient-ndvm/config
@@ -1,2 +1,2 @@
-SELINUX=permissive
+SELINUX=enforcing
 SELINUXTYPE=xc_policy


### PR DESCRIPTION
This change restores the ndvm to SELinux enforcing mode by default,
as it used to be prior to the jethro merge.   Depends on the ndvm
policy fixes.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>