### PR TITLE
Clean-up Xenstored packaging & deployment

### DIFF
--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -31,6 +31,7 @@ RDEPENDS_${PN} = " \
     xcpmd \
     vbetool-xc \
     xenclient-toolstack \
+    xenclient-toolstack-xenstored \
     xenclient-input-daemon \
     xenclient-dom0-tweaks \
     xenclient-splash-images \
@@ -75,7 +76,6 @@ RDEPENDS_${PN} = " \
     xenclient-udev-force-discreet-net-to-eth0 \
     xenclient-nwd \
     wget \
-    xen-tools-xenstored \
     xen-tools-xenconsoled \
     xenclient-repo-certs \
     gobi-loader \

--- a/recipes-openxt/xenclient/xenclient-toolstack/xenstored.initscript
+++ b/recipes-openxt/xenclient/xenclient-toolstack/xenstored.initscript
@@ -19,7 +19,7 @@
 
 
 PIDFILE=/var/run/xenstored.pid
-EXECUTABLE=/usr/sbin/xenstored
+EXECUTABLE=/usr/bin/xenstored
 
 [ -f "${EXECUTABLE}" ] || exit 0
 


### PR DESCRIPTION
xen-tools installs and registers the xenstored initscript, which in the
end calls the xenstored binary shipped with the xenclient-toolstack
package.

As we currently use the forked OCAML implementation of xenstored, have a
split package xenclient-toolstack-xenstored that will install and
register its own xenstored initscript for the OCAML forked xenstored.
Fix the xen-tools xenstored initscript to use the C xenstored shipped
with xen-tools-xenstored.

In the end change the dom0 package-group to install the
xenclient-toolstack OCAML xenstored only.
