### PR TITLE
linux-4.4 microcode-xen.c failed to init

### DIFF
--- a/recipes-kernel/linux/4.4/patches/konrad-microcode.patch
+++ b/recipes-kernel/linux/4.4/patches/konrad-microcode.patch
@@ -33,10 +33,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.4.9/arch/x86/include/asm/microcode.h
+Index: linux-4.4.10/arch/x86/include/asm/microcode.h
 ===================================================================
---- linux-4.4.9.orig/arch/x86/include/asm/microcode.h	2016-05-11 15:15:38.052216388 +0200
-+++ linux-4.4.9/arch/x86/include/asm/microcode.h	2016-05-11 15:15:55.635304170 +0200
+--- linux-4.4.10.orig/arch/x86/include/asm/microcode.h	2016-05-11 11:23:26.000000000 +0200
++++ linux-4.4.10/arch/x86/include/asm/microcode.h	2016-05-12 14:48:35.915206491 +0200
 @@ -194,4 +194,13 @@
  #endif
  }
@@ -51,10 +51,10 @@ Index: linux-4.4.9/arch/x86/include/asm/microcode.h
 +#endif
 +
  #endif /* _ASM_X86_MICROCODE_H */
-Index: linux-4.4.9/arch/x86/xen/Kconfig
+Index: linux-4.4.10/arch/x86/xen/Kconfig
 ===================================================================
---- linux-4.4.9.orig/arch/x86/xen/Kconfig	2016-05-11 15:15:36.198908936 +0200
-+++ linux-4.4.9/arch/x86/xen/Kconfig	2016-05-11 15:15:38.052216388 +0200
+--- linux-4.4.10.orig/arch/x86/xen/Kconfig	2016-05-11 11:23:26.000000000 +0200
++++ linux-4.4.10/arch/x86/xen/Kconfig	2016-05-12 14:48:35.915206491 +0200
 @@ -55,3 +55,8 @@
  	bool "Support for running as a PVH guest"
  	depends on X86_64 && XEN && XEN_PVHVM
@@ -64,19 +64,19 @@ Index: linux-4.4.9/arch/x86/xen/Kconfig
 +       def_bool y
 +       depends on XEN_DOM0 && MICROCODE
 +
-Index: linux-4.4.9/arch/x86/kernel/cpu/microcode/Makefile
+Index: linux-4.4.10/arch/x86/kernel/cpu/microcode/Makefile
 ===================================================================
---- linux-4.4.9.orig/arch/x86/kernel/cpu/microcode/Makefile	2016-05-11 15:15:36.198908936 +0200
-+++ linux-4.4.9/arch/x86/kernel/cpu/microcode/Makefile	2016-05-11 15:15:38.052216388 +0200
+--- linux-4.4.10.orig/arch/x86/kernel/cpu/microcode/Makefile	2016-05-11 11:23:26.000000000 +0200
++++ linux-4.4.10/arch/x86/kernel/cpu/microcode/Makefile	2016-05-12 14:48:35.915206491 +0200
 @@ -2,3 +2,4 @@
  obj-$(CONFIG_MICROCODE)			+= microcode.o
  microcode-$(CONFIG_MICROCODE_INTEL)	+= intel.o intel_lib.o
  microcode-$(CONFIG_MICROCODE_AMD)	+= amd.o
 +microcode-$(CONFIG_MICROCODE_XEN)	+= xen.o
-Index: linux-4.4.9/arch/x86/kernel/cpu/microcode/core.c
+Index: linux-4.4.10/arch/x86/kernel/cpu/microcode/core.c
 ===================================================================
---- linux-4.4.9.orig/arch/x86/kernel/cpu/microcode/core.c	2016-05-11 15:15:36.202242223 +0200
-+++ linux-4.4.9/arch/x86/kernel/cpu/microcode/core.c	2016-05-11 15:15:38.052216388 +0200
+--- linux-4.4.10.orig/arch/x86/kernel/cpu/microcode/core.c	2016-05-11 11:23:26.000000000 +0200
++++ linux-4.4.10/arch/x86/kernel/cpu/microcode/core.c	2016-05-23 13:36:28.586428813 +0200
 @@ -32,6 +32,8 @@
  #include <linux/fs.h>
  #include <linux/mm.h>
@@ -86,8 +86,12 @@ Index: linux-4.4.9/arch/x86/kernel/cpu/microcode/core.c
  #include <asm/microcode_intel.h>
  #include <asm/cpu_device_id.h>
  #include <asm/microcode_amd.h>
-@@ -633,7 +635,9 @@
- 	if (paravirt_enabled() || dis_ucode_ldr)
+@@ -630,10 +632,12 @@
+ 	struct cpuinfo_x86 *c = &boot_cpu_data;
+ 	int error;
+ 
+-	if (paravirt_enabled() || dis_ucode_ldr)
++	if (dis_ucode_ldr)
  		return -EINVAL;
  
 -	if (c->x86_vendor == X86_VENDOR_INTEL)
@@ -97,10 +101,10 @@ Index: linux-4.4.9/arch/x86/kernel/cpu/microcode/core.c
  		microcode_ops = init_intel_microcode();
  	else if (c->x86_vendor == X86_VENDOR_AMD)
  		microcode_ops = init_amd_microcode();
-Index: linux-4.4.9/arch/x86/kernel/cpu/microcode/xen.c
+Index: linux-4.4.10/arch/x86/kernel/cpu/microcode/xen.c
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ linux-4.4.9/arch/x86/kernel/cpu/microcode/xen.c	2016-05-11 15:15:38.052216388 +0200
++++ linux-4.4.10/arch/x86/kernel/cpu/microcode/xen.c	2016-05-12 14:48:35.915206491 +0200
 @@ -0,0 +1,198 @@
 +/*
 + * Xen microcode update driver


### PR DESCRIPTION
Linux 3.18 introduced a commit disabling microcode update logic for
paravirt guest since Xen support is not upstream.
As we have konrad's patch, we can remove that test.

OXT-418