### PR TITLE
Backport CVE-2014-3615 and fix XSA-179 regression

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/cve-2014-3615-vbe-rework-sanity-checks.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/cve-2014-3615-vbe-rework-sanity-checks.patch
@@ -1,0 +1,235 @@
+From c1b886c45dc70f247300f549dce9833f3fa2def5 Mon Sep 17 00:00:00 2001
+From: Gerd Hoffmann <kraxel@redhat.com>
+Date: Tue, 26 Aug 2014 15:35:23 +0200
+Subject: [PATCH] vbe: rework sanity checks
+
+Plug a bunch of holes in the bochs dispi interface parameter checking.
+Add a function doing verification on all registers.  Call that
+unconditionally on every register write.  That way we should catch
+everything, even changing one register affecting the valid range of
+another register.
+
+Some of the holes have been added by commit
+e9c6149f6ae6873f14a12eea554925b6aa4c4dec.  Before that commit the
+maximum possible framebuffer (VBE_DISPI_MAX_XRES * VBE_DISPI_MAX_YRES *
+32 bpp) has been smaller than the qemu vga memory (8MB) and the checking
+for VBE_DISPI_MAX_XRES + VBE_DISPI_MAX_YRES + VBE_DISPI_MAX_BPP was ok.
+
+Some of the holes have been there forever, such as
+VBE_DISPI_INDEX_X_OFFSET and VBE_DISPI_INDEX_Y_OFFSET register writes
+lacking any verification.
+
+Security impact:
+
+(1) Guest can make the ui (gtk/vnc/...) use memory rages outside the vga
+frame buffer as source  ->  host memory leak.  Memory isn't leaked to
+the guest but to the vnc client though.
+
+(2) Qemu will segfault in case the memory range happens to include
+unmapped areas  ->  Guest can DoS itself.
+
+The guest can not modify host memory, so I don't think this can be used
+by the guest to escape.
+
+CVE-2014-3615
+
+Cc: qemu-stable@nongnu.org
+Cc: secalert@redhat.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Reviewed-by: Laszlo Ersek <lersek@redhat.com>
+---
+ hw/display/vga.c | 154 ++++++++++++++++++++++++++++++++++---------------------
+ 1 file changed, 95 insertions(+), 59 deletions(-)
+
+Index: qemu-1.4.0/hw/vga.c
+===================================================================
+--- qemu-1.4.0.orig/hw/vga.c	2016-05-27 15:46:54.484379499 +0200
++++ qemu-1.4.0/hw/vga.c	2016-05-27 15:49:23.392828940 +0200
+@@ -586,6 +586,93 @@
+     }
+ }
+ 
++/*
++ * Sanity check vbe register writes.
++ *
++ * As we don't have a way to signal errors to the guest in the bochs
++ * dispi interface we'll go adjust the registers to the closest valid
++ * value.
++ */
++static void vbe_fixup_regs(VGACommonState *s)
++{
++    uint16_t *r = s->vbe_regs;
++    uint32_t bits, linelength, maxy, offset;
++
++    if (!(r[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_ENABLED)) {
++        /* vbe is turned off -- nothing to do */
++        return;
++    }
++
++    /* check depth */
++    switch (r[VBE_DISPI_INDEX_BPP]) {
++    case 4:
++    case 8:
++    case 16:
++    case 24:
++    case 32:
++        bits = r[VBE_DISPI_INDEX_BPP];
++        break;
++    case 15:
++        bits = 16;
++        break;
++    default:
++        bits = r[VBE_DISPI_INDEX_BPP] = 8;
++        break;
++    }
++
++    /* check width */
++    r[VBE_DISPI_INDEX_XRES] &= ~7u;
++    if (r[VBE_DISPI_INDEX_XRES] == 0) {
++        r[VBE_DISPI_INDEX_XRES] = 8;
++    }
++    if (r[VBE_DISPI_INDEX_XRES] > VBE_DISPI_MAX_XRES) {
++        r[VBE_DISPI_INDEX_XRES] = VBE_DISPI_MAX_XRES;
++    }
++    r[VBE_DISPI_INDEX_VIRT_WIDTH] &= ~7u;
++    if (r[VBE_DISPI_INDEX_VIRT_WIDTH] > VBE_DISPI_MAX_XRES) {
++        r[VBE_DISPI_INDEX_VIRT_WIDTH] = VBE_DISPI_MAX_XRES;
++    }
++    if (r[VBE_DISPI_INDEX_VIRT_WIDTH] < r[VBE_DISPI_INDEX_XRES]) {
++        r[VBE_DISPI_INDEX_VIRT_WIDTH] = r[VBE_DISPI_INDEX_XRES];
++    }
++
++    /* check height */
++    linelength = r[VBE_DISPI_INDEX_VIRT_WIDTH] * bits / 8;
++    maxy = s->vbe_size / linelength;
++    if (r[VBE_DISPI_INDEX_YRES] == 0) {
++        r[VBE_DISPI_INDEX_YRES] = 1;
++    }
++    if (r[VBE_DISPI_INDEX_YRES] > VBE_DISPI_MAX_YRES) {
++        r[VBE_DISPI_INDEX_YRES] = VBE_DISPI_MAX_YRES;
++    }
++    if (r[VBE_DISPI_INDEX_YRES] > maxy) {
++        r[VBE_DISPI_INDEX_YRES] = maxy;
++    }
++
++    /* check offset */
++    if (r[VBE_DISPI_INDEX_X_OFFSET] > VBE_DISPI_MAX_XRES) {
++        r[VBE_DISPI_INDEX_X_OFFSET] = VBE_DISPI_MAX_XRES;
++    }
++    if (r[VBE_DISPI_INDEX_Y_OFFSET] > VBE_DISPI_MAX_YRES) {
++        r[VBE_DISPI_INDEX_Y_OFFSET] = VBE_DISPI_MAX_YRES;
++    }
++    offset = r[VBE_DISPI_INDEX_X_OFFSET] * bits / 8;
++    offset += r[VBE_DISPI_INDEX_Y_OFFSET] * linelength;
++    if (offset + r[VBE_DISPI_INDEX_YRES] * linelength > s->vbe_size) {
++        r[VBE_DISPI_INDEX_Y_OFFSET] = 0;
++        offset = r[VBE_DISPI_INDEX_X_OFFSET] * bits / 8;
++        if (offset + r[VBE_DISPI_INDEX_YRES] * linelength > s->vbe_size) {
++            r[VBE_DISPI_INDEX_X_OFFSET] = 0;
++            offset = 0;
++        }
++    }
++
++    /* update vga state */
++    r[VBE_DISPI_INDEX_VIRT_HEIGHT] = maxy;
++    s->vbe_line_offset = linelength;
++    s->vbe_start_addr  = offset / 4;
++}
++
+ static uint32_t vbe_ioport_read_index(void *opaque, uint32_t addr)
+ {
+     VGACommonState *s = opaque;
+@@ -679,22 +766,13 @@
+             }
+             break;
+         case VBE_DISPI_INDEX_XRES:
+-            if ((val <= VBE_DISPI_MAX_XRES) && ((val & 7) == 0)) {
+-                s->vbe_regs[s->vbe_index] = val;
+-            }
+-            break;
+         case VBE_DISPI_INDEX_YRES:
+-            if (val <= VBE_DISPI_MAX_YRES) {
+-                s->vbe_regs[s->vbe_index] = val;
+-            }
+-            break;
+         case VBE_DISPI_INDEX_BPP:
+-            if (val == 0)
+-                val = 8;
+-            if (val == 4 || val == 8 || val == 15 ||
+-                val == 16 || val == 24 || val == 32) {
+-                s->vbe_regs[s->vbe_index] = val;
+-            }
++        case VBE_DISPI_INDEX_VIRT_WIDTH:
++        case VBE_DISPI_INDEX_X_OFFSET:
++        case VBE_DISPI_INDEX_Y_OFFSET:
++            s->vbe_regs[s->vbe_index] = val;
++            vbe_fixup_regs(s);
+             break;
+         case VBE_DISPI_INDEX_BANK:
+             if (s->vbe_regs[VBE_DISPI_INDEX_BPP] == 4) {
+@@ -711,21 +789,11 @@
+                 !(s->vbe_regs[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_ENABLED)) {
+                 int h, shift_control;
+ 
+-                s->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] =
+-                    s->vbe_regs[VBE_DISPI_INDEX_XRES];
+-                s->vbe_regs[VBE_DISPI_INDEX_VIRT_HEIGHT] =
+-                    s->vbe_regs[VBE_DISPI_INDEX_YRES];
++                s->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] = 0;
+                 s->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] = 0;
+                 s->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] = 0;
+-
+-                if (!s->vbe_ext_regs[VBE_DISPI_EXT_INDEX_STRIDE - VBE_DISPI_EXT_INDEX_START]) {
+-                    if (s->vbe_regs[VBE_DISPI_INDEX_BPP] == 4)
+-                        s->vbe_line_offset = s->vbe_regs[VBE_DISPI_INDEX_XRES] >> 1;
+-                    else
+-                        s->vbe_line_offset = s->vbe_regs[VBE_DISPI_INDEX_XRES] *
+-                            ((s->vbe_regs[VBE_DISPI_INDEX_BPP] + 7) >> 3);
+-                }
+-                s->vbe_start_addr = 0;
++                s->vbe_regs[VBE_DISPI_INDEX_ENABLE] |= VBE_DISPI_ENABLED;
++                vbe_fixup_regs(s);
+ 
+                 /* clear the screen (should be done in BIOS) */
+                 if (!(val & VBE_DISPI_NOCLEARMEM)) {
+@@ -774,40 +842,6 @@
+             s->vbe_regs[s->vbe_index] = val;
+             vga_update_memory_access(s);
+             break;
+-        case VBE_DISPI_INDEX_VIRT_WIDTH:
+-            {
+-                int w, h, line_offset;
+-
+-                if (val < s->vbe_regs[VBE_DISPI_INDEX_XRES])
+-                    return;
+-                w = val;
+-                if (s->vbe_regs[VBE_DISPI_INDEX_BPP] == 4)
+-                    line_offset = w >> 1;
+-                else
+-                    line_offset = w * ((s->vbe_regs[VBE_DISPI_INDEX_BPP] + 7) >> 3);
+-                h = s->vbe_size / line_offset;
+-                /* XXX: support weird bochs semantics ? */
+-                if (h < s->vbe_regs[VBE_DISPI_INDEX_YRES])
+-                    return;
+-                s->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] = w;
+-                s->vbe_regs[VBE_DISPI_INDEX_VIRT_HEIGHT] = h;
+-                s->vbe_line_offset = line_offset;
+-            }
+-            break;
+-        case VBE_DISPI_INDEX_X_OFFSET:
+-        case VBE_DISPI_INDEX_Y_OFFSET:
+-            {
+-                int x;
+-                s->vbe_regs[s->vbe_index] = val;
+-                s->vbe_start_addr = s->vbe_line_offset * s->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET];
+-                x = s->vbe_regs[VBE_DISPI_INDEX_X_OFFSET];
+-                if (s->vbe_regs[VBE_DISPI_INDEX_BPP] == 4)
+-                    s->vbe_start_addr += x >> 1;
+-                else
+-                    s->vbe_start_addr += x * ((s->vbe_regs[VBE_DISPI_INDEX_BPP] + 7) >> 3);
+-                s->vbe_start_addr >>= 2;
+-            }
+-            break;
+         default:
+             break;
+         }

