### PR TITLE
OXT-575 repackage iwlwifi firmware

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -37,24 +37,7 @@ IMAGE_INSTALL = "\
     packagegroup-xenclient-common \
     packagegroup-xenclient-installer \
     kernel-module-e1000e \
-    linux-firmware-iwlwifi-135-6 \
-    linux-firmware-iwlwifi-3160-7 \
-    linux-firmware-iwlwifi-3160-8 \
-    linux-firmware-iwlwifi-3160-9 \
-    linux-firmware-iwlwifi-6000-4 \
-    linux-firmware-iwlwifi-6000g2a-5 \
-    linux-firmware-iwlwifi-6000g2a-6 \
-    linux-firmware-iwlwifi-6000g2b-5 \
-    linux-firmware-iwlwifi-6000g2b-6 \
-    linux-firmware-iwlwifi-6050-4 \
-    linux-firmware-iwlwifi-6050-5 \
-    linux-firmware-iwlwifi-7260-7 \
-    linux-firmware-iwlwifi-7260-8 \
-    linux-firmware-iwlwifi-7260-9 \
-    linux-firmware-iwlwifi-7260-12 \
-    linux-firmware-iwlwifi-7260-13 \
-    linux-firmware-iwlwifi-7265-8 \
-    linux-firmware-iwlwifi-7265-9 \
+    linux-firmware-iwlwifi \
     linux-firmware-bnx2 \
     ${ANGSTROM_EXTRA_INSTALL}"
 

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -33,24 +33,7 @@ IMAGE_INSTALL = "\
     xenclient-dbusbouncer \
     networkmanager \
     xenclient-toolstack \
-    linux-firmware-iwlwifi-135-6 \
-    linux-firmware-iwlwifi-3160-7 \
-    linux-firmware-iwlwifi-3160-8 \
-    linux-firmware-iwlwifi-3160-9 \
-    linux-firmware-iwlwifi-6000-4 \
-    linux-firmware-iwlwifi-6000g2a-5 \
-    linux-firmware-iwlwifi-6000g2a-6 \
-    linux-firmware-iwlwifi-6000g2b-5 \
-    linux-firmware-iwlwifi-6000g2b-6 \
-    linux-firmware-iwlwifi-6050-4 \
-    linux-firmware-iwlwifi-6050-5 \
-    linux-firmware-iwlwifi-7260-7 \
-    linux-firmware-iwlwifi-7260-8 \
-    linux-firmware-iwlwifi-7260-9 \
-    linux-firmware-iwlwifi-7260-12 \
-    linux-firmware-iwlwifi-7260-13 \
-    linux-firmware-iwlwifi-7265-8 \
-    linux-firmware-iwlwifi-7265-9 \
+    linux-firmware-iwlwifi \
     linux-firmware-bnx2 \
     bridge-utils \
     iptables \

--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -91,22 +91,7 @@ RDEPENDS_${PN} = " \
     apptool \
     dmidecode \
     netcat \
-    linux-firmware-iwlwifi-135-6 \
-    linux-firmware-iwlwifi-3160-7 \
-    linux-firmware-iwlwifi-3160-8 \
-    linux-firmware-iwlwifi-3160-9 \
-    linux-firmware-iwlwifi-6000-4 \
-    linux-firmware-iwlwifi-6000g2a-5 \
-    linux-firmware-iwlwifi-6000g2a-6 \
-    linux-firmware-iwlwifi-6000g2b-5 \
-    linux-firmware-iwlwifi-6000g2b-6 \
-    linux-firmware-iwlwifi-6050-4 \
-    linux-firmware-iwlwifi-6050-5 \
-    linux-firmware-iwlwifi-7260-7 \
-    linux-firmware-iwlwifi-7260-8 \
-    linux-firmware-iwlwifi-7260-9 \
-    linux-firmware-iwlwifi-7265-8 \
-    linux-firmware-iwlwifi-7265-9 \
+    linux-firmware-iwlwifi \
     linux-firmware-bnx2 \
     libicbinn-server \
     screen \

--- a/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -10,12 +10,14 @@ NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 PACKAGES =+ "${PN}-whence-license ${PN}-bnx2 \
              ${PN}-iwlwifi \
              ${PN}-iwlwifi-7260-12 ${PN}-iwlwifi-7260-13 \
+             ${PN}-iwlwifi-8000c \
             "
 LICENSE_${PN}-bnx2 = "WHENCE"
 LICENSE_${PN}-whence-license = "WHENCE"
 LICENSE_${PN}-iwlwifi = "Firmware-iwlwifi_firmware"
 LICENSE_${PN}-iwlwifi-7260-12 = "Firmware-iwlwifi_firmware"
 LICENSE_${PN}-iwlwifi-7260-13 = "Firmware-iwlwifi_firmware"
