### PR TITLE
XCPMD boot dep update [OXT-434] and selinux policy for default rules [OXT-449]

### DIFF
--- a/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
+++ b/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
@@ -72,7 +72,7 @@ script xenclient-vusb-daemon
 dep dbus-1 udev xenstored surfman xenmgr
 
 script xcpmd
-dep dbus-1 xenstored surfman acpid
+dep dbus-1 xenstored surfman acpid dbd
 
 script surfman
 dep dbus-1 xenstored

--- a/recipes-openxt/bootage/bootage_git.bb
+++ b/recipes-openxt/bootage/bootage_git.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 PV = "0+git${SRCPV}"
+PR = "r1"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/bootage.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/xenpmd.fc
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/xenpmd.fc
@@ -18,5 +18,7 @@
 #
 #############################################################################
 
-/usr/sbin/xcpmd		--	gen_context(system_u:object_r:xenpmd_exec_t,s0)
-/var/run/xcpmd\.pid    --      gen_context(system_u:object_r:xenpmd_var_run_t,s0)
+/usr/sbin/xcpmd                 -- gen_context(system_u:object_r:xenpmd_exec_t,s0)
+/var/run/xcpmd\.pid             -- gen_context(system_u:object_r:xenpmd_var_run_t,s0)
+/usr/share/xcpmd                -d gen_context(system_u:object_r:xenpmd_etc_t,s0)
+/usr/share/xcpmd/default\.rules -- gen_context(system_u:object_r:xenpmd_etc_t,s0)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/xenpmd.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/xenpmd.te
@@ -37,6 +37,9 @@ type xenpmd_var_run_t;
 files_pid_file(xenpmd_var_run_t)
 files_pid_filetrans(xenpmd_t, xenpmd_var_run_t, file)
 
+type xenpmd_etc_t;
+files_config_file(xenpmd_etc_t)
+
 ########################################
 #
 # xenpmd local policy
@@ -74,6 +77,8 @@ allow xenpmd_t self:netlink_socket create_socket_perms;
 allow xenpmd_t xenpmd_var_t:dir manage_dir_perms;
 allow xenpmd_t xenpmd_var_t:file manage_file_perms;
 allow xenpmd_t xenpmd_var_run_t:file manage_file_perms;
+allow xenpmd_t xenpmd_etc_t:dir list_dir_perms;
+allow xenpmd_t xenpmd_etc_t:file read_file_perms;
 
 # allow XCPMD to receive messages from xenmgr
 xenpmd_dbus_chat(xend_t)

--- a/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-PR .= ".1"
+PR .= ".2"
 
 SRC_URI += " \
     file://config \


### PR DESCRIPTION
Required by [xctools PR29](https://github.com/OpenXT/xctools/pull/29).