### PR TITLE
Preserve label of /var/lock/xen-atapi-pt-lock* on restorecon.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/stubdom-helpers.fc
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/stubdom-helpers.fc
@@ -20,3 +20,4 @@
 
 /usr/lib/xen/bin/atapi_pt_helper        --      gen_context(system_u:object_r:atapi_helper_exec_t,s0)
 /usr/lib/xen/bin/audio_helper(_start)?  --      gen_context(system_u:object_r:audio_helper_exec_t,s0)
+/var/lock/xen-atapi-pt-lock-[0-9]+_[0-9]+_[0-9]+_[0-9]+ -- gen_context(system_u:object_r:atapi_helper_lock_t,s0)


### PR DESCRIPTION
atapi_pt_helper creates `/var/lock/xen-atapi-pt-lock-<a>_<b>_<c>_<d>`,
and policy defines a type transition to assign it atapi_helper_lock_t,
but there is no file_contexts (.fc) entry for it.  Thus, a restorecon
will incorrectly reset it to var_lock_t.  Add an entry for it.
After this change, restorecon -Rv /var/lock reports no changes.

OXT-306

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>