### PR TITLE
Stable-6: OXT-668: intel microcode update to 20160714

### DIFF
--- a/recipes-kernel/intel/intel-microcode.inc
+++ b/recipes-kernel/intel/intel-microcode.inc
@@ -5,7 +5,7 @@ DESCRIPTION = "Intel microcode"
 # but the package does not contain the license so we set this to CLOSED to make bb happy. 
 LICENSE = "CLOSED"
 
-SRC_URI = " http://downloadmirror.intel.com/19342/eng/microcode-${PV}.tgz "
+SRC_URI = " http://downloadmirror.intel.com/26156/eng/microcode-${PV}.tgz "
 
 do_install() {
         install -d ${D}/etc

--- a/recipes-kernel/intel/intel-microcode_20130906.bb
+++ b/recipes-kernel/intel/intel-microcode_20130906.bb
@@ -1,5 +1,0 @@
-require recipes-kernel/intel/intel-microcode.inc
-
-SRC_URI = "${OPENXT_MIRROR}/microcode-${PV}.tgz " 
-SRC_URI[md5sum] = "40008cd2a18a96bf04d3290e8faad812"
-SRC_URI[sha256sum] = "7b6ba0db102581674c29a2e2b859ba51e5cfb11e6cbef9056e4ac6cde2116386"

--- a/recipes-kernel/intel/intel-microcode_20160714.bb
+++ b/recipes-kernel/intel/intel-microcode_20160714.bb
@@ -1,0 +1,5 @@
+require recipes-kernel/intel/intel-microcode.inc
+
+SRC_URI = "${OPENXT_MIRROR}/microcode-${PV}.tgz "
+SRC_URI[md5sum] = "84e4c0530dc38fd7b804daf894b1bdf9"
+SRC_URI[sha256sum] = "f3a9c6fc93275bf1febc26f7c397ac93ed5f109e47fb52932f6dbd5cfdbc840e"


### PR DESCRIPTION
Note: the OpenXT mirror needs to be updated before this PR can be accepted.

This recipe should be replaced by a dependency on the meta-intel
layer, but unfortunately at the moment the microcode version in
the upstream layer is not from 2016. An upstream patch has been
submitted to correct that and we update the OpenXT version here in
the meantime.

refs: OXT-668

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>

cherry-picked from commit: b6a172f18d2b28d4632b1b9b671607ed8fd44e40