### PR TITLE
OXT-524 : fix the software licence of linux-firmware package

### DIFF
--- a/recipes-kernel/linux-firmware/LICENCE.broadcom_bnx2
+++ b/recipes-kernel/linux-firmware/LICENCE.broadcom_bnx2
@@ -1,0 +1,8 @@
+ This file contains firmware data derived from proprietary unpublished
+ source code, Copyright (c) 2004 - 2010 Broadcom Corporation.
+
+ Permission is hereby granted for the distribution of this firmware data
+ in hexadecimal or equivalent format, provided this copyright notice is
+ accompanying it.
+
+Found in hex form in kernel source.

--- a/recipes-kernel/linux-firmware/linux-firmware_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bb
@@ -4,9 +4,11 @@ SECTION = "kernel"
 # Notes:
 # Based on the OE one but with the new git repository
 
-LICENSE = "Proprietary"
+LICENSE = "Intel & Broadcom"
 
-LIC_FILES_CHKSUM = "file://LICENCE.iwlwifi_firmware;md5=3fd842911ea93c29cd32679aa23e1c88"
+LIC_FILES_CHKSUM = "file://LICENCE.iwlwifi_firmware;md5=3fd842911ea93c29cd32679aa23e1c88 \
+                    file://LICENCE.broadcom_bcm43xx;md5=3160c14df7228891b868060e1951dfbc \
+                    file://${FILE_DIRNAME}/LICENCE.broadcom_bnx2;md5=46e2a5689ed924549feb511065c6efa9"
 
 SRCREV = "75cc3ef8ba6712fd72c073b17a790282136cc743"
 PV = "0.1+git${SRCPV}"
@@ -32,6 +34,15 @@ do_install() {
 	# Broadcom NetXtreme II firmware
 	install -d ${D}/lib/firmware/bnx2/
 	cp bnx2/bnx2-mips-09-6.2.1b.fw ${D}/lib/firmware/bnx2
+    # Ref: OXT-524
+    # It is unclear from the upstream source whether this is the intended
+    # software licence for the Broadcom bnx2 driver -- given the filename,
+    # it seems unlikely -- but we take the conservative approach and include it:
+	install -m 644 LICENCE.broadcom_bcm43xx ${D}/lib/firmware
+    # This second Broadcom licence is extracted from the WHENCE file in the
+    # upstream linux-firmware repository and is derived from comments in the
+    # kernel source:
+	install -m 644 ${FILE_DIRNAME}/LICENCE.broadcom_bnx2 ${D}/lib/firmware
 }
 
 FILES_${PN} = "/lib/firmware/"


### PR DESCRIPTION
Changes:
* Change ipkg metadata to indicate Intel and Broadcom, rather than
  Proprietary. The two licenses are Open Source compatible.
  Note that the build does indicate warnings about no generic
  licence file existing for those licences, which seems fair.

* Ensure that the Broadcom licence ends up in the package, as
  required by the licence. Previously it was missing.

* Since the upstream licence for the Broadcom firmware is unclear,
  include both possible licences.

Signed-off-by: christopher.clark6@baesystems.com
On behalf of BAE Systems.