+LICENSE_${PN}-iwlwifi-8000c = "Firmware-iwlwifi_firmware"
 
 # bug fix: these LICENSE lines are missing upstream:
 LICENSE_${PN}-iwlwifi-6000g2b-5 = "Firmware-iwlwifi_firmware"
@@ -25,12 +27,14 @@ FILES_${PN}-bnx2 = "/lib/firmware/bnx2/*.fw"
 FILES_${PN}-whence-license = "/lib/firmware/WHENCE"
 FILES_${PN}-iwlwifi-7260-12 = "/lib/firmware/iwlwifi-7260-12.ucode"
 FILES_${PN}-iwlwifi-7260-13 = "/lib/firmware/iwlwifi-7260-13.ucode"
+FILES_${PN}-iwlwifi-8000c = "/lib/firmware/iwlwifi-8000C-*.ucode"
 
 ALLOW_EMPTY_${PN}-iwlwifi = "1"
 
 RDEPENDS_${PN}-bnx2 += "${PN}-whence-license"
 RDEPENDS_${PN}-iwlwifi-7260-12 = "${PN}-iwlwifi-license"
 RDEPENDS_${PN}-iwlwifi-7260-13 = "${PN}-iwlwifi-license"
+RDEPENDS_${PN}-iwlwifi-8000c = "${PN}-iwlwifi-license"
 
 LICENSE_${PN} += "& WHENCE \
 "

--- a/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -8,10 +8,12 @@ LIC_FILES_CHKSUM += "file://WHENCE;beginline=1224;endline=1264;md5=c31e99ad18d49
 NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
 PACKAGES =+ "${PN}-whence-license ${PN}-bnx2 \
+             ${PN}-iwlwifi \
              ${PN}-iwlwifi-7260-12 ${PN}-iwlwifi-7260-13 \
             "
 LICENSE_${PN}-bnx2 = "WHENCE"
 LICENSE_${PN}-whence-license = "WHENCE"
+LICENSE_${PN}-iwlwifi = "Firmware-iwlwifi_firmware"
 LICENSE_${PN}-iwlwifi-7260-12 = "Firmware-iwlwifi_firmware"
 LICENSE_${PN}-iwlwifi-7260-13 = "Firmware-iwlwifi_firmware"
 
@@ -24,6 +26,8 @@ FILES_${PN}-whence-license = "/lib/firmware/WHENCE"
 FILES_${PN}-iwlwifi-7260-12 = "/lib/firmware/iwlwifi-7260-12.ucode"
 FILES_${PN}-iwlwifi-7260-13 = "/lib/firmware/iwlwifi-7260-13.ucode"
 
+ALLOW_EMPTY_${PN}-iwlwifi = "1"
+
 RDEPENDS_${PN}-bnx2 += "${PN}-whence-license"
 RDEPENDS_${PN}-iwlwifi-7260-12 = "${PN}-iwlwifi-license"
 RDEPENDS_${PN}-iwlwifi-7260-13 = "${PN}-iwlwifi-license"
@@ -33,4 +37,12 @@ LICENSE_${PN} += "& WHENCE \
 
 LICENSE_${PN}-license += "/lib/firmware/WHENCE"
 
-RDEPENDS_${PN} += "${PN}-bnx2 ${PN}-whence-license ${PN}-iwlwifi-7260-12 ${PN}-iwlwifi-7260-13"
+# Make linux-firmware depend on all of the split-out packages.
+# Make linux-firmware-iwlwifi depend on all of the split-out iwlwifi packages.
+python populate_packages_prepend () {
+    firmware_pkgs = oe.utils.packages_filter_out_system(d)
+    d.appendVar('RDEPENDS_linux-firmware', ' ' + ' '.join(firmware_pkgs))
+
+    iwlwifi_pkgs = filter(lambda x: x.find('-iwlwifi-') != -1, firmware_pkgs)
+    d.appendVar('RDEPENDS_linux-firmware-iwlwifi', ' ' + ' '.join(iwlwifi_pkgs))
+}


### PR DESCRIPTION
Create a virtual package: linux-firmware-iwlwifi
that depends upon all of the individually packaged iwlwifi firmware packages.

Change the image package lists to use the new virtual package.

Add packaging for the 8000c series device firmwares.