### PR TITLE
OXT-516 : Remove erroneous LICENSE line from libxcdbus bb file

### DIFF
--- a/recipes-openxt/libxcdbus/libxcdbus_git.bb
+++ b/recipes-openxt/libxcdbus/libxcdbus_git.bb
@@ -10,8 +10,6 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/libxcdbus.git;protocol=${OPENXT_GIT_PROTOC
 
 EXTRA_OECONF += "--with-idldir=${STAGING_IDLDIR}"
 
-LICENSE="Proprietary"
-
 S = "${WORKDIR}/git"
 
 inherit autotools-brokensep pkgconfig lib_package xenclient


### PR DESCRIPTION
There is already a LICENSE line indicating the correct LGPLv2.1
so this extra incorrect LICENSE line should be removed.

Signed-off-by: Christopher Clark <christopher.w.clark@gmail.com>
on behalf of BAE Systems.