### PR TITLE
Move the do_compile_prepend to their own tasks

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
@@ -202,10 +202,16 @@ POL_TYPE = "xc_policy"
 #conf_file = "${THISDIR}/${PN}-${PV}/config"
 #POL_TYPE = "${@get_poltype(conf_file)}"
 
-do_compile_prepend() {
+do_srctree_copy() {
         cp -r ${WORKDIR}/policy ${S}/
+}
+ 
+do_modules_copy() {
         cat ${S}/policy/modules-upstream.conf ${S}/policy/modules-openxt.conf > ${S}/policy/modules.conf
 }
+
+addtask do_srctree_copy after do_unpack before do_compile
+addtask do_modules_copy after do_srctree_copy before do_compile
 
 do_install_append() {
         install -d ${D}/etc/selinux


### PR DESCRIPTION
With the current do_compile_prepend there is no order precedence for derived projects to add their own modules or make changes before compile to existing upstream policies. By adding specific tasks for these steps, derived projects can better extend the module and policy changes.

Signed-off-by: Richard Turner <turnerr@ainfosec.com>