### PR TITLE
OXT-524 : fix the software license of linux-firmware package

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bb
@@ -4,9 +4,11 @@ SECTION = "kernel"
 # Notes:
 # Based on the OE one but with the new git repository
 
-LICENSE = "Proprietary"
+LICENSE = "WHENCE & LICENCE.broadcom_bcm43xx & LICENCE.iwlwifi_firmware"
 
-LIC_FILES_CHKSUM = "file://LICENCE.iwlwifi_firmware;md5=3fd842911ea93c29cd32679aa23e1c88"
+LIC_FILES_CHKSUM = "file://LICENCE.iwlwifi_firmware;md5=3fd842911ea93c29cd32679aa23e1c88 \
+                    file://LICENCE.broadcom_bcm43xx;md5=3160c14df7228891b868060e1951dfbc \
+                    file://WHENCE;beginline=1224;endline=1264;md5=c31e99ad18d493aaa6bac6d78ea37155"
 
 SRCREV = "75cc3ef8ba6712fd72c073b17a790282136cc743"
 PV = "0.1+git${SRCPV}"
@@ -32,6 +34,15 @@ do_install() {
 	# Broadcom NetXtreme II firmware
 	install -d ${D}/lib/firmware/bnx2/
 	cp bnx2/bnx2-mips-09-6.2.1b.fw ${D}/lib/firmware/bnx2
+    # Ref: OXT-524
+    # It is unclear from the upstream source whether this is the intended
+    # software licence for the Broadcom bnx2 driver -- given the filename,
+    # it seems unlikely -- but we take the conservative approach and include it:
+    install -m 644 LICENCE.broadcom_bcm43xx ${D}/lib/firmware
+    # This second Broadcom licence is within the WHENCE file in the
+    # upstream linux-firmware repository and is derived from comments in the
+    # kernel source:
+    install -m 644 WHENCE ${D}/lib/firmware
 }
 
 FILES_${PN} = "/lib/firmware/"


### PR DESCRIPTION
Changes:
* Change ipkg metadata to indicate the specific firmware licenses
  rather than Proprietary.
  The firmware licenses are Open Source compatible.

* Ensure that the Broadcom license ends up in the package, as
  required by the license. Previously it was missing.

* Since the upstream license for the Broadcom firmware is unclear,
  include both possible licenses.

Signed-off-by: christopher.clark6@baesystems.com