### PR TITLE
OXT-588 : fix packaging of acms software license

### DIFF
--- a/files/additional-licenses/Intel-ACMs
+++ b/files/additional-licenses/Intel-ACMs
@@ -1,0 +1,18 @@
+Copyright (c) 2007 - 2016, Intel Corporation.
+All rights reserved.
+
+Redistribution
+--------------
+Redistribution and use in binary form, without modification, are permitted provided that the following conditions are met:
+  o  Redistributions must reproduce the above copyright notice and the following disclaimer in the documentation and/or other materials provided with the distribution.
+  o  Neither the name of Intel Corporation nor the names of its suppliers may be used to endorse or promote products derived from this software without specific prior written permission.
+  o  No reverse engineering, decompilation, or disassembly of this software is permitted.
+
+Limited patent license
+----------------------
+Intel Corporation grants a world-wide, royalty-free, non-exclusive license under patents it now or hereafter owns or controls to make, have made, use,import, offer to sell and sell ("Utilize") this software, but solely to the extent that any such patent is necessary to Utilize the software alone. The patent license shall not apply to any combinations which include this software.  No hardware per se is licensed hereunder.
+
+DISCLAIMER
+----------
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -122,6 +122,7 @@ do_post_rootfs_items() {
 	cp -f ${IMAGE_ROOTFS}/boot/3rd_gen_i5_i7_SINIT_67.BIN ${DEPLOY_DIR_IMAGE}/ivb_snb.acm
 	cp -f ${IMAGE_ROOTFS}/boot/5th_gen_i5_i7_SINIT_79.BIN ${DEPLOY_DIR_IMAGE}/bdw.acm
 	cp -f ${IMAGE_ROOTFS}/boot/6th_gen_i5_i7_SINIT_71.BIN ${DEPLOY_DIR_IMAGE}/skl.acm
+	cp -f ${IMAGE_ROOTFS}/boot/license-SINIT-ACMs.txt ${DEPLOY_DIR_IMAGE}/license-SINIT-ACMs.txt
 }
 
 addtask post_rootfs_items after do_rootfs before do_build

--- a/recipes-openxt/acms/acms.bb
+++ b/recipes-openxt/acms/acms.bb
@@ -1,3 +1,8 @@
+DESCRIPTION = "Authenticated Code Modules for SINIT"
+HOMEPAGE = "https://software.intel.com/en-us/articles/intel-trusted-execution-technology"
+BUGTRACKER = "https://software.intel.com/en-us/forums/intel-trusted-execution-technology-intel-txt"
+SECTION = "bootloaders"
+
 SRC_URI[gm45.md5sum] = "330c774e71fe390d7ab649d5e2b1d504"
 SRC_URI[gm45.sha256sum] = "2b7c9f76c68b48ea537e8b120a8ecd477f8f7a53eaa656a60435111200be4e6a"
 SRC_URI[q45.md5sum] = "4af698f82ff70f5f25c99968b47e679e"
@@ -22,7 +27,7 @@ SRC_URI[skl.md5sum] = "b07b5fb355815655be14c84df84a69a5"
 SRC_URI[skl.sha256sum] = "9f7b17dfb87719dc7c789d7e319071a0fbcca5b547bfd8b2aa3bf253760e23c6"
 
 PR="r3"
-LICENSE = "Proprietary"
+LICENSE = "Intel-ACMs"
 LIC_FILES_CHKSUM = "file://GM45_GS45_PM45-SINIT_51/license.txt;md5=60d123634e0b94f8c425003389e64bda \
                     file://Q45_Q43-SINIT_51/license.txt;md5=60d123634e0b94f8c425003389e64bda \
                     file://Q35-SINIT_51/license.txt;md5=60d123634e0b94f8c425003389e64bda \
@@ -58,4 +63,8 @@ do_install() {
         do
                 install -m 644 "$i" ${D}/boot
         done
+
+        # After inspection of the licenses of the individual ACM files,
+        # the most recent Skylake license is sufficient to cover all:
+        install -m 444 6th_gen_i5_i7-SINIT_71/license.txt ${D}/boot/license-SINIT-ACMs.txt
 }


### PR DESCRIPTION
Add the Intel ACM software license to the layer's additional
licenses.

Indicate "Intel-ACMs" as the license in the recipe rather than the
generic "Proprietary".

Include the most recent ACM license file in the distributed package
as required by the license.

Add some descriptive package metadata to the recipe.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>