### PR TITLE
Stable-6: OXT-667 : wpa-supplicant : apply CVE fixes

### DIFF
--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2014-1-0001-Add-os_exec-helper-to-run-external-programs.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2014-1-0001-Add-os_exec-helper-to-run-external-programs.patch
@@ -1,0 +1,122 @@
+From 89de07a9442072f88d49869d8ecd8d42bae050a0 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@qca.qualcomm.com>
+Date: Mon, 6 Oct 2014 16:27:44 +0300
+Subject: [PATCH 1/3] Add os_exec() helper to run external programs
+
+Signed-off-by: Jouni Malinen <jouni@qca.qualcomm.com>
+
+Modified for OpenXT.org
+Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
+---
+ src/utils/os.h       |  9 +++++++++
+ src/utils/os_unix.c  | 55 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/utils/os_win32.c |  6 ++++++
+ 3 files changed, 70 insertions(+)
+
+diff --git a/src/utils/os.h b/src/utils/os.h
+index f196209..b9247d8 100644
+--- a/src/utils/os.h
++++ b/src/utils/os.h
+@@ -475,6 +475,15 @@ size_t os_strlcpy(char *dest, const char *src, size_t siz);
+  */
+ size_t os_strlcpy(char *dest, const char *src, size_t siz);
+ 
++/**
++ * os_exec - Execute an external program
++ * @program: Path to the program
++ * @arg: Command line argument string
++ * @wait_completion: Whether to wait until the program execution completes
++ * Returns: 0 on success, -1 on error
++ */
++int os_exec(const char *program, const char *arg, int wait_completion);
++
+ 
+ #ifdef OS_REJECT_C_LIB_FUNCTIONS
+ #define malloc OS_DO_NOT_USE_malloc
+diff --git a/src/utils/os_unix.c b/src/utils/os_unix.c
+index 7498967..523a4d0 100644
+--- a/src/utils/os_unix.c
++++ b/src/utils/os_unix.c
+@@ -15,6 +15,7 @@
+ #include "includes.h"
+ 
+ #include "os.h"
++#include <sys/wait.h>
+ 
+ #ifdef WPA_TRACE
+
+@@ -435,3 +435,57 @@ char * os_strdup(const char *s)
+ }
+ 
+ #endif /* WPA_TRACE */
++
++
++int os_exec(const char *program, const char *arg, int wait_completion)
++{
++	pid_t pid;
++	int pid_status;
++
++	pid = fork();
++	if (pid < 0) {
++		perror("fork");
++		return -1;
++	}
++
++	if (pid == 0) {
++		/* run the external command in the child process */
++		const int MAX_ARG = 30;
++		char *_program, *_arg, *pos;
++		char *argv[MAX_ARG + 1];
++		int i;
++
++		_program = os_strdup(program);
++		_arg = os_strdup(arg);
++
++		argv[0] = _program;
++
++		i = 1;
++		pos = _arg;
++		while (i < MAX_ARG && pos && *pos) {
++			while (*pos == ' ')
++				pos++;
++			if (*pos == '\0')
++				break;
++			argv[i++] = pos;
++			pos = os_strchr(pos, ' ');
++			if (pos)
++				*pos++ = '\0';
++		}
++		argv[i] = NULL;
++
++		execv(program, argv);
++		perror("execv");
++		os_free(_program);
++		os_free(_arg);
++		exit(0);
++		return -1;
++	}
++
++	if (wait_completion) {
++		/* wait for the child process to complete in the parent */
++		waitpid(pid, &pid_status, 0);
++	}
++
++	return 0;
++}
+diff --git a/src/utils/os_win32.c b/src/utils/os_win32.c
+index 55937de..57ee132 100644
+--- a/src/utils/os_win32.c
++++ b/src/utils/os_win32.c
+@@ -220,3 +220,9 @@ size_t os_strlcpy(char *dest, const char *src, size_t siz)
+ 
+ 	return s - src - 1;
+ }
++
++
++int os_exec(const char *program, const char *arg, int wait_completion)
++{
++	return -1;
++}
+-- 
+1.9.1
+

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2014-1-0002-wpa_cli-Use-os_exec-for-action-script-execution.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2014-1-0002-wpa_cli-Use-os_exec-for-action-script-execution.patch
@@ -1,0 +1,59 @@
+From c5f258de76dbb67fb64beab39a99e5c5711f41fe Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@qca.qualcomm.com>
+Date: Mon, 6 Oct 2014 17:25:52 +0300
+Subject: [PATCH 2/3] wpa_cli: Use os_exec() for action script execution
+
+Use os_exec() to run the action script operations to avoid undesired
+command line processing for control interface event strings. Previously,
+it could have been possible for some of the event strings to include
+unsanitized data which is not suitable for system() use. (CVE-2014-3686)
+
+Signed-off-by: Jouni Malinen <jouni@qca.qualcomm.com>
+---
+ wpa_supplicant/wpa_cli.c | 25 ++++++++-----------------
+ 1 file changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/wpa_supplicant/wpa_cli.c b/wpa_supplicant/wpa_cli.c
+index 18b9b77..fe30b41 100644
+--- a/wpa_supplicant/wpa_cli.c
++++ b/wpa_supplicant/wpa_cli.c
+@@ -1771,28 +1771,19 @@ static int str_match(const char *a, const char *b)
+ static int wpa_cli_exec(const char *program, const char *arg1,
+ 			const char *arg2)
+ {
+-	char *cmd;
++	char *arg;
+ 	size_t len;
+ 	int res;
+-	int ret = 0;
+ 
+-	len = os_strlen(program) + os_strlen(arg1) + os_strlen(arg2) + 3;
+-	cmd = os_malloc(len);
+-	if (cmd == NULL)
+-		return -1;
+-	res = os_snprintf(cmd, len, "%s %s %s", program, arg1, arg2);
+-	if (res < 0 || (size_t) res >= len) {
+-		os_free(cmd);
++	len = os_strlen(arg1) + os_strlen(arg2) + 2;
++	arg = os_malloc(len);
++	if (arg == NULL)
+ 		return -1;
+-	}
+-	cmd[len - 1] = '\0';
+-#ifndef _WIN32_WCE
+-	if (system(cmd) < 0)
+-		ret = -1;
+-#endif /* _WIN32_WCE */
+-	os_free(cmd);
++	os_snprintf(arg, len, "%s %s", arg1, arg2);
++	res = os_exec(program, arg, 1);
++	os_free(arg);
+ 
+-	return ret;
++	return res;
+ }
+ 
+ 
+-- 
+1.9.1
+

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2015-2-0001-WPS-Fix-HTTP-chunked-transfer-encoding-parser.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2015-2-0001-WPS-Fix-HTTP-chunked-transfer-encoding-parser.patch
@@ -1,0 +1,49 @@
+From 5acd23f4581da58683f3cf5e36cb71bbe4070bd7 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Tue, 28 Apr 2015 17:08:33 +0300
+Subject: [PATCH] WPS: Fix HTTP chunked transfer encoding parser
+
+strtoul() return value may end up overflowing the int h->chunk_size and
+resulting in a negative value to be stored as the chunk_size. This could
+result in the following memcpy operation using a very large length
+argument which would result in a buffer overflow and segmentation fault.
+
+This could have been used to cause a denial service by any device that
+has been authorized for network access (either wireless or wired). This
+would affect both the WPS UPnP functionality in a WPS AP (hostapd with
+upnp_iface parameter set in the configuration) and WPS ER
+(wpa_supplicant with WPS_ER_START control interface command used).
+
+Validate the parsed chunk length value to avoid this. In addition to
+rejecting negative values, we can also reject chunk size that would be
+larger than the maximum configured body length.
+
+Thanks to Kostya Kortchinsky of Google security team for discovering and
+reporting this issue.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/wps/httpread.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/wps/httpread.c b/src/wps/httpread.c
+index 2f08f37..d2855e3 100644
+--- a/src/wps/httpread.c
++++ b/src/wps/httpread.c
+@@ -533,6 +533,13 @@ static void httpread_read_handler(int sd, void *eloop_ctx, void *sock_ctx)
+ 					if (!isxdigit(*cbp))
+ 						goto bad;
+ 					h->chunk_size = strtoul(cbp, NULL, 16);
++					if (h->chunk_size < 0 ||
++					    h->chunk_size > h->max_bytes) {
++						wpa_printf(MSG_DEBUG,
++							   "httpread: Invalid chunk size %d",
++							   h->chunk_size);
++						goto bad;
++					}
+ 					/* throw away chunk header
+ 					 * so we have only real data
+ 					 */
+-- 
+1.9.1
+

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2015-3-0001-AP-WMM-Fix-integer-underflow-in-WMM-Action-frame-par.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2015-3-0001-AP-WMM-Fix-integer-underflow-in-WMM-Action-frame-par.patch
@@ -1,0 +1,41 @@
+From ef566a4d4f74022e1fdb0a2addfe81e6de9f4aae Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Wed, 29 Apr 2015 02:21:53 +0300
+Subject: [PATCH] AP WMM: Fix integer underflow in WMM Action frame parser
+
+The length of the WMM Action frame was not properly validated and the
+length of the information elements (int left) could end up being
+negative. This would result in reading significantly past the stack
+buffer while parsing the IEs in ieee802_11_parse_elems() and while doing
+so, resulting in segmentation fault.
+
+This can result in an invalid frame being used for a denial of service
+attack (hostapd process killed) against an AP with a driver that uses
+hostapd for management frame processing (e.g., all mac80211-based
+drivers).
+
+Thanks to Kostya Kortchinsky of Google security team for discovering and
+reporting this issue.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/ap/wmm.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/ap/wmm.c b/src/ap/wmm.c
+index 6d4177c..314e244 100644
+--- a/src/ap/wmm.c
++++ b/src/ap/wmm.c
+@@ -274,6 +274,9 @@ void hostapd_wmm_action(struct hostapd_data *hapd,
+ 		return;
+ 	}
+ 
++	if (left < 0)
++		return; /* not a valid WMM Action frame */
++
+ 	/* extract the tspec info element */
+ 	if (ieee802_11_parse_elems(pos, left, &elems, 1) == ParseFailed) {
+ 		hostapd_logger(hapd, mgmt->sa, HOSTAPD_MODULE_IEEE80211,
+-- 
+1.9.1
+

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2015-5-0001-NFC-Fix-payload-length-validation-in-NDEF-record-par.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2015-5-0001-NFC-Fix-payload-length-validation-in-NDEF-record-par.patch
@@ -1,0 +1,64 @@
+From df9079e72760ceb7ebe7fb11538200c516bdd886 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Tue, 7 Jul 2015 21:57:28 +0300
+Subject: [PATCH] NFC: Fix payload length validation in NDEF record parser
+
+It was possible for the 32-bit record->total_length value to end up
+wrapping around due to integer overflow if the longer form of payload
+length field is used and record->payload_length gets a value close to
+2^32. This could result in ndef_parse_record() accepting a too large
+payload length value and the record type filter reading up to about 20
+bytes beyond the end of the buffer and potentially killing the process.
+This could also result in an attempt to allocate close to 2^32 bytes of
+heap memory and if that were to succeed, a buffer read overflow of the
+same length which would most likely result in the process termination.
+In case of record->total_length ending up getting the value 0, there
+would be no buffer read overflow, but record parsing would result in an
+infinite loop in ndef_parse_records().
+
+Any of these error cases could potentially be used for denial of service
+attacks over NFC by using a malformed NDEF record on an NFC Tag or
+sending them during NFC connection handover if the application providing
+the NDEF message to hostapd/wpa_supplicant did no validation of the
+received records. While such validation is likely done in the NFC stack
+that needs to parse the NFC messages before further processing,
+hostapd/wpa_supplicant better be prepared for any data being included
+here.
+
+Fix this by validating record->payload_length value in a way that
+detects integer overflow. (CID 122668)
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+
+Modified for http://openXT.org
+Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
+---
+ src/wps/ndef.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/wps/ndef.c b/src/wps/ndef.c
+index 5604b0a..50d018f 100644
+--- a/src/wps/ndef.c
++++ b/src/wps/ndef.c
+@@ -48,6 +48,8 @@ static int ndef_parse_record(const u8 *data, u32 size,
+ 		if (size < 6)
+ 			return -1;
+ 		record->payload_length = ntohl(*(u32 *)pos);
++		if (record->payload_length > size - 6)
++			return -1;
+ 		pos += sizeof(u32);
+ 	}
+ 
+@@ -75,7 +77,8 @@ static int ndef_parse_record(const u8 *data, u32 size,
+ 	pos += record->payload_length;
+ 
+ 	record->total_length = pos - data;
+-	if (record->total_length > size)
++	if (record->total_length > size ||
++	    record->total_length < record->payload_length)
+ 		return -1;
+ 	return 0;
+ }
+-- 
+1.9.1
+

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2016-1-0001-WPS-Reject-a-Credential-with-invalid-passphrase.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2016-1-0001-WPS-Reject-a-Credential-with-invalid-passphrase.patch
@@ -1,0 +1,97 @@
+WPA/WPA2-Personal passphrase is not allowed to include control
+characters. Reject a Credential received from a WPS Registrar both as
+STA (Credential) and AP (AP Settings) if the credential is for WPAPSK or
+WPA2PSK authentication type and includes an invalid passphrase.
+
+This fixes an issue where hostapd or wpa_supplicant could have updated
+the configuration file PSK/passphrase parameter with arbitrary data from
+an external device (Registrar) that may not be fully trusted. Should
+such data include a newline character, the resulting configuration file
+could become invalid and fail to be parsed.
+
+Signed-off-by: Jouni Malinen <jouni@qca.qualcomm.com>
+
+Modified for OpenXT
+Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
+
+diff --git a/src/utils/common.c b/src/utils/common.c
+index 1b8ea80..a28dd5b 100644
+--- a/src/utils/common.c
++++ b/src/utils/common.c
+@@ -361,3 +361,14 @@ void * __hide_aliasing_typecast(void *foo)
+ {
+ 	return foo;
+ }
++
++int has_ctrl_char(const u8 *data, size_t len)
++{
++   size_t i;
++
++   for (i = 0; i < len; i++) {
++       if (data[i] < 32 || data[i] == 127)
++           return 1;
++   }
++   return 0;
++}
+diff --git a/src/utils/common.h b/src/utils/common.h
+index f17bf69..18e77ab 100644
+--- a/src/utils/common.h
++++ b/src/utils/common.h
+@@ -443,6 +443,7 @@ void wpa_get_ntp_timestamp(u8 *buf);
+ int wpa_snprintf_hex(char *buf, size_t buf_size, const u8 *data, size_t len);
+ int wpa_snprintf_hex_uppercase(char *buf, size_t buf_size, const u8 *data,
+ 			       size_t len);
++int has_ctrl_char(const u8 *data, size_t len);
+ 
+ #ifdef CONFIG_NATIVE_WINDOWS
+ void wpa_unicode2ascii_inplace(TCHAR *str);
+diff --git a/src/wps/wps_attr_process.c b/src/wps/wps_attr_process.c
+index 4751bbc..9183a8d 100644
+--- a/src/wps/wps_attr_process.c
++++ b/src/wps/wps_attr_process.c
+@@ -264,7 +264,7 @@ static int wps_process_cred_802_1x_enabled(struct wps_credential *cred,
+ }
+ 
+ 
+-static void wps_workaround_cred_key(struct wps_credential *cred)
++static int wps_workaround_cred_key(struct wps_credential *cred)
+ {
+ 	if (cred->auth_type & (WPS_AUTH_WPAPSK | WPS_AUTH_WPA2PSK) &&
+ 	    cred->key_len > 8 && cred->key_len < 64 &&
+@@ -278,6 +278,16 @@ static void wps_workaround_cred_key(struct wps_credential *cred)
+ 			   "termination from ASCII passphrase");
+ 		cred->key_len--;
+ 	}
++
++    if (cred->auth_type & (WPS_AUTH_WPAPSK | WPS_AUTH_WPA2PSK) &&
++       (cred->key_len < 8 || has_ctrl_char(cred->key, cred->key_len))) {
++        wpa_printf(MSG_INFO, "WPS: Reject credential with invalid WPA/WPA2-Personal passphrase");
++        wpa_hexdump_ascii_key(MSG_INFO, "WPS: Network Key",
++                     cred->key, cred->key_len);
++        return -1;
++    }
++
++    return 0;
+ }
+ 
+ 
+@@ -303,9 +313,7 @@ int wps_process_cred(struct wps_parse_attr *attr,
+ 	    wps_process_cred_802_1x_enabled(cred, attr->dot1x_enabled))
+ 		return -1;
+ 
+-	wps_workaround_cred_key(cred);
+-
+-	return 0;
++	return wps_workaround_cred_key(cred);
+ }
+ 
+ 
+@@ -324,7 +332,5 @@ int wps_process_ap_settings(struct wps_parse_attr *attr,
+ 	    wps_process_cred_mac_addr(cred, attr->mac_addr))
+ 		return -1;
+ 
+-	wps_workaround_cred_key(cred);
+-
+-	return 0;
++	return wps_workaround_cred_key(cred);
+ }

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2016-1-0002-Reject-psk-parameter-set-with-invalid-passphrase-cha.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2016-1-0002-Reject-psk-parameter-set-with-invalid-passphrase-cha.patch
@@ -1,0 +1,53 @@
+From 73e4abb24a936014727924d8b0b2965edfc117dd Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@qca.qualcomm.com>
+Date: Fri, 4 Mar 2016 18:46:41 +0200
+Subject: [PATCH 2/5] Reject psk parameter set with invalid passphrase
+ character
+
+WPA/WPA2-Personal passphrase is not allowed to include control
+characters. Reject a passphrase configuration attempt if that passphrase
+includes an invalid passphrase.
+
+This fixes an issue where wpa_supplicant could have updated the
+configuration file psk parameter with arbitrary data from the control
+interface or D-Bus interface. While those interfaces are supposed to be
+accessible only for trusted users/applications, it may be possible that
+an untrusted user has access to a management software component that
+does not validate the passphrase value before passing it to
+wpa_supplicant.
+
+This could allow such an untrusted user to inject up to 63 characters of
+almost arbitrary data into the configuration file. Such configuration
+file could result in wpa_supplicant trying to load a library (e.g.,
+opensc_engine_path, pkcs11_engine_path, pkcs11_module_path,
+load_dynamic_eap) from user controlled location when starting again.
+This would allow code from that library to be executed under the
+wpa_supplicant process privileges.
+
+Signed-off-by: Jouni Malinen <jouni@qca.qualcomm.com>
+
+Modified for OpenXT
+Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
+---
+ wpa_supplicant/config.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/wpa_supplicant/config.c b/wpa_supplicant/config.c
+index b1c7870..fdd9643 100644
+--- a/wpa_supplicant/config.c
++++ b/wpa_supplicant/config.c
+@@ -341,6 +341,12 @@ static int wpa_config_parse_psk(const struct parse_data *data,
+ 		}
+ 		wpa_hexdump_ascii_key(MSG_MSGDUMP, "PSK (ASCII passphrase)",
+ 				      (u8 *) value, len);
++		if (has_ctrl_char((u8 *) value, len)) {
++			wpa_printf(MSG_ERROR,
++					"Line %d: Invalid passphrase character",
++					line);
++			return -1;
++		}
+ 		if (ssid->passphrase && os_strlen(ssid->passphrase) == len &&
+ 		    os_memcmp(ssid->passphrase, value, len) == 0)
+ 			return 0;
+-- 
+1.9.1

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/2016-1-0003-Remove-newlines-from-wpa_supplicant-config-network-o.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/2016-1-0003-Remove-newlines-from-wpa_supplicant-config-network-o.patch
@@ -1,0 +1,74 @@
+From 0fe5a234240a108b294a87174ad197f6b5cb38e9 Mon Sep 17 00:00:00 2001
+From: Paul Stewart <pstew@google.com>
+Date: Thu, 3 Mar 2016 15:40:19 -0800
+Subject: [PATCH 3/5] Remove newlines from wpa_supplicant config network
+ output
+
+Spurious newlines output while writing the config file can corrupt the
+wpa_supplicant configuration. Avoid writing these for the network block
+parameters. This is a generic filter that cover cases that may not have
+been explicitly addressed with a more specific commit to avoid control
+characters in the psk parameter.
+
+Signed-off-by: Paul Stewart <pstew@google.com>
+
+Modified for OpenXT
+Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
+---
+
+diff --git a/src/utils/common.c b/src/utils/common.c
+index a28dd5b..ebb8336 100644
+--- a/src/utils/common.c
++++ b/src/utils/common.c
+@@ -372,3 +372,13 @@ int has_ctrl_char(const u8 *data, size_t len)
+    }
+    return 0;
+ }
++
++int has_newline(const char *str)
++{
++    while (*str) {
++        if (*str == '\n' || *str == '\r')
++            return 1;
++        str++;
++    }
++    return 0;
++}
+diff --git a/src/utils/common.h b/src/utils/common.h
+index 18e77ab..ce58cb5 100644
+--- a/src/utils/common.h
++++ b/src/utils/common.h
+@@ -444,6 +444,7 @@ int wpa_snprintf_hex(char *buf, size_t buf_size, const u8 *data, size_t len);
+ int wpa_snprintf_hex_uppercase(char *buf, size_t buf_size, const u8 *data,
+ 			       size_t len);
+ int has_ctrl_char(const u8 *data, size_t len);
++int has_newline(const char *str);
+ 
+ #ifdef CONFIG_NATIVE_WINDOWS
+ void wpa_unicode2ascii_inplace(TCHAR *str);
+diff --git a/wpa_supplicant/config.c b/wpa_supplicant/config.c
+index 4ec0f26..8508ecf 100644
+--- a/wpa_supplicant/config.c
++++ b/wpa_supplicant/config.c
+@@ -1963,8 +1963,19 @@ char * wpa_config_get(struct wpa_ssid *ssid, const char *var)
+ 
+ 	for (i = 0; i < NUM_SSID_FIELDS; i++) {
+ 		const struct parse_data *field = &ssid_fields[i];
+-		if (os_strcmp(var, field->name) == 0)
+-			return field->writer(field, ssid);
++		if (os_strcmp(var, field->name) == 0) {
++			char *ret = field->writer(field, ssid);
++
++			if (ret && has_newline(ret)) {
++				wpa_printf(MSG_ERROR,
++						"Found newline in value for %s; not returning it",
++						var);
++				os_free(ret);
++				ret = NULL;
++			}
++
++			return ret;
++		}
+ 	}
+ 
+ 	return NULL;

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_0.7.3.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_0.7.3.bbappend
@@ -11,6 +11,14 @@ PR .= ".1"
 SRC_URI += " \
             file://dbus-scan-results.patch;patch=1 \
             file://libnl3_2.patch \
+            file://2014-1-0001-Add-os_exec-helper-to-run-external-programs.patch \
+            file://2014-1-0002-wpa_cli-Use-os_exec-for-action-script-execution.patch \
+            file://2015-2-0001-WPS-Fix-HTTP-chunked-transfer-encoding-parser.patch \
+            file://2015-3-0001-AP-WMM-Fix-integer-underflow-in-WMM-Action-frame-par.patch \
+            file://2015-5-0001-NFC-Fix-payload-length-validation-in-NDEF-record-par.patch \
+            file://2016-1-0001-WPS-Reject-a-Credential-with-invalid-passphrase.patch \
+            file://2016-1-0002-Reject-psk-parameter-set-with-invalid-passphrase-cha.patch \
+            file://2016-1-0003-Remove-newlines-from-wpa_supplicant-config-network-o.patch \
 "
 
 S = "${WORKDIR}/wpa_supplicant-${PV}"


### PR DESCRIPTION
Motivated by fixes for:
  CVE-2015-8041
  CVE-2015-4141

Source material obtained from: http://w1.fi/security/
2014-1 through to 2016-1
with porting as necessary to apply patches to 0.7.3

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
(cherry picked from commit d538c2e383e1868980dcef0cfdafbb8e76c2fe7c)