### PR TITLE
OXT-496: remove ca-certificates package from dom0

### DIFF
--- a/recipes-core/images/xenclient-dom0-image.bb
+++ b/recipes-core/images/xenclient-dom0-image.bb
@@ -9,7 +9,8 @@ IMAGE_FSTYPES = "xc.ext3.gz"
 
 # No thanks, we provide our own xorg.conf with the hacked Intel driver
 # And we don't need Avahi
-BAD_RECOMMENDATIONS += "xserver-xorg avahi-daemon avahi-autoipd"
+# Nor a collection of questionable CA certificates
+BAD_RECOMMENDATIONS += "xserver-xorg avahi-daemon avahi-autoipd ca-certificates"
 # The above seems to be broken and we *really* don't want avahi!
 PACKAGE_REMOVE = "avahi-daemon avahi-autoipd"
 

--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -26,6 +26,8 @@ ANGSTROM_EXTRA_INSTALL += ""
 
 export IMAGE_BASENAME = "xenclient-installer-image"
 
+BAD_RECOMMENDATIONS += "ca-certificates"
+
 DEPENDS = "packagegroup-base packagegroup-xenclient-installer"
 
 IMAGE_INSTALL = "\

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -7,7 +7,7 @@ COMPATIBLE_MACHINE = "(xenclient-ndvm)"
 
 IMAGE_FSTYPES = "xc.ext3.vhd.gz"
 
-BAD_RECOMMENDATIONS += "avahi-daemon avahi-autoipd"
+BAD_RECOMMENDATIONS += "avahi-daemon avahi-autoipd ca-certificates"
 # The above seems to be broken and we *really* don't want avahi!
 PACKAGE_REMOVE = "avahi-daemon avahi-autoipd hicolor-icon-theme"
 


### PR DESCRIPTION
using the BAD_RECOMMENDATIONS and PACKAGE_REMOVE macros when
building the dom0 rootfs.

libcurl and wget have RRECOMMENDS which were likely pulling it in.

refs: OXT-496