### PR TITLE
Change configure_measured_launch() to use luksOpen --test-passphrase.

### DIFF
--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -245,7 +245,7 @@ configure_measured_launch()
         rm -f ${key_file}
         return 1
     }
-    cat ${key_file} | cryptsetup -q -d - -S 1 luksCheckKey \
+    cat ${key_file} | cryptsetup -q -d - -S 1 luksOpen --test-passphrase \
         ${config_dev} >/dev/null 2>&1 || {
         echo "failed to verify new crypto key in config LUKS" >&2
         rm -f ${key_file}


### PR DESCRIPTION
configure_measured_launch() was invoking cryptsetup with a custom-defined
luksCheckKey action to test the key it just added.  The patch implementing
luksCheckKey was not forward-ported during the jethro merge, so this
was always failing.  As cryptsetup has changed its internal API and
data structures, the patch no longer applies, even manually, and would
require a rewrite.  However, research discovered that luksOpen now
supports a --test-passphrase option that seems to provide equivalent
functionality.  So simply switch from luksCheckKey to luksOpen
--test-passphrase.

With this change, I can successfully run tpm-setup after install
and transition to a measured launch.  This does not fix being
able to initially install with measured launch enabled; some other
issue is still breaking that functionality.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>