### PR TITLE
xen/v4v: add a XSM/Flask v4v use permission check

### DIFF
--- a/recipes-extended/xen/files/openxt-xen-xsmv4vuse.patch
+++ b/recipes-extended/xen/files/openxt-xen-xsmv4vuse.patch
@@ -1,0 +1,140 @@
+Index: xen-4.3.4/xen/common/v4v.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/v4v.c
++++ xen-4.3.4/xen/common/v4v.c
+@@ -1687,7 +1687,7 @@ v4v_send (struct domain *src_d, v4v_addr
+     }
+ 
+   /* XSM: verify if src is allowed to send to dst */
+-  if (xsm_v4v_send(src_d, dst_d) != 0)
++  if (xsm_v4v_send(XSM_HOOK, src_d, dst_d) != 0)
+     {
+       printk(KERN_ERR "V4V: XSM REJECTED %i -> %i\n",
+              src_addr->domain, dst_addr->domain);
+@@ -1798,7 +1798,7 @@ v4v_sendv (struct domain *src_d, v4v_add
+     }
+ 
+   /* XSM: verify if src is allowed to send to dst */
+-  if (xsm_v4v_send(src_d, dst_d) != 0)
++  if (xsm_v4v_send(XSM_HOOK, src_d, dst_d) != 0)
+     {
+       printk(KERN_ERR "V4V: XSM REJECTED %i -> %i\n",
+              src_addr->domain, dst_addr->domain);
+@@ -1878,7 +1878,11 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
+            XEN_GUEST_HANDLE (void) arg3, uint32_t arg4, uint32_t arg5)
+ {
+   struct domain *d = current->domain;
+-  long rc = -EFAULT;
++  long rc;
++
++  rc = xsm_v4v_use(XSM_HOOK, d);
++  if (rc)
++      return rc;
+ 
+ #ifdef V4V_DEBUG
+ 
+@@ -1889,6 +1893,8 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
+ #endif
+ 
+   domain_lock (d);
++
++  rc = -EFAULT;
+   switch (cmd)
+     {
+     case V4VOP_register_ring:
+Index: xen-4.3.4/xen/include/xsm/dummy.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/xsm/dummy.h
++++ xen-4.3.4/xen/include/xsm/dummy.h
+@@ -636,9 +636,16 @@ static XSM_INLINE int xsm_ioport_mapping
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+-static XSM_INLINE int xsm_v4v_send(struct domain *d, struct domain *t)
++static XSM_INLINE int xsm_v4v_send(XSM_DEFAULT_ARG struct domain *d, struct domain *t)
+ {
+-    return 0;
++    XSM_ASSERT_ACTION(XSM_HOOK);
++    return xsm_default_action(action, d, t);
++}
++
++static XSM_INLINE int xsm_v4v_use(XSM_DEFAULT_ARG struct domain *d)
++{
++    XSM_ASSERT_ACTION(XSM_HOOK);
++    return xsm_default_action(action, d, d);
+ }
+ 
+ #endif /* CONFIG_X86 */
+Index: xen-4.3.4/xen/include/xsm/xsm.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/xsm/xsm.h
++++ xen-4.3.4/xen/include/xsm/xsm.h
+@@ -166,6 +166,7 @@ struct xsm_operations {
+     int (*map_gmfn_foreign) (struct domain *d, struct domain *t);
+ #endif
+     int (*v4v_send) (struct domain *dom1, struct domain *dom2);
++    int (*v4v_use) (struct domain *d);
+ };
+ 
+ #ifdef XSM_ENABLE
+@@ -626,10 +627,15 @@ static inline int xsm_ioport_mapping (xs
+     return xsm_ops->ioport_mapping(d, s, e, allow);
+ }
+ 
+-static inline int xsm_v4v_send(struct domain *d1, struct domain *d2)
++static inline int xsm_v4v_send(xsm_default_t def, struct domain *d1, struct domain *d2)
+ {
+     return xsm_ops->v4v_send(d1,d2);
+ }
++
++static inline int xsm_v4v_use(xsm_default_t def, struct domain *d)
++{
++    return xsm_ops->v4v_use(d);
++}
+ #endif /* CONFIG_X86 */
+ 
+ #ifdef CONFIG_ARM
+Index: xen-4.3.4/xen/xsm/dummy.c
+===================================================================
+--- xen-4.3.4.orig/xen/xsm/dummy.c
++++ xen-4.3.4/xen/xsm/dummy.c
+@@ -136,4 +136,5 @@ void xsm_fixup_ops (struct xsm_operation
+ #endif
+     set_to_dummy_if_null(ops, memory_translate);
+     set_to_dummy_if_null(ops, v4v_send);
++    set_to_dummy_if_null(ops, v4v_use);
+ }
+Index: xen-4.3.4/xen/xsm/flask/hooks.c
+===================================================================
+--- xen-4.3.4.orig/xen/xsm/flask/hooks.c
++++ xen-4.3.4/xen/xsm/flask/hooks.c
+@@ -1481,6 +1481,11 @@ static int flask_v4v_send(struct domain
+     return domain_has_perm(dom1, dom2, SECCLASS_V4V, V4V__SEND);
+ }
+ 
++static int flask_v4v_use(struct domain *d)
++{
++    return current_has_perm(d, SECCLASS_V4V, V4V__USE);
++}
++
+ long do_flask_op(XEN_GUEST_HANDLE_PARAM(xsm_op_t) u_flask_op);
+ 
+ static struct xsm_operations flask_ops = {
+@@ -1590,6 +1595,7 @@ static struct xsm_operations flask_ops =
+     .map_gmfn_foreign = flask_map_gmfn_foreign,
+ #endif
+     .v4v_send = flask_v4v_send,
++    .v4v_use = flask_v4v_use,
+ };
+ 
+ static __init int flask_init(void)
+Index: xen-4.3.4/xen/xsm/flask/policy/access_vectors
+===================================================================
+--- xen-4.3.4.orig/xen/xsm/flask/policy/access_vectors
++++ xen-4.3.4/xen/xsm/flask/policy/access_vectors
+@@ -458,4 +458,5 @@ class security
+ class v4v
+ {
+     send
++    use
+ }

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -122,6 +122,7 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://xsa-170-guest-user-mode-may-crash-guest-with-non-canonical-rip.patch;patch=1 \
     file://xsa-173-x86-shadow-pagetables-address-width-overflow.patch;patch=1 \
     file://xen-fix-xsave.patch \
+    file://openxt-xen-xsmv4vuse.patch \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"


### PR DESCRIPTION
Add a XSM/Flask v4v use permission check to control
the ability to invoke any of the v4v hypercalls.
The existing v4v send permission check only controls the
ability to send via v4v, but still allows use of other v4v
hypercalls, and a subset of the v4v send code path is still
reachable prior to the send check.  The use permission check can
be used to remove the v4v hypercall interface entirely from the
attack surface of the hypervisor for domains that have no legitimate
reason to use v4v.

This change depends on a separate change to xsm-policy to allow v4v
use by authorized domains.

Also update the xsm_v4v_send hook to follow the upstream convention
of including a XSM_DEFAULT_ARG parameter and returning the result of
xsm_default_action() when XSM is disabled; this convention was introduced
in xen commit 0d7f18b01f69c6b89aa3654bd2b11e24f41aaf71 but the v4v XSM
send hook was apparently not updated for it.  This has no impact in
OpenXT since XSM is always enabled, but makes it consistent with upstream.

OXT-666

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
(cherry picked from commit 304d2cfed33e175ca1299975c422cddafe18035f)