### PR TITLE
Add RDEPENDS for libgcc to trousers.

### DIFF
--- a/recipes-openxt/trousers/trousers_0.3.2-1.bb
+++ b/recipes-openxt/trousers/trousers_0.3.2-1.bb
@@ -49,6 +49,7 @@ do_install_append() {
 }
 
 RPROVIDES_${PN} =+ "${PN}-data"
+RDEPENDS_${PN} = "libgcc"
 PACKAGES =+ "${PN}-data"
 FILES_${PN}-data = "${datadir}/trousers/system.data.auth \
 	${datadir}/trousers/system.data.noauth \


### PR DESCRIPTION
tcsd depends on libgcc_s.so.1 for pthread_cancel.
The absence of libgcc_s.so.1 from the installer rootfs was
causing tcsd to abort during installation, and thereby
preventing installing with measured launch enabled.
libgcc_s.so.1 was already being included in the dom0 rootfs,
which is why tpm-setup could work.

With this fix and the luksCheckKey fix applied, one can
once again install with measured launch enabled.

OXT-473
OXT-518

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>