### PR TITLE
Linux: set 4.4 as the default kernel

### DIFF
--- a/conf/distro/openxt-linux-3.18.conf
+++ b/conf/distro/openxt-linux-3.18.conf
@@ -16,7 +16,7 @@
 # require conf/sanity.conf
 #
 
-PREFERRED_VERSION_linux-openxt ?= "4.4%"
+PREFERRED_VERSION_linux-openxt ?= "3.18%"
 
 require conf/distro/openxt-main.conf
 

--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -16,7 +16,7 @@
 # require conf/sanity.conf
 #
 
-PREFERRED_VERSION_linux-openxt ?= "3.18%"
+PREFERRED_VERSION_linux-openxt ?= "4.4%"
 
 # Down the road this should probably be a machine config thing so it is possible
 # to have images that do not include selinux


### PR DESCRIPTION
Ignore the diff, all I did is:

    xenclient-oe/conf/distro$ git mv openxt-main.conf openxt-linux-3.18.conf
    xenclient-oe/conf/distro$ git mv openxt-linux-4.4.conf openxt-main.conf

OXT-476

Signed-off-by: Jed <lejosnej@ainfosec.com>