### PR TITLE
refpolicy: Do not allow sending to dbus unconfined domains by default.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/openxt-dbus-deny-send-unconfined.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/openxt-dbus-deny-send-unconfined.patch
@@ -1,0 +1,18 @@
+Index: refpolicy/policy/modules/contrib/dbus.te
+===================================================================
+--- refpolicy.orig/policy/modules/contrib/dbus.te
++++ refpolicy/policy/modules/contrib/dbus.te
+@@ -258,4 +258,12 @@ optional_policy(`
+ #
+ 
+ allow dbusd_unconfined { system_dbusd_t session_bus_type dbusd_session_bus_client dbusd_system_bus_client }:dbus all_dbus_perms;
+-allow { dbusd_session_bus_client dbusd_system_bus_client } dbusd_unconfined:dbus send_msg;
++# This rule was added by upstream refpolicy commit
++# 6bef7a14757124c56fadc08c255e9dd6c29a15f9 in order to allow
++# dbus clients to answer to dbus unconfined domains.  However,
++# this is overly permissive and dangerous, since it exposes
++# dbus unconfined domains (i.e. those domains which are allowed
++# to send to any dbus destination) to any dbus client at all.
++# Disabling this for OpenXT.  Long term solution is to remove
++# unconfined altogether from OpenXT policy - sds.
++#allow { dbusd_session_bus_client dbusd_system_bus_client } dbusd_unconfined:dbus send_msg;

--- a/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
@@ -176,6 +176,7 @@ SRC_URI += " \
     file://patches/upstream-update-netlink-classes.patch;patch=1 \
     file://patches/upstream-contrib-networkmanager.patch;patch=1 \
     file://patches/openxt-sysadm-lsusb.patch;patch=1 \
+    file://patches/openxt-dbus-deny-send-unconfined.patch;patch=1 \
     "
     
 def get_poltype(f):


### PR DESCRIPTION
Upstream refpolicy commit 6bef7a14757124c56fadc08c255e9dd6c29a15f9
added a reverse rule for the existing rule that allowed dbus unconfined
domains to send to any dbus client in order to allow those dbus clients to
answer.  However, this exposes dbus unconfined domains (i.e. those domains
which are allowed to send to any dbus destination) to any regular
dbus client.  Remove this rule.  Explicit rules on individual domain
pairs can be added if needed.

In the specific case of OpenXT, this opened up D-BUS send from staff_t
or any other dbus client domain to xenmgr (xend_t), since the OpenXT policy
patches make xend_t an unconfined domain.  The user-visible effect was
that xec and xec-vm worked from a staff_t shell rather than requiring
a newrole.  This change restores the prior behavior of denying use of
xec or xec-vm by staff_t.

The longer term fix is to remove unconfined from xend_t and
ultimately remove the unconfined module entirely from the OpenXT
policy and fully confine all domains, but that is likely to have
wider side effects and require substantially more testing.

OXT-686

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>