### PR TITLE
OXT-680: Input-server PIDfile handling in initscript

### DIFF
--- a/recipes-openxt/xenclient/xenclient-input-daemon/input-daemon.initscript
+++ b/recipes-openxt/xenclient/xenclient-input-daemon/input-daemon.initscript
@@ -17,7 +17,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-# Provides:		xenmgr
+PIDFILE=/var/run/input_server.pid
 
 set -e
 
@@ -28,17 +28,19 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 case "$1" in
 start)
 	echo "Starting XenMgr input daemon"
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile /var/run/input_server.pid --exec /usr/bin/input_server
+	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec /usr/bin/input_server
 	;;
   stop)
 	echo "Stopping XenMgr input daemon"
-	start-stop-daemon --stop --quiet --oknodo --pidfile /var/run/input_server.pid
+	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+	rm -f $PIDFILE
 	;;
 
   restart)
 	echo "Restarting XenMgr server"
-	start-stop-daemon --stop --quiet --oknodo --pidfile /var/run/input_server.pid
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile /var/run/input_server.pid --exec /usr/bin/input_server
+	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+	rm -f $PIDFILE
+	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec /usr/bin/input_server
 	;;
 
   *)

--- a/recipes-openxt/xenclient/xenclient-input-daemon/input-daemon.initscript
+++ b/recipes-openxt/xenclient/xenclient-input-daemon/input-daemon.initscript
@@ -25,8 +25,6 @@ set -e
 
 test -x $DAEMON || exit 0
 
-export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
-
 case "$1" in
 	start)
 	echo "Starting $NAME"

--- a/recipes-openxt/xenclient/xenclient-input-daemon/input-daemon.initscript
+++ b/recipes-openxt/xenclient/xenclient-input-daemon/input-daemon.initscript
@@ -17,33 +17,36 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
+NAME="Input Server"
+DAEMON=/usr/bin/input_server
 PIDFILE=/var/run/input_server.pid
 
 set -e
 
-test -x /usr/bin/input_server || exit 0
+test -x $DAEMON || exit 0
 
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
 case "$1" in
-start)
-	echo "Starting XenMgr input daemon"
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec /usr/bin/input_server
+	start)
+	echo "Starting $NAME"
+	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON
 	;;
-  stop)
-	echo "Stopping XenMgr input daemon"
+
+	stop)
+	echo "Stopping $NAME"
 	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
 	rm -f $PIDFILE
 	;;
 
-  restart)
-	echo "Restarting XenMgr server"
+	restart)
+	echo "Restarting $NAME"
 	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
 	rm -f $PIDFILE
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec /usr/bin/input_server
+	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON
 	;;
 
-  *)
+	*)
 	echo "Usage: $0 {start|stop|restart}"
 	exit 1
 esac


### PR DESCRIPTION
start-stop-daemon will not remove the PID file, the initscript then might fail to restart the daemon.

OXT-680

The rest is just cosmetic.