### PR TITLE
fstab: make /var/cache big enough for opkg downloads

### DIFF
--- a/recipes-core/base-files/base-files/fstab.xenclient-dom0
+++ b/recipes-core/base-files/base-files/fstab.xenclient-dom0
@@ -2,7 +2,7 @@ rootfs                        /             auto   defaults,noatime             
 proc                          /proc         proc   defaults                                                     0  0
 devpts                        /dev/pts      devpts mode=0620,gid=5                                              0  0
 tmpfs                         /var/volatile tmpfs  defaults,rootcontext=system_u:object_r:var_t:s0,size=2M      0  0
-tmpfs                         /var/cache    tmpfs  defaults,rootcontext=system_u:object_r:var_t:s0,size=2M      0  0
+tmpfs                         /var/cache    tmpfs  defaults,rootcontext=system_u:object_r:var_t:s0,size=100M    0  0
 tmpfs                         /var/lib/dbus tmpfs  defaults,rootcontext=system_u:object_r:system_dbusd_var_lib_t:s0,size=1M    0  0
 tmpfs                         /var/lock     tmpfs  defaults,rootcontext=system_u:object_r:var_lock_t:s0,size=1M 0  0
 tmpfs                         /var/run      tmpfs  defaults,rootcontext=system_u:object_r:var_run_t:s0,size=1M  0  0

--- a/recipes-core/base-files/base-files/fstab.xenclient-ndvm
+++ b/recipes-core/base-files/base-files/fstab.xenclient-ndvm
@@ -2,7 +2,7 @@ rootfs          /                                       auto   ro               
 proc            /proc                                   proc   defaults                                                         0  0
 devpts          /dev/pts                                devpts mode=0620,gid=5                                                  0  0
 tmpfs           /var/volatile                           tmpfs  defaults,rootcontext=system_u:object_r:var_t:s0,size=1M          0  0
-tmpfs           /var/cache                              tmpfs  defaults,rootcontext=system_u:object_r:var_t:s0,size=2M          0  0
+tmpfs           /var/cache                              tmpfs  defaults,rootcontext=system_u:object_r:var_t:s0,size=100M        0  0
 tmpfs           /var/lock                               tmpfs  defaults,rootcontext=system_u:object_r:var_lock_t:s0,size=1M     0  0
 tmpfs           /var/run                                tmpfs  defaults,rootcontext=system_u:object_r:var_run_t:s0,size=1M      0  0
 tmpfs           /var/log                                tmpfs  defaults,rootcontext=system_u:object_r:var_log_t:s0,size=10M     0  0
@@ -14,7 +14,7 @@ tmpfs           /var/lib/dbus                           tmpfs  defaults,rootcont
 tmpfs           /etc/NetworkManager tmpfs  defaults,rootcontext=system_u:object_r:NetworkManager_etc_t:s0,size=2M          0  0
 tmpfs           /etc/dnsmasq-config                     tmpfs  defaults,rootcontext=system_u:object_r:dnsmasq_etc_t:s0,size=1M          0  0
 tmpfs           /etc/iproute2                           tmpfs  defaults,rootcontext=system_u:object_r:net_conf_t:s0,size=1M          0  0
-tmpfs           /var/lib/dhcp                           tmpfs  defaults,rootcontext=system_u:object_r:dhcp_state_t:s0,size=1M   0  0  
+tmpfs           /var/lib/dhcp                           tmpfs  defaults,rootcontext=system_u:object_r:dhcp_state_t:s0,size=1M   0  0
 tmpfs           /var/lib/NetworkManager                 tmpfs  defaults,rootcontext=system_u:object_r:NetworkManager_var_lib_t:s0,size=1M   0  0
 xenfs		/proc/xen				xenfs  defaults								0  0
 

--- a/recipes-core/base-files/base-files/fstab.xenclient-syncvm
+++ b/recipes-core/base-files/base-files/fstab.xenclient-syncvm
@@ -2,7 +2,7 @@ proc            /proc                   proc    defaults                0  0
 xenfs           /proc/xen               xenfs   defaults                0  0
 devpts          /dev/pts                devpts  mode=0620,gid=5         0  0
 tmpfs           /var/volatile           tmpfs   defaults,size=1M        0  0
-tmpfs           /var/cache              tmpfs   defaults,size=1M        0  0
+tmpfs           /var/cache              tmpfs   defaults,size=100M      0  0
 tmpfs           /var/lock               tmpfs   defaults,size=1M        0  0
 tmpfs           /var/run                tmpfs   defaults,size=1M        0  0
 tmpfs           /var/log                tmpfs   defaults,size=10M       0  0

--- a/recipes-core/base-files/base-files/fstab.xenclient-uivm
+++ b/recipes-core/base-files/base-files/fstab.xenclient-uivm
@@ -1,7 +1,7 @@
 proc            /proc                   proc    defaults                0  0
 devpts          /dev/pts                devpts  mode=0620,gid=5         0  0
 tmpfs           /var/volatile           tmpfs   defaults,size=1M        0  0
-tmpfs           /var/cache              tmpfs   defaults,size=1M        0  0
+tmpfs           /var/cache              tmpfs   defaults,size=100M      0  0
 tmpfs           /var/lock               tmpfs   defaults,size=1M        0  0
 tmpfs           /var/run                tmpfs   defaults,size=1M        0  0
 tmpfs           /var/log                tmpfs   defaults,size=10M       0  0


### PR DESCRIPTION
OXT-553

Signed-off-by: Jed <lejosnej@ainfosec.com>