### PR TITLE
OXT-575: package and install two iwlwifi firmwares in NDVM and installer filesystems

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -51,6 +51,8 @@ IMAGE_INSTALL = "\
     linux-firmware-iwlwifi-7260-7 \
     linux-firmware-iwlwifi-7260-8 \
     linux-firmware-iwlwifi-7260-9 \
+    linux-firmware-iwlwifi-7260-12 \
+    linux-firmware-iwlwifi-7260-13 \
     linux-firmware-iwlwifi-7265-8 \
     linux-firmware-iwlwifi-7265-9 \
     linux-firmware-bnx2 \

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -47,6 +47,8 @@ IMAGE_INSTALL = "\
     linux-firmware-iwlwifi-7260-7 \
     linux-firmware-iwlwifi-7260-8 \
     linux-firmware-iwlwifi-7260-9 \
+    linux-firmware-iwlwifi-7260-12 \
+    linux-firmware-iwlwifi-7260-13 \
     linux-firmware-iwlwifi-7265-8 \
     linux-firmware-iwlwifi-7265-9 \
     linux-firmware-bnx2 \

--- a/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -8,18 +8,29 @@ LIC_FILES_CHKSUM += "file://WHENCE;beginline=1224;endline=1264;md5=c31e99ad18d49
 NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
 PACKAGES =+ "${PN}-whence-license ${PN}-bnx2 \
+             ${PN}-iwlwifi-7260-12 ${PN}-iwlwifi-7260-13 \
             "
 LICENSE_${PN}-bnx2 = "WHENCE"
 LICENSE_${PN}-whence-license = "WHENCE"
+LICENSE_${PN}-iwlwifi-7260-12 = "Firmware-iwlwifi_firmware"
+LICENSE_${PN}-iwlwifi-7260-13 = "Firmware-iwlwifi_firmware"
+
+# bug fix: these LICENSE lines are missing upstream:
+LICENSE_${PN}-iwlwifi-6000g2b-5 = "Firmware-iwlwifi_firmware"
+LICENSE_${PN}-iwlwifi-license = "Firmware-iwlwifi_firmware"
 
 FILES_${PN}-bnx2 = "/lib/firmware/bnx2/*.fw"
 FILES_${PN}-whence-license = "/lib/firmware/WHENCE"
+FILES_${PN}-iwlwifi-7260-12 = "/lib/firmware/iwlwifi-7260-12.ucode"
+FILES_${PN}-iwlwifi-7260-13 = "/lib/firmware/iwlwifi-7260-13.ucode"
 
 RDEPENDS_${PN}-bnx2 += "${PN}-whence-license"
+RDEPENDS_${PN}-iwlwifi-7260-12 = "${PN}-iwlwifi-license"
+RDEPENDS_${PN}-iwlwifi-7260-13 = "${PN}-iwlwifi-license"
 
 LICENSE_${PN} += "& WHENCE \
 "
 
 LICENSE_${PN}-license += "/lib/firmware/WHENCE"
 
-RDEPENDS_${PN} += "${PN}-bnx2 ${PN}-whence-license"
+RDEPENDS_${PN} += "${PN}-bnx2 ${PN}-whence-license ${PN}-iwlwifi-7260-12 ${PN}-iwlwifi-7260-13"


### PR DESCRIPTION
This PR is deliberately omitting installation of these two firmwares into the dom0 filesystem due to OXT-576. This should enable validation of correct functionality of the wifi device without the firmware present in dom0. If this succeeds, all wifi firmware can then be removed from the dom0 filesystem.