### PR TITLE
Fix access to /etc/NetworkManager by NetworkManager and network-slave.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20140311/patches/policy.modules.contrib.networkmanager.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20140311/patches/policy.modules.contrib.networkmanager.diff
@@ -171,7 +171,7 @@ Index: refpolicy/policy/modules/contrib/networkmanager.if
  ##	All of the rules required to
  ##	administrate an networkmanager environment.
  ## </summary>
-@@ -317,3 +454,59 @@ interface(`networkmanager_admin',`
+@@ -317,3 +454,63 @@ interface(`networkmanager_admin',`
  	files_search_tmp($1)
  	admin_pattern($1, NetworkManager_tmp_t)
  ')
@@ -189,11 +189,15 @@ Index: refpolicy/policy/modules/contrib/networkmanager.if
 +interface(`networkmanager_manage_etc',`
 +	gen_require(`
 +		type NetworkManager_etc_t;
++		type NetworkManager_etc_rw_t;
 +	')
 +
 +	manage_files_pattern($1, NetworkManager_etc_t, NetworkManager_etc_t);
 +	manage_dirs_pattern($1, NetworkManager_etc_t, NetworkManager_etc_t);
 +	read_lnk_files_pattern($1, NetworkManager_etc_t, NetworkManager_etc_t);
++	manage_dirs_pattern($1, NetworkManager_etc_t, NetworkManager_etc_rw_t)
++	manage_files_pattern($1, NetworkManager_etc_t, NetworkManager_etc_rw_t)
++	filetrans_pattern($1, NetworkManager_etc_t, NetworkManager_etc_rw_t, { dir file })
 +')
 +
 +########################################


### PR DESCRIPTION
/etc/NetworkManager within the ndvm is a tmpfs mount populated by
network-slave and managed via NetworkManager.  The top-level directory
for this mount is assigned NetworkManager_etc_t via a rootcontext= mount
option in the fstab.  Normally read-only configuration files for
NetworkManager are labeled with NetworkManager_etc_t while read-write
configuration files are labeled NetworkManager_etc_rw_t.  There is an
automatic file type transition defined so that when NetworkManager creates
files under /etc/NetworkManager, they are assigned the NetworkManager_etc_rw_t
type.  However, network-slave lacked a corresponding type transition
definition, and thus the files it created were being left in
NetworkManager_etc_t, producing denials when manually configuring
networking (shown below).

Extend the networkmanager_manage_etc() interface that is already
being called by the network-slave domain to also define a file type
transition to NetworkManager_etc_rw_t and to allow the caller to
manage directories and files with this type.  This causes all files
and subdirectories created by network-slave under /etc/NetworkManager
to be assigned NetworkManager_etc_rw_t and thus to be updateable by
NetworkManager.

If we truly need multiple types under /etc/NetworkManager for some
reason, then we would need to either define name-based type transitions
to distinguish based on the specific file name, or modify network-slave
to explicitly label the files.

Resolves the following denials:
avc:  denied  { unlink } for  pid=738 comm="NetworkManager" name=57697265642045746865726E657420436F6E6E656374696F6E dev="tmpfs" ino=10207 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:NetworkManager_etc_t:s0 tclass=file permissive=0

avc:  denied  { setattr } for  pid=738 comm="NetworkManager" name=57697265642045746865726E657420436F6E6E656374696F6E dev="tmpfs" ino=10207 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:NetworkManager_etc_t:s0 tclass=file permissive=0

(The name= field above decodes to "Wired Ethernet Connection", which
was the connection being edited).

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>