### PR TITLE
Remove guest rules from rpc-proxy.rules.

### DIFF
--- a/recipes-openxt/xenclient/rpc-proxy/rpc-proxy.rules
+++ b/recipes-openxt/xenclient/rpc-proxy/rpc-proxy.rules
@@ -6,21 +6,6 @@ allow stubdom true destination com.citrix.xenclient.surfman
 allow stubdom true destination com.citrix.xenclient.xenmgr
 allow stubdom true destination org.freedesktop.DBus interface org.freedesktop.DBus
 
-# allow guests to call 'gather' on diagnostics interface (required by xc-diag)
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr.diag member gather
-
-# allow anybody to do some vm queries required for switcher bar
-allow destination com.citrix.xenclient.xenmgr interface org.freedesktop.DBus.Properties member Get
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr member list_vms
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr.vm member get_db_key
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr.vm member read_icon
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr.vm member switch
-allow destination com.citrix.xenclient.input interface com.citrix.xenclient.input member get_focus_domid
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr member find_vm_by_domid
-
-# allow guest to do some requests
-allow destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.xenmgr.guestreq member request_attention
-
 # allow conditional domstore (private db space) access
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member read if-boolean domstore-read-access true
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member read_binary if-boolean domstore-read-access true
@@ -29,22 +14,6 @@ allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db memb
 
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member write if-boolean domstore-write-access true
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member rm if-boolean domstore-write-access true
-
-# allow incoming error messages & method returns from guests
-allow inc-error
-allow inc-method-return
-
-# allow some rpc agent signals from guests
-allow inc-signal interface com.citrix.xenclient.guest member agent_started
-allow inc-signal interface com.citrix.xenclient.guest member agent_uninstalled
-allow inc-signal interface com.citrix.xenclient.guest member xorg_running
-
-# allow guests to export services by letting some standard messages through
-allow destination org.freedesktop.DBus interface org.freedesktop.DBus member Hello
-allow destination org.freedesktop.DBus interface org.freedesktop.DBus member RequestName
-allow destination org.freedesktop.DBus interface org.freedesktop.DBus member ReleaseName
-allow destination org.freedesktop.DBus interface org.freedesktop.DBus member AddMatch               
-allow destination org.freedesktop.DBus interface org.freedesktop.DBus member GetNameOwner 
 
 # allow vms with usb-control property to talk to usb daemon
 allow destination com.citrix.xenclient.usbdaemon if-boolean usb-control true

--- a/recipes-openxt/xenclient/rpc-proxy/rpc-proxy.rules
+++ b/recipes-openxt/xenclient/rpc-proxy/rpc-proxy.rules
@@ -1,11 +1,6 @@
 # nothing can be done by default
 deny all
 
-# allow stubdoms to talk to surfman,xenmgr,dbus
-allow stubdom true destination com.citrix.xenclient.surfman
-allow stubdom true destination com.citrix.xenclient.xenmgr
-allow stubdom true destination org.freedesktop.DBus interface org.freedesktop.DBus
-
 # allow conditional domstore (private db space) access
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member read if-boolean domstore-read-access true
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member read_binary if-boolean domstore-read-access true


### PR DESCRIPTION
rpc-proxy.rules still contains a set of a rules permitting obsolete and
removed functionality such as the guest switcher functionality. These
rules were also allowed for all domains, not just guests, so they were
accessible from e.g. the ndvm. We need to remove these rules.

Tested by trying to send one of these messages from the ndvm before
and after the change and confirming that it failed after the change,
with a rpc-proxy: (1->0) DENY message in /var/log/messages.

Saw no other rpc-proxy DENY messages in /var/log/messages, so does not
appear to break any functionality but admittedly did not extensively test.

OXT-639

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>