### PR TITLE
[DO NOT MERGE - this is a fallback PR] - OXT-689 : return EEXIST when reregistering an existing ring

### DIFF
--- a/recipes-extended/xen/files/xc-xt-v4v.patch
+++ b/recipes-extended/xen/files/xc-xt-v4v.patch
@@ -135,10 +135,10 @@ index e22a41b..7ad5db0 100644
      int port;
 diff --git xen-4.3.4.orig/xen/common/v4v.c xen-4.3.4/xen/common/v4v.c
 new file mode 100644
-index 0000000..1549ac6
+index 0000000..20af7e8
 --- /dev/null
 +++ xen-4.3.4/xen/common/v4v.c
-@@ -0,0 +1,1976 @@
+@@ -0,0 +1,1974 @@
 +/******************************************************************************
 + * v4v.c
 + * 
@@ -1495,12 +1495,10 @@ index 0000000..1549ac6
 +          ring_info->mfns = NULL;
 +
 +        } else {
-+          /* Ring info already existed. If mfn list was already populated remove the 
-+           * MFN's from list and then add the new list.
-+           */
-+          printk(KERN_INFO "v4v: dom%d re-registering existing ring, clearing MFN list\n",
-+              current->domain->domain_id);
-+          v4v_ring_remove_mfns(ring_info);
++          printk(KERN_INFO "v4v: dom%d ring already registered\n",
++                 current->domain->domain_id);
++          ret = -EEXIST;
++          break;
 +      }
 +
 +      spin_lock (&ring_info->lock);


### PR DESCRIPTION
Removes the code that replaced the MFNs of the existing ring.
It was not holding the necessary write locks to invoke
v4v_ring_remove_mfns so could allow excess decrements to
the page reference counts via concurrent accesses.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>