### PR TITLE
OXT-653: v4v hypervisor code fixes

### DIFF
--- a/recipes-extended/xen/files/xc-xt-v4v.patch
+++ b/recipes-extended/xen/files/xc-xt-v4v.patch
@@ -1,8 +1,8 @@
-Index: xen-4.3.4/xen/arch/x86/hvm/hvm.c
-===================================================================
+diff --git xen-4.3.4.orig/xen/arch/x86/hvm/hvm.c xen-4.3.4/xen/arch/x86/hvm/hvm.c
+index 8d4e1b6..1f57445 100644
 --- xen-4.3.4.orig/xen/arch/x86/hvm/hvm.c
 +++ xen-4.3.4/xen/arch/x86/hvm/hvm.c
-@@ -3366,6 +3366,7 @@ static hvm_hypercall_t *const hvm_hyperc
+@@ -3366,6 +3366,7 @@ static hvm_hypercall_t *const hvm_hypercall64_table[NR_hypercalls] = {
      HYPERCALL(sysctl),
      HYPERCALL(domctl),
      HYPERCALL(tmem_op),
@@ -10,7 +10,7 @@ Index: xen-4.3.4/xen/arch/x86/hvm/hvm.c
      [ __HYPERVISOR_arch_1 ] = (hvm_hypercall_t *)paging_domctl_continuation
  };
  
-@@ -3386,6 +3387,7 @@ static hvm_hypercall_t *const hvm_hyperc
+@@ -3386,6 +3387,7 @@ static hvm_hypercall_t *const hvm_hypercall32_table[NR_hypercalls] = {
      HYPERCALL(sysctl),
      HYPERCALL(domctl),
      HYPERCALL(tmem_op),
@@ -18,8 +18,8 @@ Index: xen-4.3.4/xen/arch/x86/hvm/hvm.c
      [ __HYPERVISOR_arch_1 ] = (hvm_hypercall_t *)paging_domctl_continuation
  };
  
-Index: xen-4.3.4/xen/arch/x86/x86_64/compat/entry.S
-===================================================================
+diff --git xen-4.3.4.orig/xen/arch/x86/x86_64/compat/entry.S xen-4.3.4/xen/arch/x86/x86_64/compat/entry.S
+index 77a45f2..c303744 100644
 --- xen-4.3.4.orig/xen/arch/x86/x86_64/compat/entry.S
 +++ xen-4.3.4/xen/arch/x86/x86_64/compat/entry.S
 @@ -413,6 +413,7 @@ ENTRY(compat_hypercall_table)
@@ -38,8 +38,8 @@ Index: xen-4.3.4/xen/arch/x86/x86_64/compat/entry.S
          .rept __HYPERVISOR_arch_0-(.-compat_hypercall_args_table)
          .byte 0 /* compat_ni_hypercall      */
          .endr
-Index: xen-4.3.4/xen/arch/x86/x86_64/entry.S
-===================================================================
+diff --git xen-4.3.4.orig/xen/arch/x86/x86_64/entry.S xen-4.3.4/xen/arch/x86/x86_64/entry.S
+index 01432b8..d28356d 100644
 --- xen-4.3.4.orig/xen/arch/x86/x86_64/entry.S
 +++ xen-4.3.4/xen/arch/x86/x86_64/entry.S
 @@ -755,6 +755,7 @@ ENTRY(hypercall_table)
@@ -58,8 +58,8 @@ Index: xen-4.3.4/xen/arch/x86/x86_64/entry.S
          .rept __HYPERVISOR_arch_0-(.-hypercall_args_table)
          .byte 0 /* do_ni_hypercall      */
          .endr
-Index: xen-4.3.4/xen/common/Makefile
-===================================================================
+diff --git xen-4.3.4.orig/xen/common/Makefile xen-4.3.4/xen/common/Makefile
+index 0dc2050..4389d03 100644
 --- xen-4.3.4.orig/xen/common/Makefile
 +++ xen-4.3.4/xen/common/Makefile
 @@ -47,6 +47,7 @@ obj-y += tmem_xen.o
@@ -70,8 +70,8 @@ Index: xen-4.3.4/xen/common/Makefile
  
  obj-bin-$(CONFIG_X86) += $(foreach n,decompress bunzip2 unxz unlzma unlzo,$(n).init.o)
  
