### PR TITLE
refpolicy: Update SELinux definitions for Linux 4.4

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.apm.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.apm.diff
@@ -2,7 +2,15 @@ Index: refpolicy/policy/modules/contrib/apm.te
 ===================================================================
 --- refpolicy.orig/policy/modules/contrib/apm.te
 +++ refpolicy/policy/modules/contrib/apm.te
-@@ -100,6 +100,8 @@ dev_rw_apm_bios(apmd_t)
+@@ -64,6 +64,7 @@ dontaudit apmd_t self:capability { setui
+ allow apmd_t self:process { signal_perms getsession };
+ allow apmd_t self:fifo_file rw_fifo_file_perms;
+ allow apmd_t self:netlink_socket create_socket_perms;
++allow apmd_t self:netlink_generic_socket create_socket_perms;
+ allow apmd_t self:unix_stream_socket { accept listen };
+ 
+ allow apmd_t apmd_lock_t:file manage_file_perms;
+@@ -100,6 +101,8 @@ dev_rw_apm_bios(apmd_t)
  dev_rw_sysfs(apmd_t)
  dev_dontaudit_getattr_all_chr_files(apmd_t)
  dev_dontaudit_getattr_all_blk_files(apmd_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/upstream-add-binder-security-class.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/upstream-add-binder-security-class.patch
@@ -1,0 +1,45 @@
+From 946d0237d2be451becd7d0a9e349be5098fc2dd3 Mon Sep 17 00:00:00 2001
+From: Laurent Bigonville <bigon@bigon.be>
+Date: Wed, 6 May 2015 18:31:28 +0200
+Subject: [PATCH] Add "binder" security class and access vectors
+
+---
+ policy/flask/access_vectors   | 8 ++++++++
+ policy/flask/security_classes | 2 ++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/policy/flask/access_vectors b/policy/flask/access_vectors
+index da539c8..2b20aa0 100644
+--- a/policy/flask/access_vectors
++++ b/policy/flask/access_vectors
+@@ -844,6 +844,14 @@ inherits socket
+ 	attach_queue
+ }
+ 
++class binder
++{
++	impersonate
++	call
++	set_context_mgr
++	transfer
++}
++
+ class x_pointer
+ inherits x_device
+ 
+diff --git a/policy/flask/security_classes b/policy/flask/security_classes
+index caed61a..653d347 100644
+--- a/policy/flask/security_classes
++++ b/policy/flask/security_classes
+@@ -123,6 +123,8 @@ class kernel_service
+ 
+ class tun_socket
+ 
++class binder
++
+ # Still More SE-X Windows stuff
+ class x_pointer			# userspace
+ class x_keyboard		# userspace
+-- 
+2.5.5
+

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/upstream-contrib-networkmanager.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/upstream-contrib-networkmanager.patch
@@ -1,0 +1,33 @@
+From d29aff48b5fbd718c91cf92c46d82faf6d56b7bc Mon Sep 17 00:00:00 2001
+From: Stephen Smalley <sds@tycho.nsa.gov>
+Date: Fri, 22 May 2015 08:49:50 -0400
+Subject: [PATCH] contrib: networkmanager: allow netlink_generic_socket access
+
+refpolicy commit 58b302957652322288618ceda0771d39e74a9e46
+defined the new netlink socket security classes introduced by
+kernel commit 223ae516404a7a65f09e79a1c0291521c233336e.
+NetworkManager requires netlink_generic_socket access when
+running on a kernel with this change.  Add an allow rule for it,
+while retaining the existing :netlink_socket rule for compatibility
+on older kernels.
+
+Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
+---
+ policy/modules/contrib/networkmanager.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/contrib/networkmanager.te b/policy/modules/contrib/networkmanager.te
+index abd35ac..7dc7cb7 100644
+--- a/policy/modules/contrib/networkmanager.te
++++ b/policy/modules/contrib/networkmanager.te
+@@ -47,6 +47,7 @@ allow NetworkManager_t self:unix_dgram_socket sendto;
+ allow NetworkManager_t self:unix_stream_socket { accept listen };
+ allow NetworkManager_t self:netlink_route_socket create_netlink_socket_perms;
+ allow NetworkManager_t self:netlink_socket create_socket_perms;
++allow NetworkManager_t self:netlink_generic_socket create_socket_perms;
+ allow NetworkManager_t self:netlink_kobject_uevent_socket create_socket_perms;
+ allow NetworkManager_t self:tcp_socket { accept listen };
+ allow NetworkManager_t self:tun_socket { create_socket_perms relabelfrom relabelto };
+-- 
+2.5.5
+

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/upstream-update-netlink-classes.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/upstream-update-netlink-classes.patch
@@ -1,0 +1,216 @@
+From 58b302957652322288618ceda0771d39e74a9e46 Mon Sep 17 00:00:00 2001
+From: Stephen Smalley <sds@tycho.nsa.gov>
+Date: Thu, 21 May 2015 13:38:09 -0400
+Subject: [PATCH] Update netlink socket classes.
+
+Define new netlink socket security classes introduced by kernel commit
+223ae516404a7a65f09e79a1c0291521c233336e.
+
+Note that this does not remove the long-since obsolete
+netlink_firewall_socket and netlink_ip6_fw_socket classes
+from refpolicy in case they are still needed for legacy
+distribution policies.
+
+Add the new socket classes to socket_class_set.
+Update ubac and mls constraints for the new socket classes.
+Add allow rules for a few specific known cases (netutils, iptables,
+netlabel, ifconfig, udev) in core policy that require access.
+Further refinement for the contrib tree will be needed.  Any allow
+rule previously written on :netlink_socket may need to be rewritten or
+duplicated for one of the more specific classes.  For now, we retain the
+existing :netlink_socket rules for compatibility on older kernels.
+
+Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
+---
+ policy/constraints                  |  8 ++++++++
+ policy/flask/access_vectors         | 24 ++++++++++++++++++++++++
+ policy/flask/security_classes       | 10 ++++++++++
+ policy/mls                          |  6 +++---
+ policy/modules/admin/netutils.te    |  2 ++
+ policy/modules/system/iptables.te   |  1 +
+ policy/modules/system/netlabel.te   |  1 +
+ policy/modules/system/sysnetwork.te |  1 +
+ policy/modules/system/udev.te       |  1 +
+ policy/support/obj_perm_sets.spt    |  2 +-
+ 10 files changed, 52 insertions(+), 4 deletions(-)
+
+Index: refpolicy/policy/constraints
+===================================================================
+--- refpolicy.orig/policy/constraints
++++ refpolicy/policy/constraints
+@@ -150,6 +150,14 @@ exempted_ubac_constraint(netlink_kobject
+ exempted_ubac_constraint(appletalk_socket, ubacsock)
+ exempted_ubac_constraint(dccp_socket, ubacsock)
+ exempted_ubac_constraint(tun_socket, ubacsock)
++exempted_ubac_constraint(netlink_iscsi_socket, ubacsock)
++exempted_ubac_constraint(netlink_fib_lookup_socket, ubacsock)
++exempted_ubac_constraint(netlink_connector_socket, ubacsock)
++exempted_ubac_constraint(netlink_netfilter_socket, ubacsock)
++exempted_ubac_constraint(netlink_generic_socket, ubacsock)
++exempted_ubac_constraint(netlink_scsitransport_socket, ubacsock)
++exempted_ubac_constraint(netlink_rdma_socket, ubacsock)
++exempted_ubac_constraint(netlink_crypto_socket, ubacsock)
+ 
+ constrain socket_class_set { create relabelto relabelfrom } 
+ (
+Index: refpolicy/policy/flask/access_vectors
+===================================================================
+--- refpolicy.orig/policy/flask/access_vectors
++++ refpolicy/policy/flask/access_vectors
+@@ -852,6 +852,30 @@ class binder
+ 	transfer
+ }
+ 
++class netlink_iscsi_socket
++inherits socket
++
++class netlink_fib_lookup_socket
++inherits socket
++
++class netlink_connector_socket
++inherits socket
++
++class netlink_netfilter_socket
++inherits socket
++
++class netlink_generic_socket
++inherits socket
++
++class netlink_scsitransport_socket
++inherits socket
++
++class netlink_rdma_socket
++inherits socket
++
++class netlink_crypto_socket
++inherits socket
++
+ class x_pointer
+ inherits x_device
+ 
+Index: refpolicy/policy/flask/security_classes
+===================================================================
+--- refpolicy.orig/policy/flask/security_classes
++++ refpolicy/policy/flask/security_classes
+@@ -125,6 +125,16 @@ class tun_socket
+ 
+ class binder
+ 
++# Updated netlink classes for more recent netlink protocols.
++class netlink_iscsi_socket
++class netlink_fib_lookup_socket
++class netlink_connector_socket
++class netlink_netfilter_socket
++class netlink_generic_socket
++class netlink_scsitransport_socket
++class netlink_rdma_socket
++class netlink_crypto_socket
++
+ # Still More SE-X Windows stuff
+ class x_pointer			# userspace
+ class x_keyboard		# userspace
+Index: refpolicy/policy/mls
+===================================================================
+--- refpolicy.orig/policy/mls
++++ refpolicy/policy/mls
+@@ -164,7 +164,7 @@ mlsconstrain filesystem { mount remount
+ #
+ 
+ # new socket labels must be dominated by the relabeling subjects clearance
+-mlsconstrain { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket } relabelto
++mlsconstrain { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket netlink_rdma_socket netlink_crypto_socket } relabelto
+ 	( h1 dom h2 );
+ 
+ # the socket "read+write" ops
+@@ -180,7 +180,7 @@ mlsconstrain { socket tcp_socket udp_soc
+ 
+ 
+ # the socket "read" ops (note the check is dominance of the low level)
+-mlsconstrain { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket } { read getattr listen accept getopt recv_msg }
++mlsconstrain { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket netlink_rdma_socket netlink_crypto_socket } { read getattr listen accept getopt recv_msg }
+ 	(( l1 dom l2 ) or
+ 	 (( t1 == mlsnetreadtoclr ) and ( h1 dom l2 )) or
+ 	 ( t1 == mlsnetread ));
+@@ -191,7 +191,7 @@ mlsconstrain { netlink_route_socket netl
+ 	 ( t1 == mlsnetread ));
+ 
+ # the socket "write" ops
+-mlsconstrain { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket } { write setattr relabelfrom connect setopt shutdown }
++mlsconstrain { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket netlink_rdma_socket netlink_crypto_socket } { write setattr relabelfrom connect setopt shutdown }
+ 	(( l1 eq l2 ) or 
+ 	 (( t1 == mlsnetwriteranged ) and ( l1 dom l2 ) and ( l1 domby h2 )) or
+ 	 (( t1 == mlsnetwritetoclr ) and ( h1 dom l2 ) and ( l1 domby l2 )) or
+Index: refpolicy/policy/modules/admin/netutils.te
+===================================================================
+--- refpolicy.orig/policy/modules/admin/netutils.te
++++ refpolicy/policy/modules/admin/netutils.te
+@@ -38,6 +38,8 @@ dontaudit netutils_t self:capability { d
+ allow netutils_t self:process { setcap signal_perms };
+ allow netutils_t self:netlink_route_socket create_netlink_socket_perms;
+ allow netutils_t self:netlink_socket create_socket_perms;
++# For tcpdump.
++allow netutils_t self:netlink_netfilter_socket create_socket_perms;
+ allow netutils_t self:packet_socket create_socket_perms;
+ allow netutils_t self:udp_socket create_socket_perms;
+ allow netutils_t self:tcp_socket create_stream_socket_perms;
+Index: refpolicy/policy/modules/system/iptables.te
+===================================================================
+--- refpolicy.orig/policy/modules/system/iptables.te
++++ refpolicy/policy/modules/system/iptables.te
+@@ -35,6 +35,7 @@ dontaudit iptables_t self:capability sys
+ allow iptables_t self:fifo_file rw_fifo_file_perms;
+ allow iptables_t self:process { sigchld sigkill sigstop signull signal };
+ allow iptables_t self:netlink_socket create_socket_perms;
++allow iptables_t self:netlink_netfilter_socket create_socket_perms;
+ allow iptables_t self:rawip_socket create_socket_perms;
+ 
+ manage_files_pattern(iptables_t, iptables_conf_t, iptables_conf_t)
+Index: refpolicy/policy/modules/system/netlabel.te
+===================================================================
+--- refpolicy.orig/policy/modules/system/netlabel.te
++++ refpolicy/policy/modules/system/netlabel.te
+@@ -18,6 +18,7 @@ role system_r types netlabel_mgmt_t;
+ # modify the network subsystem configuration
+ allow netlabel_mgmt_t self:capability net_admin;
+ allow netlabel_mgmt_t self:netlink_socket create_socket_perms;
++allow netlabel_mgmt_t self:netlink_generic_socket create_socket_perms;
+ 
+ kernel_read_network_state(netlabel_mgmt_t)
+ 
+Index: refpolicy/policy/modules/system/sysnetwork.te
+===================================================================
+--- refpolicy.orig/policy/modules/system/sysnetwork.te
++++ refpolicy/policy/modules/system/sysnetwork.te
+@@ -288,6 +288,7 @@ allow ifconfig_t self:packet_socket crea
+ # generic netlink socket for iw
+ # socket(PF_NETLINK, SOCK_RAW|SOCK_CLOEXEC, NETLINK_GENERIC) = 3
+ allow ifconfig_t self:netlink_socket create_socket_perms;
++allow ifconfig_t self:netlink_generic_socket create_socket_perms;
+ allow ifconfig_t self:netlink_route_socket create_netlink_socket_perms;
+ allow ifconfig_t self:netlink_xfrm_socket create_netlink_socket_perms;
+ allow ifconfig_t self:tcp_socket { create ioctl };
+Index: refpolicy/policy/modules/system/udev.te
+===================================================================
+--- refpolicy.orig/policy/modules/system/udev.te
++++ refpolicy/policy/modules/system/udev.te
+@@ -59,6 +59,7 @@ allow udev_t self:unix_stream_socket { l
+ allow udev_t self:unix_dgram_socket sendto;
+ allow udev_t self:unix_stream_socket connectto;
+ allow udev_t self:netlink_kobject_uevent_socket create_socket_perms;
++allow udev_t self:netlink_generic_socket create_socket_perms;
+ allow udev_t self:rawip_socket create_socket_perms;
+ 
+ # Ignore CAP_IPC_LOCK denial triggered by mmap(MAP_LOCKED);
+Index: refpolicy/policy/support/obj_perm_sets.spt
+===================================================================
+--- refpolicy.orig/policy/support/obj_perm_sets.spt
++++ refpolicy/policy/support/obj_perm_sets.spt
+@@ -28,7 +28,7 @@ define(`devfile_class_set', `{ chr_file
+ #
+ # All socket classes.
+ #
+-define(`socket_class_set', `{ tcp_socket udp_socket rawip_socket netlink_socket packet_socket unix_stream_socket unix_dgram_socket appletalk_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket netlink_kobject_uevent_socket tun_socket }')
++define(`socket_class_set', `{ tcp_socket udp_socket rawip_socket netlink_socket packet_socket unix_stream_socket unix_dgram_socket appletalk_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket netlink_kobject_uevent_socket tun_socket netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket netlink_rdma_socket netlink_crypto_socket }')
+ 
+ 
+ #

--- a/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
@@ -172,6 +172,9 @@ SRC_URI += " \
     file://patches/dbusbouncer-interfaces.diff \
     file://patches/qemu1.4_wrapper_file_context.patch;striplevel=1 \
     file://patches/openxt_system_unconfined_readonly_neverallow_fixes.patch;patch=1 \
+    file://patches/upstream-add-binder-security-class.patch;patch=1 \
+    file://patches/upstream-update-netlink-classes.patch;patch=1 \
+    file://patches/upstream-contrib-networkmanager.patch;patch=1 \
     "
     
 def get_poltype(f):


### PR DESCRIPTION
Linux 4.4 includes additional SELinux security classes that
are not defined by the refpolicy release used in OpenXT.

Consequently, on boot, one gets the following warnings in dmesg:

SELinux:  Class netlink_iscsi_socket not defined in policy.
SELinux:  Class netlink_fib_lookup_socket not defined in policy.
SELinux:  Class netlink_connector_socket not defined in policy.
SELinux:  Class netlink_netfilter_socket not defined in policy.
SELinux:  Class netlink_generic_socket not defined in policy.
SELinux:  Class netlink_scsitransport_socket not defined in policy.
SELinux:  Class netlink_rdma_socket not defined in policy.
SELinux:  Class netlink_crypto_socket not defined in policy.
SELinux:  Class binder not defined in policy.
SELinux: the above unknown classes and permissions will be allowed

In Linux 4.2, additional, finer-grained netlink socket security classes
were defined for various netlink protocols to permit specific control
over them rather than falling back to the general netlink_socket security
class.  The binder security class was also finally upstreamed from Android
for control over the binder driver.

Add two patches from upstream refpolicy to define these security
classes, and one patch from upstream refpolicy to allow NETLINK_GENERIC
usage by networkmanager.  These patches silence the above warnings,
ensure proper SELinux enforcement over these netlink protocols (and
over the binder driver if one were to ever enable it), and allow operation
of NetworkManager.

Adjust the existing patch for the apmd domain used by acpid to also
allow it to use NETLINK_GENERIC sockets to address denials triggered
once the new classes are defined such as:

avc:  denied  { create } for  pid=860 comm="acpid" scontext=system_u:system_r:apmd_t:s0 tcontext=system_u:system_r:apmd_t:s0 tclass=netlink_generic_socket permissive=0

There may be other domains previously allowed access to netlink_socket
that will now need access to one of the more specific classes, but
I do not see any other denials at present.

These changes have no impact on older kernels (e.g. 3.18).  The existing
rules on netlink_socket are left in place for compatibility with
such kernels.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>