### PR TITLE
Do not audit db-cmd ipc_lock denial.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20140311/patches/policy.modules.system.udev.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20140311/patches/policy.modules.system.udev.diff
@@ -29,7 +29,19 @@ Index: refpolicy/policy/modules/system/udev.te
  type udev_etc_t alias etc_udev_t;
  files_config_file(udev_etc_t)
  
-@@ -90,6 +96,7 @@ kernel_rw_unix_dgram_sockets(udev_t)
+@@ -55,6 +61,11 @@ allow udev_t self:unix_stream_socket con
+ allow udev_t self:netlink_kobject_uevent_socket create_socket_perms;
+ allow udev_t self:rawip_socket create_socket_perms;
+ 
++# Ignore CAP_IPC_LOCK denial triggered by mmap(MAP_LOCKED);
++# the operation will still succeed.  See the following kernel commit:
++# http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a5a6579db33af91f4f5134e14be758dc71c1b694
++dontaudit udev_t self:capability ipc_lock;
++
+ allow udev_t udev_exec_t:file write;
+ can_exec(udev_t, udev_exec_t)
+ 
+@@ -90,6 +101,7 @@ kernel_rw_unix_dgram_sockets(udev_t)
  kernel_dgram_send(udev_t)
  kernel_signal(udev_t)
  kernel_search_debugfs(udev_t)
@@ -37,7 +49,7 @@ Index: refpolicy/policy/modules/system/udev.te
  
  #https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=235182
  kernel_rw_net_sysctls(udev_t)
-@@ -119,6 +126,7 @@ files_read_etc_files(udev_t)
+@@ -119,6 +131,7 @@ files_read_etc_files(udev_t)
  files_exec_etc_files(udev_t)
  files_getattr_generic_locks(udev_t)
  files_search_mnt(udev_t)
@@ -45,7 +57,7 @@ Index: refpolicy/policy/modules/system/udev.te
  
  fs_getattr_all_fs(udev_t)
  fs_list_inotifyfs(udev_t)
-@@ -318,8 +326,40 @@ optional_policy(`
+@@ -318,8 +331,40 @@ optional_policy(`
  	kernel_read_xen_state(udev_t)
  	xen_manage_log(udev_t)
  	xen_read_image_files(udev_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20140311/policy/modules/apps/db-cmd.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20140311/policy/modules/apps/db-cmd.te
@@ -63,3 +63,8 @@ optional_policy(`
 	network_slave_rw_fifo_files(db_cmd_t)
 	network_slave_rw_stream_sockets(db_cmd_t)
 ')
+
+# Ignore CAP_IPC_LOCK denial triggered by mmap(MAP_LOCKED);
+# the operation will still succeed.  See the following kernel commit:
+# http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a5a6579db33af91f4f5134e14be758dc71c1b694
+dontaudit db_cmd_t self:capability ipc_lock;

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20140311/policy/modules/services/network-daemon.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20140311/policy/modules/services/network-daemon.te
@@ -139,3 +139,8 @@ allow network_slave_t self:fifo_file rw_fifo_file_perms;
 allow network_slave_t self:netlink_route_socket rw_netlink_socket_perms;
 allow network_slave_t self:process signal;
 allow network_slave_t network_slave_exec_t:file execute_no_trans;
+
+# Ignore CAP_IPC_LOCK denial triggered by mmap(MAP_LOCKED);
+# the operation will still succeed.  See the following kernel commit:
+# http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a5a6579db33af91f4f5134e14be758dc71c1b694
+dontaudit network_slave_t self:capability ipc_lock;


### PR DESCRIPTION
mmap(MAP_LOCKED) can trigger spurious ipc_lock denials because
can_do_mlock() performs the capable(CAP_IPC_LOCK) check first and
then checks whether the caller's RLIMIT_MEMLOCK is non-zero; in either
case, the operation can proceed.  This was fixed by
http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a5a6579db33af91f4f5134e14be758dc71c1b694
to reorder the checks.

db-cmd may run under the caller's domain or in its own domain, depending
on policy.  Thus, we need to dontaudit this permission for several domains.

Resolves these denials:
avc:  denied  { ipc_lock } for  pid=1196 comm="db-cmd" capability=14  scontext=system_u:system_r:udev_t:s0-s0:c0.c1023 tcontext=system_u:system_r:udev_t:s0-s0:c0.c1023 tclass=capability permissive=0

avc:  denied  { ipc_lock } for  pid=508 comm="db-cmd" capability=14  scontext=system_u:system_r:network_slave_t:s0 tcontext=system_u:system_r:network_slave_t:s0 tclass=capability permissive=0

avc:  denied  { ipc_lock } for  pid=573 comm="db-cmd" capability=14  scontext=system_u:system_r:db_cmd_t:s0 tcontext=system_u:system_r:db_cmd_t:s0 tclass=capability permissive=0

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>