### PR TITLE
Have one dm-agent for both stubdom and dom0

### DIFF
--- a/recipes-core/images/xenclient-stubdomain-initramfs-image.bb
+++ b/recipes-core/images/xenclient-stubdomain-initramfs-image.bb
@@ -10,7 +10,7 @@ DEPENDS += "dialog"
  
 IMAGE_FSTYPES = "cpio.gz"
 IMAGE_INSTALL = "busybox bridge-utils initramfs-xenclient"
-IMAGE_INSTALL += "qemu-dm-stubdom v4v-module dm-agent-stubdom simple-poweroff rsyslog"
+IMAGE_INSTALL += "qemu-dm-stubdom v4v-module dm-agent simple-poweroff rsyslog"
 IMAGE_LINGUAS = ""
 IMAGE_DEV_MANAGER = "busybox-mdev"
 IMAGE_BOOT = "${IMAGE_DEV_MANAGER}"

--- a/recipes-openxt/dm-agent/dm-agent-stubdom_git.bb
+++ b/recipes-openxt/dm-agent/dm-agent-stubdom_git.bb
@@ -1,7 +1,0 @@
-require dm-agent.inc
-
-FILESEXTRAPATHS_prepend := "${THISDIR}/dm-agent:"
-
-SRCREV = "${AUTOREV}"
-
-EXTRA_OECONF += "--disable-syslog --disable-dmbus"


### PR DESCRIPTION
Without dmbus there is no need to split dm-agent in two flavor.

OXT-544