### PR TITLE
Fix xenclient-extra

### DIFF
--- a/recipes-core/packagegroups/packagegroup-xenclient-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-extra.bb
@@ -15,10 +15,8 @@ RDEPENDS_${PN} = "\
     gcc \
     gdb \
     git \
-    icbinn-fuse \
     ltrace \
     make \
-    nfs-utils \
     powertop \
     quilt \
     screen \


### PR DESCRIPTION
icbinn-fuse, nfs-utils and valgrind failed to build.
Removed the first two and fixed valgrind.

Signed-off-by: Jed <lejosnej@ainfosec.com>