### PR TITLE
Allow running lsusb from a newrole'd root shell.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/openxt-sysadm-lsusb.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/openxt-sysadm-lsusb.patch
@@ -1,0 +1,11 @@
+Index: refpolicy/policy/modules/roles/sysadm.te
+===================================================================
+--- refpolicy.orig/policy/modules/roles/sysadm.te
++++ refpolicy/policy/modules/roles/sysadm.te
+@@ -533,3 +533,6 @@ optional_policy(`
+ optional_policy(`
+ 	xsmutil_run(sysadm_t, sysadm_r)
+ ')
++
++# For running lsusb from a nr shell.
++allow sysadm_t self:netlink_kobject_uevent_socket create_socket_perms;

--- a/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
@@ -175,6 +175,7 @@ SRC_URI += " \
     file://patches/upstream-add-binder-security-class.patch;patch=1 \
     file://patches/upstream-update-netlink-classes.patch;patch=1 \
     file://patches/upstream-contrib-networkmanager.patch;patch=1 \
+    file://patches/openxt-sysadm-lsusb.patch;patch=1 \
     "
     
 def get_poltype(f):


### PR DESCRIPTION
Running lsusb from a newrole'd root shell fails with
the following SELinux denials:
    avc:  denied  { create } for  pid=1556 comm="lsusb" scontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 tclass=netlink_kobject_uevent_socket
    avc:  denied  { bind } for  pid=1556 comm="lsusb" scontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 tclass=netlink_kobject_uevent_socket
    avc:  denied  { read } for  pid=1556 comm="lsusb" scontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 tcontext=root:sysadm_r:sysadm_t:s0-s0:c0.c1023 tclass=netlink_kobject_uevent_socket

Permit this by allowing sysadm_t to create and use netlink sockets with the
NETLINK_KOBJECT_UEVENT protocol.  The alternative would be to introduce
a separate domain for lsusb or other programs that require such access,
but this doesn't seem justified given that we only want to allow this from
a newrole'd root shell and this additional access is not significant for
sysadm_t.

OXT-677

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
(cherry picked from commit 5bf09e704a72ddafed006a8130ed9345d9629b44)