-Index: xen-4.3.4/xen/common/domain.c
-===================================================================
+diff --git xen-4.3.4.orig/xen/common/domain.c xen-4.3.4/xen/common/domain.c
+index 4465377..a16613d 100644
 --- xen-4.3.4.orig/xen/common/domain.c
 +++ xen-4.3.4/xen/common/domain.c
 @@ -199,7 +199,8 @@ struct domain *domain_create(
@@ -96,7 +96,7 @@ Index: xen-4.3.4/xen/common/domain.c
              goto fail;
          init_status |= INIT_gnttab;
  
-+	if ( v4v_init(d) !=0 ) 
++	if ( v4v_init(d) !=0 )
 +	    goto fail;
 +	init_status |= INIT_v4v;
 +
@@ -120,11 +120,11 @@ Index: xen-4.3.4/xen/common/domain.c
          evtchn_destroy(d);
          gnttab_release_mappings(d);
          tmem_destroy(d->tmem);
-Index: xen-4.3.4/xen/common/event_channel.c
-===================================================================
+diff --git xen-4.3.4.orig/xen/common/event_channel.c xen-4.3.4/xen/common/event_channel.c
+index e22a41b..7ad5db0 100644
 --- xen-4.3.4.orig/xen/common/event_channel.c
 +++ xen-4.3.4/xen/common/event_channel.c
-@@ -683,7 +683,7 @@ void send_guest_vcpu_virq(struct vcpu *v
+@@ -683,7 +683,7 @@ void send_guest_vcpu_virq(struct vcpu *v, uint32_t virq)
      spin_unlock_irqrestore(&v->virq_lock, flags);
  }
  
@@ -133,11 +133,12 @@ Index: xen-4.3.4/xen/common/event_channel.c
  {
      unsigned long flags;
      int port;
-Index: xen-4.3.4/xen/common/v4v.c
-===================================================================
+diff --git xen-4.3.4.orig/xen/common/v4v.c xen-4.3.4/xen/common/v4v.c
+new file mode 100644
+index 0000000..1549ac6
 --- /dev/null
 +++ xen-4.3.4/xen/common/v4v.c
-@@ -0,0 +1,1908 @@
+@@ -0,0 +1,1976 @@
 +/******************************************************************************
 + * v4v.c
 + * 
@@ -566,10 +567,30 @@ Index: xen-4.3.4/xen/common/v4v.c
 +}
 +#endif
 +
++/*
++ * v4v_sanitize_ring creates a modified copy of the ring pointers
++ * where the rx_ptr is rounded up to ensure it is aligned, and then
++ * ring wrap is handled. Simplifies safe use of the rx_ptr for
++ * available space calculation.
++ */
++static void v4v_sanitize_ring(v4v_ring_t *ring,
++                              struct v4v_ring_info *ring_info)
++{
++  uint32_t rx_ptr = ring->rx_ptr;
++
++  ring->tx_ptr = ring_info->tx_ptr;
++  ring->len = ring_info->len;
++
++  rx_ptr = V4V_ROUNDUP(rx_ptr);
++  if (rx_ptr >= ring_info->len)
++    rx_ptr = 0;
++
++  ring->rx_ptr = rx_ptr;
++}
 +
 +
 +/*caller must have L3*/
-+static size_t
++static long
 +v4v_ringbuf_insert (struct domain *d,
 +                    struct v4v_ring_info *ring_info,
 +                    struct v4v_ring_id *src_id, uint32_t proto,
@@ -583,10 +604,9 @@ Index: xen-4.3.4/xen/common/v4v.c
 +  int32_t happy_ret = len;
 +  int32_t ret = 0;
 +
-+
-+
-+  if ((V4V_ROUNDUP (len) + sizeof (struct v4v_ring_message_header)) >=
-+      ring_info->len)
++  if (((V4V_ROUNDUP (len) + sizeof (struct v4v_ring_message_header)) >=
++      ring_info->len) ||
++      (len > V4V_MAX_MSG_SIZE))
 +      return -EMSGSIZE;
 +
 +  do
@@ -596,8 +616,7 @@ Index: xen-4.3.4/xen/common/v4v.c
 +           v4v_memcpy_from_guest_ring (&ring, ring_info, 0, sizeof (ring))))
 +        break;
 +
-+      ring.tx_ptr = ring_info->tx_ptr;
-+      ring.len = ring_info->len;
++      v4v_sanitize_ring(&ring, ring_info);
 +
 +#ifdef V4V_DEBUG
 +      printk (KERN_ERR
@@ -682,18 +701,28 @@ Index: xen-4.3.4/xen/common/v4v.c
 +
 +}
 +
-+static ssize_t
-+v4v_iov_count (XEN_GUEST_HANDLE (v4v_iov_t) iovs, int niov)
++static long
++v4v_iov_count (XEN_GUEST_HANDLE (v4v_iov_t) iovs, size_t niov)
 +{
 +  v4v_iov_t iov;
 +  size_t ret = 0;
++
++  if (niov > V4V_MAXIOV)
++    return -EINVAL;
 +
 +  while (niov--)
 +    {
 +      if (copy_from_guest (&iov, iovs, 1))
 +        return -EFAULT;
 +
++      if (iov.iov_len > V4V_MAX_MSG_SIZE)
++        return -EINVAL;
++
 +      ret += iov.iov_len;
++
++      if (ret > V4V_MAX_MSG_SIZE)
++        return -EINVAL;
++
 +      guest_handle_add_offset (iovs, 1);
 +    }
 +
@@ -702,7 +731,7 @@ Index: xen-4.3.4/xen/common/v4v.c
 +}
 +
 +/*caller must have L3*/
-+static ssize_t
++static long
 +v4v_ringbuf_insertv (struct domain *d,
 +                     struct v4v_ring_info *ring_info,
 +                     struct v4v_ring_id *src_id, uint32_t proto,
@@ -714,13 +743,17 @@ Index: xen-4.3.4/xen/common/v4v.c
 +  int32_t sp;
 +  int32_t happy_ret;
 +  int32_t ret = 0;
-+
++  uint32_t orig_len = len, total_len = 0;
 +
 +  happy_ret = len;
 +
-+  if ((V4V_ROUNDUP (len) + sizeof (struct v4v_ring_message_header)) >=
-+      ring_info->len)
++  if (((V4V_ROUNDUP (len) + sizeof (struct v4v_ring_message_header)) >=
++      ring_info->len) ||
++      (len > V4V_MAX_MSG_SIZE))
 +      return -EMSGSIZE;
++
++  if (niov > V4V_MAXIOV)
++      return -EINVAL;
 +
 +  do
 +    {
@@ -729,8 +762,7 @@ Index: xen-4.3.4/xen/common/v4v.c
 +           v4v_memcpy_from_guest_ring (&ring, ring_info, 0, sizeof (ring))))
 +        break;
 +
-+      ring.tx_ptr = ring_info->tx_ptr;
-+      ring.len = ring_info->len;
++      v4v_sanitize_ring(&ring, ring_info);
 +
 +#ifdef V4V_DEBUG
 +      printk (KERN_ERR
@@ -772,9 +804,9 @@ Index: xen-4.3.4/xen/common/v4v.c
 +      if (ring.tx_ptr == ring_info->len)
 +        ring.tx_ptr = 0;
 +
-+
 +      while (niov--)
 +        {
++          XEN_GUEST_HANDLE_PARAM (uint8_t) bufp_hnd;
 +          XEN_GUEST_HANDLE (uint8_t) buf_hnd;
 +          v4v_iov_t iov;
 +
@@ -784,8 +816,22 @@ Index: xen-4.3.4/xen/common/v4v.c
 +              break;
 +            }
 +
-+          buf_hnd.p = (uint8_t *) (unsigned long)iov.iov_base; //FIXME
++          bufp_hnd = guest_handle_from_ptr(iov.iov_base, uint8_t);
++          buf_hnd = guest_handle_from_param(bufp_hnd, uint8_t);
 +          len = iov.iov_len;
++
++          if (len > V4V_MAX_MSG_SIZE)
++            {
++              ret = -EINVAL;
++              break;
++            }
++
++          total_len += len;
++          if (total_len > orig_len)
++            {
++              ret = -EINVAL;
++              break;
++            }
 +
 +          if (unlikely (!guest_handle_okay (buf_hnd, len)))
 +            {
@@ -1056,10 +1102,12 @@ Index: xen-4.3.4/xen/common/v4v.c
 +
 +/*Called should hold no more than R(L1) */
 +static int
-+v4v_fill_ring_datas (struct domain *d, int nent,
++v4v_fill_ring_datas (struct domain *d, size_t nent,
 +                     XEN_GUEST_HANDLE (v4v_ring_data_ent_t) data_ent_hnd)
 +{
 +  int ret = 0;
++  if (nent > V4V_MAXENT)
++    return -EINVAL;
 +  read_lock (&v4v_lock);
 +  while (!ret && nent--)
 +    {
@@ -1109,6 +1157,9 @@ Index: xen-4.3.4/xen/common/v4v.c
 +    guest_handle_add_offset (slop_hnd, sizeof (v4v_pfn_list_t));
 +    pfn_hnd = guest_handle_cast (slop_hnd, v4v_pfn_t);
 +  }
++
++  if (pfn_list.npage  > (V4V_MAX_RING_SIZE >> PAGE_SHIFT))
++      return -EINVAL;
 +
 +  mfns = v4v_xmalloc_array (mfn_t, pfn_list.npage);
 +  if (!mfns)
@@ -1370,6 +1421,12 @@ Index: xen-4.3.4/xen/common/v4v.c
 +          break;
 +        }
 +
++      if (ring.len > V4V_MAX_RING_SIZE)
++        {
++          ret = -EINVAL;
++          break;
++        }
++
 +      ring.id.addr.domain = d->domain_id;
 +      if (copy_field_to_guest (ring_hnd, &ring, id))
 +        {
@@ -1382,9 +1439,18 @@ Index: xen-4.3.4/xen/common/v4v.c
 +      if ((ring.tx_ptr >= ring.len)
 +          || (V4V_ROUNDUP (ring.tx_ptr) != ring.tx_ptr))
 +        {
-+          ring.tx_ptr = ring.rx_ptr;
++          /*
++           * Since the ring is a mess, attempt to flush the contents of it
++           * here by setting the tx_ptr to the next aligned message slot past
++           * the latest rx_ptr we have observed. Handle ring wrap correctly.
++           */
++          ring.tx_ptr = V4V_ROUNDUP(ring.rx_ptr);
++          if (ring.tx_ptr >= ring.len)
++          {
++            ring.tx_ptr = 0;
++          }
++          copy_field_to_guest (ring_hnd, &ring, tx_ptr); /* XXX: not atomic */
 +        }
-+      copy_field_to_guest (ring_hnd, &ring, tx_ptr);
 +
 +#if 0
 +      if (ring_data_hnd)
@@ -1569,7 +1635,7 @@ Index: xen-4.3.4/xen/common/v4v.c
 +
 +
 +/*Hypercall to do the send*/
-+static size_t
++static long
 +v4v_send (struct domain *src_d, v4v_addr_t * src_addr,
 +          v4v_addr_t * dst_addr, uint32_t proto,
 +          XEN_GUEST_HANDLE (void) buf, size_t len)
@@ -1577,9 +1643,12 @@ Index: xen-4.3.4/xen/common/v4v.c
 +  struct domain *dst_d;
 +  struct v4v_ring_id src_id;
 +  struct v4v_ring_info *ring_info;
-+  int ret = 0;
++  long ret = 0;
 +
 +  if (!dst_addr)
++      return -EINVAL;
++
++  if (len > V4V_MAX_MSG_SIZE)
 +      return -EINVAL;
 +
 +  read_lock (&v4v_lock);
@@ -1670,7 +1739,7 @@ Index: xen-4.3.4/xen/common/v4v.c
 +}
 +
 +/*Hypercall to do the send*/
-+static size_t
++static long
 +v4v_sendv (struct domain *src_d, v4v_addr_t * src_addr,
 +           v4v_addr_t * dst_addr, uint32_t proto,
 +           XEN_GUEST_HANDLE (v4v_iov_t) iovs, size_t niov)
@@ -1743,7 +1812,7 @@ Index: xen-4.3.4/xen/common/v4v.c
 +          ret = -ECONNREFUSED;
 +      else
 +        {
-+          uint32_t len = v4v_iov_count (iovs, niov);
++          long len = v4v_iov_count (iovs, niov);
 +
 +          if (len < 0)
 +            {
@@ -2046,11 +2115,11 @@ Index: xen-4.3.4/xen/common/v4v.c
 + * indent-tabs-mode: nil
 + * End:
 + */
-Index: xen-4.3.4/xen/include/Makefile
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/Makefile xen-4.3.4/xen/include/Makefile
+index 62846a1..9cf8982 100644
 --- xen-4.3.4.orig/xen/include/Makefile
 +++ xen-4.3.4/xen/include/Makefile
-@@ -77,7 +77,7 @@ ifeq ($(XEN_TARGET_ARCH),$(XEN_COMPILE_A
+@@ -77,7 +77,7 @@ ifeq ($(XEN_TARGET_ARCH),$(XEN_COMPILE_ARCH))
  
  all: headers.chk
  
@@ -2059,8 +2128,8 @@ Index: xen-4.3.4/xen/include/Makefile
  	for i in $(filter %.h,$^); do $(CC) -ansi -include stdint.h -Wall -W -Werror -S -o /dev/null -xc $$i || exit 1; echo $$i; done >$@.new
  	mv $@.new $@
  
-Index: xen-4.3.4/xen/include/asm-x86/guest_access.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/asm-x86/guest_access.h xen-4.3.4/xen/include/asm-x86/guest_access.h
+index ca700c9..9815a9c 100644
 --- xen-4.3.4.orig/xen/include/asm-x86/guest_access.h
 +++ xen-4.3.4/xen/include/asm-x86/guest_access.h
 @@ -48,7 +48,7 @@
@@ -2072,11 +2141,12 @@ Index: xen-4.3.4/xen/include/asm-x86/guest_access.h
      (XEN_GUEST_HANDLE_PARAM(type)) { _x };            \
  })
  
-Index: xen-4.3.4/xen/include/public/v4v.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/public/v4v.h xen-4.3.4/xen/include/public/v4v.h
+new file mode 100644
+index 0000000..b1d4bd3
 --- /dev/null
 +++ xen-4.3.4/xen/include/public/v4v.h
-@@ -0,0 +1,492 @@
+@@ -0,0 +1,531 @@
 +#ifndef __V4V_H__
 +#define __V4V_H__
 +
@@ -2122,6 +2192,28 @@ Index: xen-4.3.4/xen/include/public/v4v.h
 +
 +#define V4V_PROTO_DGRAM		0x3c2c1db8
 +#define V4V_PROTO_STREAM	0x70f6a8e5
++
++/*
++ * The maximum size of a V4V ring.
++ */
++#define V4V_MAX_RING_SIZE  (16777216ULL)
++
++/*
++ * The Linux v4v driver never passes more than two iovs.
++ * Linux defines UIO_MAXIOV as 1024.
++ * POSIX mandates at least 16, not that this is a POSIX API of course.
++ *
++ * Limit the total amount of data posted in a single v4v operation to
++ * no more than 2^31 bytes to reduce risk of integer overflow defects.
++ * Each v4v iov can hold ~ 2^24 bytes, so set V4V_MAXIOV to 2^(31-24).
++ */
++#define V4V_MAXIOV          128U
++
++/*
++ * The Linux v4v driver passes the pending xmit_count.
++ * It does not impose any hard limit, but we'll cap it to 4096.
++ */
++#define V4V_MAXENT          4096U
 +
 +/************** Structure definitions **********/
 +
@@ -2315,15 +2407,32 @@ Index: xen-4.3.4/xen/include/public/v4v.h
 +#pragma pack(pop)
 +#endif
 +
++/*
++ * The maximum size of a guest message that may be sent on a V4V ring.
++ */
++#define V4V_MAX_MSG_SIZE ((V4V_MAX_RING_SIZE) - \
++        (sizeof(struct v4v_ring_message_header)) - \
++        V4V_ROUNDUP(1))
++
 +/************ Internal RING 0/-1 parts **********/
 +#if !defined(V4V_EXCLUDE_INTERNAL)
 +
 +#if !defined(__GNUC__)
++extern void _mm_mfence(void);
++#pragma intrinsic(_mm_mfence)
++
 +static __inline void
-+mb (void)
++v4v_mb (void)
 +{
 +    _mm_mfence ();
 +    _ReadWriteBarrier ();
++}
++#elif !defined(__LINUX__)
++static __inline void
++v4v_mb (void)
++{
++    __sync_synchronize();
++    asm volatile("":::"memory");
 +}
 +#endif
 +
@@ -2424,7 +2533,7 @@ Index: xen-4.3.4/xen/include/public/v4v.h
 +    if (rxp == r->len)
 +        rxp = 0;
 +
-+    mb ();
++    v4v_mb ();
 +
 +    if (consume)
 +        r->rx_ptr = rxp;
@@ -2547,7 +2656,7 @@ Index: xen-4.3.4/xen/include/public/v4v.h
 +    if (rxp == r->len)
 +        rxp = 0;
 +
-+    mb ();
++    v4v_mb ();
 +
 +    if (consume)
 +        r->rx_ptr = rxp;
@@ -2569,8 +2678,8 @@ Index: xen-4.3.4/xen/include/public/v4v.h
 + * indent-tabs-mode: nil
 + * End:
 + */
-Index: xen-4.3.4/xen/include/public/xen.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/public/xen.h xen-4.3.4/xen/include/public/xen.h
+index fe179b9..c2f1e42 100644
 --- xen-4.3.4.orig/xen/include/public/xen.h
 +++ xen-4.3.4/xen/include/public/xen.h
 @@ -100,7 +100,7 @@ DEFINE_XEN_GUEST_HANDLE(xen_ulong_t);
@@ -2591,8 +2700,8 @@ Index: xen-4.3.4/xen/include/public/xen.h
  #define VIRQ_ENOMEM     12 /* G. (DOM0) Low on heap memory       */
  
  /* Architecture-specific VIRQ definitions. */
-Index: xen-4.3.4/xen/include/xen/sched.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/xen/sched.h xen-4.3.4/xen/include/xen/sched.h
+index 82ed400..b1bafd6 100644
 --- xen-4.3.4.orig/xen/include/xen/sched.h
 +++ xen-4.3.4/xen/include/xen/sched.h
 @@ -13,6 +13,7 @@
@@ -2614,8 +2723,9 @@ Index: xen-4.3.4/xen/include/xen/sched.h
  };
  
  struct domain_setup_info
-Index: xen-4.3.4/xen/include/xen/v4v.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/xen/v4v.h xen-4.3.4/xen/include/xen/v4v.h
+new file mode 100644
+index 0000000..8358c36
 --- /dev/null
 +++ xen-4.3.4/xen/include/xen/v4v.h
 @@ -0,0 +1,82 @@
@@ -2701,11 +2811,11 @@ Index: xen-4.3.4/xen/include/xen/v4v.h
 + * indent-tabs-mode: nil
 + * End:
 + */
-Index: xen-4.3.4/xen/include/xen/xencomm.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/xen/xencomm.h xen-4.3.4/xen/include/xen/xencomm.h
+index 3426b8a..eb61588 100644
 --- xen-4.3.4.orig/xen/include/xen/xencomm.h
 +++ xen-4.3.4/xen/include/xen/xencomm.h
-@@ -65,7 +65,7 @@ static inline unsigned long xencomm_inli
+@@ -65,7 +65,7 @@ static inline unsigned long xencomm_inline_addr(const void *handle)
  
  /* Cast a guest handle to the specified type of handle. */
  #define guest_handle_cast(hnd, type) ({         \
@@ -2714,11 +2824,11 @@ Index: xen-4.3.4/xen/include/xen/xencomm.h
      XEN_GUEST_HANDLE_PARAM(type) _y;            \
      set_xen_guest_handle(_y, _x);               \
      _y;                                         \
-Index: xen-4.3.4/xen/include/xsm/dummy.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/xsm/dummy.h xen-4.3.4/xen/include/xsm/dummy.h
+index f65fa9a..7b4e7aa 100644
 --- xen-4.3.4.orig/xen/include/xsm/dummy.h
 +++ xen-4.3.4/xen/include/xsm/dummy.h
-@@ -636,6 +636,11 @@ static XSM_INLINE int xsm_ioport_mapping
+@@ -636,6 +636,11 @@ static XSM_INLINE int xsm_ioport_mapping(XSM_DEFAULT_ARG struct domain *d, uint3
      return xsm_default_action(action, current->domain, d);
  }
  
@@ -2730,8 +2840,8 @@ Index: xen-4.3.4/xen/include/xsm/dummy.h
  #endif /* CONFIG_X86 */
  
  #ifdef CONFIG_ARM
-Index: xen-4.3.4/xen/include/xsm/xsm.h
-===================================================================
+diff --git xen-4.3.4.orig/xen/include/xsm/xsm.h xen-4.3.4/xen/include/xsm/xsm.h
+index 7ab80f8..76da5d7 100644
 --- xen-4.3.4.orig/xen/include/xsm/xsm.h
 +++ xen-4.3.4/xen/include/xsm/xsm.h
 @@ -165,6 +165,7 @@ struct xsm_operations {
@@ -2742,7 +2852,7 @@ Index: xen-4.3.4/xen/include/xsm/xsm.h
  };
  
  #ifdef XSM_ENABLE
-@@ -624,6 +625,11 @@ static inline int xsm_ioport_mapping (xs
+@@ -624,6 +625,11 @@ static inline int xsm_ioport_mapping (xsm_default_t def, struct domain *d, uint3
  {
      return xsm_ops->ioport_mapping(d, s, e, allow);
  }
@@ -2754,21 +2864,21 @@ Index: xen-4.3.4/xen/include/xsm/xsm.h
  #endif /* CONFIG_X86 */
  
  #ifdef CONFIG_ARM
-Index: xen-4.3.4/xen/xsm/dummy.c
-===================================================================
+diff --git xen-4.3.4.orig/xen/xsm/dummy.c xen-4.3.4/xen/xsm/dummy.c
+index bc2e28e..0d0ac95 100644
 --- xen-4.3.4.orig/xen/xsm/dummy.c
 +++ xen-4.3.4/xen/xsm/dummy.c
-@@ -135,4 +135,5 @@ void xsm_fixup_ops (struct xsm_operation
+@@ -135,4 +135,5 @@ void xsm_fixup_ops (struct xsm_operations *ops)
      set_to_dummy_if_null(ops, map_gmfn_foreign);
  #endif
      set_to_dummy_if_null(ops, memory_translate);
 +    set_to_dummy_if_null(ops, v4v_send);
  }
-Index: xen-4.3.4/xen/xsm/flask/hooks.c
-===================================================================
+diff --git xen-4.3.4.orig/xen/xsm/flask/hooks.c xen-4.3.4/xen/xsm/flask/hooks.c
+index a30a782..04169e3 100644
 --- xen-4.3.4.orig/xen/xsm/flask/hooks.c
 +++ xen-4.3.4/xen/xsm/flask/hooks.c
-@@ -1470,6 +1470,11 @@ static int flask_map_gmfn_foreign(struct
+@@ -1470,6 +1470,11 @@ static int flask_map_gmfn_foreign(struct domain *d, struct domain *t)
  }
  #endif
  
@@ -2780,7 +2890,7 @@ Index: xen-4.3.4/xen/xsm/flask/hooks.c
  long do_flask_op(XEN_GUEST_HANDLE_PARAM(xsm_op_t) u_flask_op);
  
  static struct xsm_operations flask_ops = {
-@@ -1578,6 +1583,7 @@ static struct xsm_operations flask_ops =
+@@ -1578,6 +1583,7 @@ static struct xsm_operations flask_ops = {
  #ifdef CONFIG_ARM
      .map_gmfn_foreign = flask_map_gmfn_foreign,
  #endif
@@ -2788,8 +2898,8 @@ Index: xen-4.3.4/xen/xsm/flask/hooks.c
  };
  
  static __init int flask_init(void)
-Index: xen-4.3.4/xen/xsm/flask/policy/access_vectors
-===================================================================
+diff --git xen-4.3.4.orig/xen/xsm/flask/policy/access_vectors xen-4.3.4/xen/xsm/flask/policy/access_vectors
+index 77b3b50..6329202 100644
 --- xen-4.3.4.orig/xen/xsm/flask/policy/access_vectors
 +++ xen-4.3.4/xen/xsm/flask/policy/access_vectors
 @@ -450,3 +450,8 @@ class security
@@ -2801,8 +2911,8 @@ Index: xen-4.3.4/xen/xsm/flask/policy/access_vectors
 +{
 +    send
 +}
-Index: xen-4.3.4/xen/xsm/flask/policy/security_classes
-===================================================================
+diff --git xen-4.3.4.orig/xen/xsm/flask/policy/security_classes xen-4.3.4/xen/xsm/flask/policy/security_classes
+index ef134a7..560f76e 100644
 --- xen-4.3.4.orig/xen/xsm/flask/policy/security_classes
 +++ xen-4.3.4/xen/xsm/flask/policy/security_classes
 @@ -17,5 +17,6 @@ class shadow


### PR DESCRIPTION
Fixes to integer overflow handling, input validation and
signed/unsigned types in v4v hypervisor code.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
Signed-off-by: James McKenzie <voreekf@madingley.org>
Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>

(cherry picked from commit 7e1f88ebe9794fa76cf22fab17bcba1d84d7bf19)