--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/vbe-bochs-dispi-return-correct-mem-size-with-qxl.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/vbe-bochs-dispi-return-correct-mem-size-with-qxl.patch
@@ -1,0 +1,74 @@
+commit 54a85d462447c1cb8a1638578a7fd086350b4d2d
+Author: Gerd Hoffmann <kraxel@redhat.com>
+Date:   Tue Aug 26 14:16:30 2014 +0200
+
+    vbe: make bochs dispi interface return the correct memory size with qxl
+    
+    VgaState->vram_size is the size of the pci bar.  In case of qxl not the
+    whole pci bar can be used as vga framebuffer.  Add a new variable
+    vbe_size to handle that case.  By default (if unset) it equals
+    vram_size, but qxl can set vbe_size to something else.
+    
+    This makes sure VBE_DISPI_INDEX_VIDEO_MEMORY_64K returns correct results
+    and sanity checks are done with the correct size too.
+    
+    Cc: qemu-stable@nongnu.org
+    Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+    Reviewed-by: Laszlo Ersek <lersek@redhat.com>
+
+Index: qemu-1.4.0/hw/qxl.c
+===================================================================
+--- qemu-1.4.0.orig/hw/qxl.c	2013-02-16 00:05:35.000000000 +0100
++++ qemu-1.4.0/hw/qxl.c	2016-05-27 15:46:54.407713626 +0200
+@@ -2059,6 +2059,7 @@
+ 
+     qxl->id = 0;
+     qxl_init_ramsize(qxl);
++    vga->vbe_size = qxl->vgamem_size;
+     vga->vram_size_mb = qxl->vga.vram_size >> 20;
+     vga_common_init(vga);
+     vga_init(vga, pci_address_space(dev), pci_address_space_io(dev), false);
+Index: qemu-1.4.0/hw/vga.c
+===================================================================
+--- qemu-1.4.0.orig/hw/vga.c	2016-05-27 15:45:48.898395853 +0200
++++ qemu-1.4.0/hw/vga.c	2016-05-27 15:46:54.484379499 +0200
+@@ -620,7 +620,7 @@
+             val = s->vbe_regs[s->vbe_index];
+         }
+     } else if (s->vbe_index == VBE_DISPI_INDEX_VIDEO_MEMORY_64K) {
+-        val = s->vram_size / (64 * 1024);
++        val = s->vbe_size / (64 * 1024);
+     } else {
+         val = 0;
+         if (!(s->vbe_regs[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_GETCAPS)) {
+@@ -785,7 +785,7 @@
+                     line_offset = w >> 1;
+                 else
+                     line_offset = w * ((s->vbe_regs[VBE_DISPI_INDEX_BPP] + 7) >> 3);
+-                h = s->vram_size / line_offset;
++                h = s->vbe_size / line_offset;
+                 /* XXX: support weird bochs semantics ? */
+                 if (h < s->vbe_regs[VBE_DISPI_INDEX_YRES])
+                     return;
+@@ -2330,6 +2330,9 @@
+         s->vram_size <<= 1;
+     }
+     s->vram_size_mb = s->vram_size >> 20;
++    if (!s->vbe_size) {
++        s->vbe_size = s->vram_size;
++    }
+ 
+     s->is_vbe_vmstate = 1;
+     memory_region_init_ram(&s->vram, "vga.vram", s->vram_size);
+Index: qemu-1.4.0/hw/vga_int.h
+===================================================================
+--- qemu-1.4.0.orig/hw/vga_int.h	2016-05-10 16:03:35.255832122 +0200
++++ qemu-1.4.0/hw/vga_int.h	2016-05-27 15:46:54.551045476 +0200
+@@ -107,6 +107,7 @@
+     MemoryRegion vram_vbe;
+     uint32_t vram_size;
+     uint32_t vram_size_mb; /* property */
++    uint32_t vbe_size;
+     uint32_t latch;
+     MemoryRegion *chain4_alias;
+     uint8_t sr_index;

--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/vga-add-sr_vbe-register-set.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/vga-add-sr_vbe-register-set.patch
@@ -1,0 +1,225 @@
+From 94ef4f337fb614f18b765a8e0e878a4c23cdedcd Mon Sep 17 00:00:00 2001
+From: Gerd Hoffmann <kraxel@redhat.com>
+Date: Tue, 17 May 2016 10:54:54 +0200
+Subject: [PATCH] vga: add sr_vbe register set
+
+Commit "fd3c136 vga: make sure vga register setup for vbe stays intact
+(CVE-2016-3712)." causes a regression.  The win7 installer is unhappy
+because it can't freely modify vga registers any more while in vbe mode.
+
+This patch introduces a new sr_vbe register set.  The vbe_update_vgaregs
+will fill sr_vbe[] instead of sr[].  Normal vga register reads and
+writes go to sr[].  Any sr register read access happens through a new
+sr() helper function which will read from sr_vbe[] with vbe active and
+from sr[] otherwise.
+
+This way we can allow guests update sr[] registers as they want, without
+allowing them disrupt vbe video modes that way.
+
+Cc: qemu-stable@nongnu.org
+Reported-by: Thomas Lamprecht <thomas@lamprecht.org>
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Message-id: 1463475294-14119-1-git-send-email-kraxel@redhat.com
+---
+ hw/display/vga.c     | 50 ++++++++++++++++++++++++++++----------------------
+ hw/display/vga_int.h |  1 +
+ 2 files changed, 29 insertions(+), 22 deletions(-)
+
+Index: qemu-1.4.0/hw/vga.c
+===================================================================
+--- qemu-1.4.0.orig/hw/vga.c	2016-05-27 18:26:35.683322748 +0200
++++ qemu-1.4.0/hw/vga.c	2016-05-27 18:27:17.832890526 +0200
+@@ -180,6 +180,11 @@
+     return s->vbe_regs[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_ENABLED;
+ }
+ 
++static inline uint8_t sr(VGACommonState *s, int idx)
++{
++    return vbe_enabled(s) ? s->sr_vbe[idx] : s->sr[idx];
++}
++
+ static void vga_update_memory_access(VGACommonState *s)
+ {
+     MemoryRegion *region, *old_region = s->chain4_alias;
+@@ -187,8 +192,8 @@
+ 
+     s->chain4_alias = NULL;
+ 
+-    if ((s->sr[VGA_SEQ_PLANE_WRITE] & VGA_SR02_ALL_PLANES) ==
+-        VGA_SR02_ALL_PLANES && s->sr[VGA_SEQ_MEMORY_MODE] & VGA_SR04_CHN_4M) {
++    if ((sr(s, VGA_SEQ_PLANE_WRITE) & VGA_SR02_ALL_PLANES) ==
++        VGA_SR02_ALL_PLANES && sr(s, VGA_SEQ_MEMORY_MODE) & VGA_SR04_CHN_4M) {
+         offset = 0;
+         switch ((s->gr[VGA_GFX_MISC] >> 2) & 3) {
+         case 0:
+@@ -265,7 +270,7 @@
+           ((s->cr[VGA_CRTC_OVERFLOW] >> 6) & 2)) << 8);
+     vretr_end_line = s->cr[VGA_CRTC_V_SYNC_END] & 0xf;
+ 
+-    clocking_mode = (s->sr[VGA_SEQ_CLOCK_MODE] >> 3) & 1;
++    clocking_mode = (sr(s, VGA_SEQ_CLOCK_MODE) >> 3) & 1;
+     clock_sel = (s->msr >> 2) & 3;
+     dots = (s->msr & 1) ? 8 : 9;
+ 
+@@ -715,13 +720,13 @@
+ 
+     if (s->vbe_regs[VBE_DISPI_INDEX_BPP] == 4) {
+         shift_control = 0;
+-        s->sr[VGA_SEQ_CLOCK_MODE] &= ~8; /* no double line */
++        s->sr_vbe[VGA_SEQ_CLOCK_MODE] &= ~8; /* no double line */
+     } else {
+         shift_control = 2;
+         /* set chain 4 mode */
+-        s->sr[VGA_SEQ_MEMORY_MODE] |= VGA_SR04_CHN_4M;
++        s->sr_vbe[VGA_SEQ_MEMORY_MODE] |= VGA_SR04_CHN_4M;
+         /* activate all planes */
+-        s->sr[VGA_SEQ_PLANE_WRITE] |= VGA_SR02_ALL_PLANES;
++        s->sr_vbe[VGA_SEQ_PLANE_WRITE] |= VGA_SR02_ALL_PLANES;
+     }
+     s->gr[VGA_GFX_MODE] = (s->gr[VGA_GFX_MODE] & ~0x60) |
+         (shift_control << 5);
+@@ -906,7 +911,7 @@
+         break;
+     }
+ 
+-    if (s->sr[VGA_SEQ_MEMORY_MODE] & VGA_SR04_CHN_4M) {
++    if (sr(s, VGA_SEQ_MEMORY_MODE) & VGA_SR04_CHN_4M) {
+         /* chain 4 mode : simplest access */
+         assert(addr < s->vram_size);
+         ret = s->vram_ptr[addr];
+@@ -974,11 +979,11 @@
+         break;
+     }
+ 
+-    if (s->sr[VGA_SEQ_MEMORY_MODE] & VGA_SR04_CHN_4M) {
++    if (sr(s, VGA_SEQ_MEMORY_MODE) & VGA_SR04_CHN_4M) {
+         /* chain 4 mode : simplest access */
+         plane = addr & 3;
+         mask = (1 << plane);
+-        if (s->sr[VGA_SEQ_PLANE_WRITE] & mask) {
++        if (sr(s, VGA_SEQ_PLANE_WRITE) & mask) {
+             assert(addr < s->vram_size);
+             s->vram_ptr[addr] = val;
+ #ifdef DEBUG_VGA_MEM
+@@ -991,7 +996,7 @@
+         /* odd/even mode (aka text mode mapping) */
+         plane = (s->gr[VGA_GFX_PLANE_READ] & 2) | (addr & 1);
+         mask = (1 << plane);
+-        if (s->sr[VGA_SEQ_PLANE_WRITE] & mask) {
++        if (sr(s, VGA_SEQ_PLANE_WRITE) & mask) {
+             addr = ((addr & ~1) << 1) | plane;
+             if (addr >= s->vram_size) {
+                 return;
+@@ -1066,7 +1071,7 @@
+ 
+     do_write:
+         /* mask data according to sr[2] */
+-        mask = s->sr[VGA_SEQ_PLANE_WRITE];
++        mask = sr(s, VGA_SEQ_PLANE_WRITE);
+         s->plane_updated |= mask; /* only used to detect font change */
+         write_mask = mask16[mask];
+         if (addr * sizeof(uint32_t) >= s->vram_size) {
+@@ -1356,10 +1361,10 @@
+     /* total width & height */
+     cheight = (s->cr[VGA_CRTC_MAX_SCAN] & 0x1f) + 1;
+     cwidth = 8;
+-    if (!(s->sr[VGA_SEQ_CLOCK_MODE] & VGA_SR01_CHAR_CLK_8DOTS)) {
++    if (!(sr(s, VGA_SEQ_CLOCK_MODE) & VGA_SR01_CHAR_CLK_8DOTS)) {
+         cwidth = 9;
+     }
+-    if (s->sr[VGA_SEQ_CLOCK_MODE] & 0x08) {
++    if (sr(s, VGA_SEQ_CLOCK_MODE) & 0x08) {
+         cwidth = 16; /* NOTE: no 18 pixel wide */
+     }
+     width = (s->cr[VGA_CRTC_H_DISP] + 1);
+@@ -1414,7 +1419,7 @@
+     int64_t now = qemu_get_clock_ms(vm_clock);
+ 
+     /* compute font data address (in plane 2) */
+-    v = s->sr[VGA_SEQ_CHARACTER_MAP];
++    v = sr(s, VGA_SEQ_CHARACTER_MAP);
+     offset = (((v >> 4) & 1) | ((v << 1) & 6)) * 8192 * 4 + 2;
+     if (offset != s->font_offsets[0]) {
+         s->font_offsets[0] = offset;
+@@ -1780,11 +1785,11 @@
+     }
+ 
+     if (shift_control == 0) {
+-        if (s->sr[VGA_SEQ_CLOCK_MODE] & 8) {
++        if (sr(s, VGA_SEQ_CLOCK_MODE) & 8) {
+             disp_width <<= 1;
+         }
+     } else if (shift_control == 1) {
+-        if (s->sr[VGA_SEQ_CLOCK_MODE] & 8) {
++        if (sr(s, VGA_SEQ_CLOCK_MODE) & 8) {
+             disp_width <<= 1;
+         }
+     }
+@@ -1833,7 +1838,7 @@
+ 
+     if (shift_control == 0) {
+         full_update |= update_palette16(s);
+-        if (s->sr[VGA_SEQ_CLOCK_MODE] & 8) {
++        if (sr(s, VGA_SEQ_CLOCK_MODE) & 8) {
+             v = VGA_DRAW_LINE4D2;
+         } else {
+             v = VGA_DRAW_LINE4;
+@@ -1841,7 +1846,7 @@
+         bits = 4;
+     } else if (shift_control == 1) {
+         full_update |= update_palette16(s);
+-        if (s->sr[VGA_SEQ_CLOCK_MODE] & 8) {
++        if (sr(s, VGA_SEQ_CLOCK_MODE) & 8) {
+             v = VGA_DRAW_LINE2D2;
+         } else {
+             v = VGA_DRAW_LINE2;
+@@ -1887,7 +1892,7 @@
+ #if 0
+     printf("w=%d h=%d v=%d line_offset=%d cr[0x09]=0x%02x cr[0x17]=0x%02x linecmp=%d sr[0x01]=0x%02x\n",
+            width, height, v, line_offset, s->cr[9], s->cr[VGA_CRTC_MODE],
+-           s->line_compare, s->sr[VGA_SEQ_CLOCK_MODE]);
++           s->line_compare, sr(s, VGA_SEQ_CLOCK_MODE));
+ #endif
+     addr1 = (s->start_addr * 4);
+     bwidth = (width * bits + 7) / 8;
+@@ -2050,6 +2055,7 @@
+ {
+     s->sr_index = 0;
+     memset(s->sr, '\0', sizeof(s->sr));
++    memset(s->sr_vbe, '\0', sizeof(s->sr_vbe));
+     s->gr_index = 0;
+     memset(s->gr, '\0', sizeof(s->gr));
+     s->ar_index = 0;
+@@ -2151,10 +2157,10 @@
+         /* total width & height */
+         cheight = (s->cr[VGA_CRTC_MAX_SCAN] & 0x1f) + 1;
+         cw = 8;
+-        if (!(s->sr[VGA_SEQ_CLOCK_MODE] & VGA_SR01_CHAR_CLK_8DOTS)) {
++        if (!(sr(s, VGA_SEQ_CLOCK_MODE) & VGA_SR01_CHAR_CLK_8DOTS)) {
+             cw = 9;
+         }
+-        if (s->sr[VGA_SEQ_CLOCK_MODE] & 0x08) {
++        if (sr(s, VGA_SEQ_CLOCK_MODE) & 0x08) {
+             cw = 16; /* NOTE: no 18 pixel wide */
+         }
+         width = (s->cr[VGA_CRTC_H_DISP] + 1);
+@@ -2320,6 +2326,7 @@
+ 
+     /* force refresh */
+     s->graphic_mode = -1;
++    vbe_update_vgaregs(s);
+     return 0;
+ }
+ 
+Index: qemu-1.4.0/hw/vga_int.h
+===================================================================
+--- qemu-1.4.0.orig/hw/vga_int.h	2016-05-27 18:26:35.843321109 +0200
++++ qemu-1.4.0/hw/vga_int.h	2016-05-27 18:26:37.779967917 +0200
+@@ -112,6 +112,7 @@
+     MemoryRegion *chain4_alias;
+     uint8_t sr_index;
+     uint8_t sr[256];
++    uint8_t sr_vbe[256];
+     uint8_t gr_index;
+     uint8_t gr[256];
+     uint8_t ar_index;

--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-179-banked-access-to-vga-memory-uses-inconsistent-bounds-checks.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-179-banked-access-to-vga-memory-uses-inconsistent-bounds-checks.patch
@@ -16,7 +16,6 @@ Patches: xsa179-qemuu-4.3-0001-vga-fix-banked-access-bounds-checking-CVE-2016-37
          xsa179-qemuu-4.3-0003-vga-factor-out-vga-register-setup.patch
          xsa179-qemuu-4.3-0004-vga-update-vga-register-setup-on-vbe-changes.patch
          xsa179-qemuu-4.3-0005-vga-make-sure-vga-register-setup-for-vbe-stays-intac.patch
-
 Qemu VGA module allows banked access to video memory using the window at
 0xa00000 and it supports different access modes with different address
 calculations.  But an attacker can easily change access modes after setting the
@@ -26,15 +25,10 @@ Qemu VGA module allows guest to edit certain registers in 'vbe' and 'vga'
 modes. ie. guest could set certain 'VGA' registers while in 'VBE' mode.  This
 is CVE-2016-3712.
 
-################################################################################
-PATCHES 
-################################################################################
-
-
 Index: qemu-1.4.0/hw/vga.c
 ===================================================================
---- qemu-1.4.0.orig/hw/vga.c	2016-05-10 15:56:36.753372298 +0200
-+++ qemu-1.4.0/hw/vga.c	2016-05-10 16:01:08.457308490 +0200
+--- qemu-1.4.0.orig/hw/vga.c	2016-05-27 18:25:02.364279319 +0200
++++ qemu-1.4.0/hw/vga.c	2016-05-27 18:25:33.550626367 +0200
 @@ -173,6 +173,13 @@
  static void vga_screen_dump(void *opaque, const char *filename, bool cswitch,
                              Error **errp);
@@ -86,8 +80,17 @@ Index: qemu-1.4.0/hw/vga.c
  
          switch(s->cr_index) {
          case VGA_CRTC_H_TOTAL:
-@@ -586,6 +598,49 @@
+@@ -598,7 +610,7 @@
+     uint16_t *r = s->vbe_regs;
+     uint32_t bits, linelength, maxy, offset;
+ 
+-    if (!(r[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_ENABLED)) {
++    if (!vbe_enabled(s)) {
+         /* vbe is turned off -- nothing to do */
+         return;
      }
+@@ -673,6 +685,49 @@
+     s->vbe_start_addr  = offset / 4;
  }
  
 +/* we initialize the VGA graphic mode */
@@ -136,8 +139,11 @@ Index: qemu-1.4.0/hw/vga.c
  static uint32_t vbe_ioport_read_index(void *opaque, uint32_t addr)
  {
      VGACommonState *s = opaque;
-@@ -697,20 +752,13 @@
-             }
+@@ -773,13 +828,10 @@
+         case VBE_DISPI_INDEX_Y_OFFSET:
+             s->vbe_regs[s->vbe_index] = val;
+             vbe_fixup_regs(s);
++            vbe_update_vgaregs(s);
              break;
          case VBE_DISPI_INDEX_BANK:
 -            if (s->vbe_regs[VBE_DISPI_INDEX_BPP] == 4) {
@@ -149,22 +155,19 @@ Index: qemu-1.4.0/hw/vga.c
              s->vbe_regs[s->vbe_index] = val;
              s->bank_offset = (val << 16);
              vga_update_memory_access(s);
-             break;
+@@ -787,53 +839,19 @@
          case VBE_DISPI_INDEX_ENABLE:
--            if ((val & VBE_DISPI_ENABLED) &&
--                !(s->vbe_regs[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_ENABLED)) {
+             if ((val & VBE_DISPI_ENABLED) &&
+                 !(s->vbe_regs[VBE_DISPI_INDEX_ENABLE] & VBE_DISPI_ENABLED)) {
 -                int h, shift_control;
--
-+            if ((val & VBE_DISPI_ENABLED) && !vbe_enabled(s)) {
-                 s->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] =
-                     s->vbe_regs[VBE_DISPI_INDEX_XRES];
-                 s->vbe_regs[VBE_DISPI_INDEX_VIRT_HEIGHT] =
-@@ -727,45 +775,13 @@
-                 }
-                 s->vbe_start_addr = 0;
  
+                 s->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] = 0;
+                 s->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] = 0;
+                 s->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] = 0;
+                 s->vbe_regs[VBE_DISPI_INDEX_ENABLE] |= VBE_DISPI_ENABLED;
+                 vbe_fixup_regs(s);
 +                vbe_update_vgaregs(s);
-+
+ 
                  /* clear the screen (should be done in BIOS) */
                  if (!(val & VBE_DISPI_NOCLEARMEM)) {
                      memset(s->vram_ptr, 0,
@@ -207,15 +210,7 @@ Index: qemu-1.4.0/hw/vga.c
              } else {
                  /* XXX: the bios should do that */
                  s->bank_offset = 0;
-@@ -806,6 +822,7 @@
-                 else
-                     s->vbe_start_addr += x * ((s->vbe_regs[VBE_DISPI_INDEX_BPP] + 7) >> 3);
-                 s->vbe_start_addr >>= 2;
-+                vbe_update_vgaregs(s);
-             }
-             break;
-         default:
-@@ -856,13 +873,21 @@
+@@ -890,13 +908,21 @@
  
      if (s->sr[VGA_SEQ_MEMORY_MODE] & VGA_SR04_CHN_4M) {
          /* chain 4 mode : simplest access */
@@ -238,7 +233,7 @@ Index: qemu-1.4.0/hw/vga.c
          s->latch = ((uint32_t *)s->vram_ptr)[addr];
  
          if (!(s->gr[VGA_GFX_MODE] & 0x08)) {
-@@ -919,6 +944,7 @@
+@@ -953,6 +979,7 @@
          plane = addr & 3;
          mask = (1 << plane);
          if (s->sr[VGA_SEQ_PLANE_WRITE] & mask) {
@@ -246,7 +241,7 @@ Index: qemu-1.4.0/hw/vga.c
              s->vram_ptr[addr] = val;
  #ifdef DEBUG_VGA_MEM
              printf("vga: chain4: [0x" TARGET_FMT_plx "]\n", addr);
-@@ -932,6 +958,9 @@
+@@ -966,6 +993,9 @@
          mask = (1 << plane);
          if (s->sr[VGA_SEQ_PLANE_WRITE] & mask) {
              addr = ((addr & ~1) << 1) | plane;
@@ -256,7 +251,7 @@ Index: qemu-1.4.0/hw/vga.c
              s->vram_ptr[addr] = val;
  #ifdef DEBUG_VGA_MEM
              printf("vga: odd/even: [0x" TARGET_FMT_plx "]\n", addr);
-@@ -1005,6 +1034,9 @@
+@@ -1039,6 +1069,9 @@
          mask = s->sr[VGA_SEQ_PLANE_WRITE];
          s->plane_updated |= mask; /* only used to detect font change */
          write_mask = mask16[mask];
@@ -266,7 +261,7 @@ Index: qemu-1.4.0/hw/vga.c
          ((uint32_t *)s->vram_ptr)[addr] =
              (((uint32_t *)s->vram_ptr)[addr] & ~write_mask) |
              (val & write_mask);
-@@ -1168,7 +1200,7 @@
+@@ -1202,7 +1235,7 @@
  {
      uint32_t start_addr, line_offset, line_compare;
  
@@ -275,7 +270,7 @@ Index: qemu-1.4.0/hw/vga.c
          line_offset = s->vbe_line_offset;
          start_addr = s->vbe_start_addr;
          line_compare = 65535;
-@@ -1618,7 +1650,7 @@
+@@ -1652,7 +1685,7 @@
  {
      int ret;
  
@@ -284,7 +279,7 @@ Index: qemu-1.4.0/hw/vga.c
          ret = s->vbe_regs[VBE_DISPI_INDEX_BPP];
      } else {
          ret = 0;
-@@ -1630,7 +1662,7 @@
+@@ -1664,7 +1697,7 @@
  {
      int width, height;
  

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -63,6 +63,7 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://vbe-bochs-dispi-return-correct-mem-size-with-qxl.patch;patch=1 \
             file://cve-2014-3615-vbe-rework-sanity-checks.patch;patch=1 \
             file://xsa-179-banked-access-to-vga-memory-uses-inconsistent-bounds-checks.patch;patch=1 \
+            file://vga-add-sr_vbe-register-set.patch;patch=1 \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -60,6 +60,8 @@ SRC_URI += "file://0001-compile-time-stubdom-flag.patch \
             file://xsa-140-qemu-leak-of-uninitialized-heap-memory-in-rtl8139-device-model.patch;patch=1 \
             file://xsa-155-paravirtualized-drivers-incautious-about-shared-memory-contents.patch;patch=1 \
             file://xsa-162-heap-buffer-overflow-vulnerability-in-pcnet-emulator.patch;patch=1 \
+            file://vbe-bochs-dispi-return-correct-mem-size-with-qxl.patch;patch=1 \
+            file://cve-2014-3615-vbe-rework-sanity-checks.patch;patch=1 \
             file://xsa-179-banked-access-to-vga-memory-uses-inconsistent-bounds-checks.patch;patch=1 \
             "
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3615
Also backport a patch introducing a new field in VGACommonState that will be used by other upstream patches to ease the backport work.

Backport the upstream fix for XSA-179 regression with windows 7 installer hanging.

OXT-572