### PR TITLE
OXT-576: remove wifi linux-firmware-* from dom0 packagegroup

### DIFF
--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -90,8 +90,6 @@ RDEPENDS_${PN} = " \
     apptool \
     dmidecode \
     netcat \
-    linux-firmware-iwlwifi \
-    linux-firmware-bnx2 \
     libicbinn-server \
     screen \
     xenclient-pcrdiff \


### PR DESCRIPTION
No known reason for wifi firmware to be present on the dom0
filesystem so remove it.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>