### PR TITLE
Stable-6: OXT-697: Backport missing CVEs for Linux kernel

### DIFF
--- a/recipes-kernel/linux/4.4/linux-openxt_4.4.16.bb
+++ b/recipes-kernel/linux/4.4/linux-openxt_4.4.16.bb
@@ -44,6 +44,16 @@ SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.t
     file://xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch;patch=1 \
+    file://cve-2016-0758-KEYS-Fix-ASN.1-indefinite-length-object-parsing.patch \
+    file://cve-2016-3135-netfilter-x_tables-check-for-size-overflow.patch \
+    file://cve-2016-3672-x86-mm-32-Enable-full-randomization-on-i386-and-X86_.patch \
+    file://cve-2016-3951-cdc_ncm-do-not-call-usbnet_link_change-from-cdc_ncm_.patch \
+    file://cve-2016-4482-usbfs-fix-potential-infoleak-in-devio.patch \
+    file://cve-2016-4568-media-videobuf2-v4l2-Verify-planes-array-in-buffer-d.patch \
+    file://cve-2016-4569-ALSA-timer-Fix-leak-in-SNDRV_TIMER_IOCTL_PARAMS.patch \
+    file://cve-2016-4578-1-ALSA-timer-Fix-leak-in-events-via-snd_timer_user_cca.patch \
+    file://cve-2016-4578-2-ALSA-timer-Fix-leak-in-events-via-snd_timer_user_tin.patch \
+    file://cve-2016-5244-rds-fix-an-infoleak-in-rds_inc_info_copy.patch \
     file://defconfig \
     "
 

--- a/recipes-kernel/linux/4.4/patches/cve-2016-0758-KEYS-Fix-ASN.1-indefinite-length-object-parsing.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-0758-KEYS-Fix-ASN.1-indefinite-length-object-parsing.patch
@@ -1,0 +1,88 @@
+From 23c8a812dc3c621009e4f0e5342aa4e2ede1ceaa Mon Sep 17 00:00:00 2001
+From: David Howells <dhowells@redhat.com>
+Date: Tue, 23 Feb 2016 11:03:12 +0000
+Subject: [PATCH] KEYS: Fix ASN.1 indefinite length object parsing
+
+This fixes CVE-2016-0758.
+
+In the ASN.1 decoder, when the length field of an ASN.1 value is extracted,
+it isn't validated against the remaining amount of data before being added
+to the cursor.  With a sufficiently large size indicated, the check:
+
+	datalen - dp < 2
+
+may then fail due to integer overflow.
+
+Fix this by checking the length indicated against the amount of remaining
+data in both places a definite length is determined.
+
+Whilst we're at it, make the following changes:
+
+ (1) Check the maximum size of extended length does not exceed the capacity
+     of the variable it's being stored in (len) rather than the type that
+     variable is assumed to be (size_t).
+
+ (2) Compare the EOC tag to the symbolic constant ASN1_EOC rather than the
+     integer 0.
+
+ (3) To reduce confusion, move the initialisation of len outside of:
+
+	for (len = 0; n > 0; n--) {
+
+     since it doesn't have anything to do with the loop counter n.
+
+Signed-off-by: David Howells <dhowells@redhat.com>
+Reviewed-by: Mimi Zohar <zohar@linux.vnet.ibm.com>
+Acked-by: David Woodhouse <David.Woodhouse@intel.com>
+Acked-by: Peter Jones <pjones@redhat.com>
+---
+ lib/asn1_decoder.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+Index: linux-4.4.15/lib/asn1_decoder.c
+===================================================================
+--- linux-4.4.15.orig/lib/asn1_decoder.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/lib/asn1_decoder.c	2016-07-25 18:15:10.434659574 +0200
+@@ -74,7 +74,7 @@
+ 
+ 	/* Extract a tag from the data */
+ 	tag = data[dp++];
+-	if (tag == 0) {
++	if (tag == ASN1_EOC) {
+ 		/* It appears to be an EOC. */
+ 		if (data[dp++] != 0)
+ 			goto invalid_eoc;
+@@ -96,10 +96,8 @@
+ 
+ 	/* Extract the length */
+ 	len = data[dp++];
+-	if (len <= 0x7f) {
+-		dp += len;
+-		goto next_tag;
+-	}
++	if (len <= 0x7f)
++		goto check_length;
+ 
+ 	if (unlikely(len == ASN1_INDEFINITE_LENGTH)) {
+ 		/* Indefinite length */
+@@ -110,14 +108,18 @@
+ 	}
+ 
+ 	n = len - 0x80;
+-	if (unlikely(n > sizeof(size_t) - 1))
++	if (unlikely(n > sizeof(len) - 1))
+ 		goto length_too_long;
+ 	if (unlikely(n > datalen - dp))
+ 		goto data_overrun_error;
+-	for (len = 0; n > 0; n--) {
++	len = 0;
++	for (; n > 0; n--) {
+ 		len <<= 8;
+ 		len |= data[dp++];
+ 	}
++check_length:
++	if (len > datalen - dp)
++		goto data_overrun_error;
+ 	dp += len;
+ 	goto next_tag;
+ 

--- a/recipes-kernel/linux/4.4/patches/cve-2016-3135-netfilter-x_tables-check-for-size-overflow.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-3135-netfilter-x_tables-check-for-size-overflow.patch
@@ -1,0 +1,31 @@
+From d157bd761585605b7882935ffb86286919f62ea1 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Thu, 10 Mar 2016 01:56:23 +0100
+Subject: [PATCH] netfilter: x_tables: check for size overflow
+
+Ben Hawkes says:
+ integer overflow in xt_alloc_table_info, which on 32-bit systems can
+ lead to small structure allocation and a copy_from_user based heap
+ corruption.
+
+Reported-by: Ben Hawkes <hawkes@google.com>
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/netfilter/x_tables.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+Index: linux-4.4.15/net/netfilter/x_tables.c
+===================================================================
+--- linux-4.4.15.orig/net/netfilter/x_tables.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/net/netfilter/x_tables.c	2016-07-25 18:16:00.187314771 +0200
+@@ -897,6 +897,9 @@
+ 	struct xt_table_info *info = NULL;
+ 	size_t sz = sizeof(*info) + size;
+ 
++	if (sz < sizeof(*info))
++		return NULL;
++
+ 	/* Pedantry: prevent them from hitting BUG() in vmalloc.c --RR */
+ 	if ((SMP_ALIGN(size) >> PAGE_SHIFT) + 2 > totalram_pages)
+ 		return NULL;

--- a/recipes-kernel/linux/4.4/patches/cve-2016-3672-x86-mm-32-Enable-full-randomization-on-i386-and-X86_.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-3672-x86-mm-32-Enable-full-randomization-on-i386-and-X86_.patch
@@ -1,0 +1,80 @@
+From 8b8addf891de8a00e4d39fc32f93f7c5eb8feceb Mon Sep 17 00:00:00 2001
+From: Hector Marco-Gisbert <hecmargi@upv.es>
+Date: Thu, 10 Mar 2016 20:51:00 +0100
+Subject: [PATCH] x86/mm/32: Enable full randomization on i386 and X86_32
+
+Currently on i386 and on X86_64 when emulating X86_32 in legacy mode, only
+the stack and the executable are randomized but not other mmapped files
+(libraries, vDSO, etc.). This patch enables randomization for the
+libraries, vDSO and mmap requests on i386 and in X86_32 in legacy mode.
+
+By default on i386 there are 8 bits for the randomization of the libraries,
+vDSO and mmaps which only uses 1MB of VA.
+
+This patch preserves the original randomness, using 1MB of VA out of 3GB or
+4GB. We think that 1MB out of 3GB is not a big cost for having the ASLR.
+
+The first obvious security benefit is that all objects are randomized (not
+only the stack and the executable) in legacy mode which highly increases
+the ASLR effectiveness, otherwise the attackers may use these
+non-randomized areas. But also sensitive setuid/setgid applications are
+more secure because currently, attackers can disable the randomization of
+these applications by setting the ulimit stack to "unlimited". This is a
+very old and widely known trick to disable the ASLR in i386 which has been
+allowed for too long.
+
+Another trick used to disable the ASLR was to set the ADDR_NO_RANDOMIZE
+personality flag, but fortunately this doesn't work on setuid/setgid
+applications because there is security checks which clear Security-relevant
+flags.
+
+This patch always randomizes the mmap_legacy_base address, removing the
+possibility to disable the ASLR by setting the stack to "unlimited".
+
+Signed-off-by: Hector Marco-Gisbert <hecmargi@upv.es>
+Acked-by: Ismael Ripoll Ripoll <iripoll@upv.es>
+Acked-by: Kees Cook <keescook@chromium.org>
+Acked-by: Arjan van de Ven <arjan@linux.intel.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: akpm@linux-foundation.org
+Cc: kees Cook <keescook@chromium.org>
+Link: http://lkml.kernel.org/r/1457639460-5242-1-git-send-email-hecmargi@upv.es
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/mm/mmap.c | 14 +-------------
+ 1 file changed, 1 insertion(+), 13 deletions(-)
+
+Index: linux-4.4.15/arch/x86/mm/mmap.c
+===================================================================
+--- linux-4.4.15.orig/arch/x86/mm/mmap.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/arch/x86/mm/mmap.c	2016-07-25 18:19:07.581427773 +0200
+@@ -94,18 +94,6 @@
+ }
+ 
+ /*
+- * Bottom-up (legacy) layout on X86_32 did not support randomization, X86_64
+- * does, but not when emulating X86_32
+- */
+-static unsigned long mmap_legacy_base(unsigned long rnd)
+-{
+-	if (mmap_is_ia32())
+-		return TASK_UNMAPPED_BASE;
+-	else
+-		return TASK_UNMAPPED_BASE + rnd;
+-}
+-
+-/*
+  * This function, called very early during the creation of a new
+  * process VM image, sets up which VM layout function to use:
+  */
+@@ -116,7 +104,7 @@
+ 	if (current->flags & PF_RANDOMIZE)
+ 		random_factor = arch_mmap_rnd();
+ 
+-	mm->mmap_legacy_base = mmap_legacy_base(random_factor);
++	mm->mmap_legacy_base = TASK_UNMAPPED_BASE + random_factor;
+ 
+ 	if (mmap_is_legacy()) {
+ 		mm->mmap_base = mm->mmap_legacy_base;

--- a/recipes-kernel/linux/4.4/patches/cve-2016-3951-cdc_ncm-do-not-call-usbnet_link_change-from-cdc_ncm_.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-3951-cdc_ncm-do-not-call-usbnet_link_change-from-cdc_ncm_.patch
@@ -1,0 +1,84 @@
+From 4d06dd537f95683aba3651098ae288b7cbff8274 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B8rn=20Mork?= <bjorn@mork.no>
+Date: Mon, 7 Mar 2016 21:15:36 +0100
+Subject: [PATCH] cdc_ncm: do not call usbnet_link_change from cdc_ncm_bind
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+usbnet_link_change will call schedule_work and should be
+avoided if bind is failing. Otherwise we will end up with
+scheduled work referring to a netdev which has gone away.
+
+Instead of making the call conditional, we can just defer
+it to usbnet_probe, using the driver_info flag made for
+this purpose.
+
+Fixes: 8a34b0ae8778 ("usbnet: cdc_ncm: apply usbnet_link_change")
+Reported-by: Andrey Konovalov <andreyknvl@gmail.com>
+Suggested-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Bjørn Mork <bjorn@mork.no>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/usb/cdc_ncm.c | 20 +++++---------------
+ 1 file changed, 5 insertions(+), 15 deletions(-)
+
+Index: linux-4.4.16/drivers/net/usb/cdc_ncm.c
+===================================================================
+--- linux-4.4.16.orig/drivers/net/usb/cdc_ncm.c	2016-07-29 16:15:27.265386230 +0200
++++ linux-4.4.16/drivers/net/usb/cdc_ncm.c	2016-07-29 16:15:28.492036031 +0200
+@@ -952,8 +952,6 @@
+ 
+ static int cdc_ncm_bind(struct usbnet *dev, struct usb_interface *intf)
+ {
+-	int ret;
+-
+ 	/* MBIM backwards compatible function? */
+ 	if (cdc_ncm_select_altsetting(intf) != CDC_NCM_COMM_ALTSETTING_NCM)
+ 		return -ENODEV;
+@@ -962,16 +960,7 @@
+ 	 * Additionally, generic NCM devices are assumed to accept arbitrarily
+ 	 * placed NDP.
+ 	 */
+-	ret = cdc_ncm_bind_common(dev, intf, CDC_NCM_DATA_ALTSETTING_NCM, 0);
+-
+-	/*
+-	 * We should get an event when network connection is "connected" or
+-	 * "disconnected". Set network connection in "disconnected" state
+-	 * (carrier is OFF) during attach, so the IP network stack does not
+-	 * start IPv6 negotiation and more.
+-	 */
+-	usbnet_link_change(dev, 0, 0);
+-	return ret;
++	return cdc_ncm_bind_common(dev, intf, CDC_NCM_DATA_ALTSETTING_NCM, 0);
+ }
+ 
+ static void cdc_ncm_align_tail(struct sk_buff *skb, size_t modulus, size_t remainder, size_t max)
+@@ -1554,7 +1543,8 @@
+ 
+ static const struct driver_info cdc_ncm_info = {
+ 	.description = "CDC NCM",
+-	.flags = FLAG_POINTTOPOINT | FLAG_NO_SETINT | FLAG_MULTI_PACKET,
++	.flags = FLAG_POINTTOPOINT | FLAG_NO_SETINT | FLAG_MULTI_PACKET
++			| FLAG_LINK_INTR,
+ 	.bind = cdc_ncm_bind,
+ 	.unbind = cdc_ncm_unbind,
+ 	.manage_power = usbnet_manage_power,
+@@ -1567,7 +1557,7 @@
+ static const struct driver_info wwan_info = {
+ 	.description = "Mobile Broadband Network Device",
+ 	.flags = FLAG_POINTTOPOINT | FLAG_NO_SETINT | FLAG_MULTI_PACKET
+-			| FLAG_WWAN,
++			| FLAG_LINK_INTR | FLAG_WWAN,
+ 	.bind = cdc_ncm_bind,
+ 	.unbind = cdc_ncm_unbind,
+ 	.manage_power = usbnet_manage_power,
+@@ -1580,7 +1570,7 @@
+ static const struct driver_info wwan_noarp_info = {
+ 	.description = "Mobile Broadband Network Device (NO ARP)",
+ 	.flags = FLAG_POINTTOPOINT | FLAG_NO_SETINT | FLAG_MULTI_PACKET
+-			| FLAG_WWAN | FLAG_NOARP,
++			| FLAG_LINK_INTR | FLAG_WWAN | FLAG_NOARP,
+ 	.bind = cdc_ncm_bind,
+ 	.unbind = cdc_ncm_unbind,
+ 	.manage_power = usbnet_manage_power,

--- a/recipes-kernel/linux/4.4/patches/cve-2016-4482-usbfs-fix-potential-infoleak-in-devio.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-4482-usbfs-fix-potential-infoleak-in-devio.patch
@@ -1,0 +1,38 @@
+From 681fef8380eb818c0b845fca5d2ab1dcbab114ee Mon Sep 17 00:00:00 2001
+From: Kangjie Lu <kangjielu@gmail.com>
+Date: Tue, 3 May 2016 16:32:16 -0400
+Subject: [PATCH] USB: usbfs: fix potential infoleak in devio
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The stack object “ci” has a total size of 8 bytes. Its last 3 bytes
+are padding bytes which are not initialized and leaked to userland
+via “copy_to_user”.
+
+Signed-off-by: Kangjie Lu <kjlu@gatech.edu>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/core/devio.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+Index: linux-4.4.15/drivers/usb/core/devio.c
+===================================================================
+--- linux-4.4.15.orig/drivers/usb/core/devio.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/drivers/usb/core/devio.c	2016-07-25 18:23:04.324869457 +0200
+@@ -1203,10 +1203,11 @@
+ 
+ static int proc_connectinfo(struct usb_dev_state *ps, void __user *arg)
+ {
+-	struct usbdevfs_connectinfo ci = {
+-		.devnum = ps->dev->devnum,
+-		.slow = ps->dev->speed == USB_SPEED_LOW
+-	};
++	struct usbdevfs_connectinfo ci;
++
++	memset(&ci, 0, sizeof(ci));
++	ci.devnum = ps->dev->devnum;
++	ci.slow = ps->dev->speed == USB_SPEED_LOW;
+ 
+ 	if (copy_to_user(arg, &ci, sizeof(ci)))
+ 		return -EFAULT;

--- a/recipes-kernel/linux/4.4/patches/cve-2016-4568-media-videobuf2-v4l2-Verify-planes-array-in-buffer-d.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-4568-media-videobuf2-v4l2-Verify-planes-array-in-buffer-d.patch
@@ -1,0 +1,53 @@
+From 2c1f6951a8a82e6de0d82b1158b5e493fc6c54ab Mon Sep 17 00:00:00 2001
+From: Sakari Ailus <sakari.ailus@linux.intel.com>
+Date: Sun, 3 Apr 2016 16:31:03 -0300
+Subject: [PATCH] [media] videobuf2-v4l2: Verify planes array in buffer
+ dequeueing
+
+When a buffer is being dequeued using VIDIOC_DQBUF IOCTL, the exact buffer
+which will be dequeued is not known until the buffer has been removed from
+the queue. The number of planes is specific to a buffer, not to the queue.
+
+This does lead to the situation where multi-plane buffers may be requested
+and queued with n planes, but VIDIOC_DQBUF IOCTL may be passed an argument
+struct with fewer planes.
+
+__fill_v4l2_buffer() however uses the number of planes from the dequeued
+videobuf2 buffer, overwriting kernel memory (the m.planes array allocated
+in video_usercopy() in v4l2-ioctl.c)  if the user provided fewer
+planes than the dequeued buffer had. Oops!
+
+Fixes: b0e0e1f83de3 ("[media] media: videobuf2: Prepare to divide videobuf2")
+
+Signed-off-by: Sakari Ailus <sakari.ailus@linux.intel.com>
+Acked-by: Hans Verkuil <hans.verkuil@cisco.com>
+Cc: stable@vger.kernel.org # for v4.4 and later
+Signed-off-by: Mauro Carvalho Chehab <mchehab@osg.samsung.com>
+---
+ drivers/media/v4l2-core/videobuf2-v4l2.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+Index: linux-4.4.15/drivers/media/v4l2-core/videobuf2-v4l2.c
+===================================================================
+--- linux-4.4.15.orig/drivers/media/v4l2-core/videobuf2-v4l2.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/drivers/media/v4l2-core/videobuf2-v4l2.c	2016-07-25 18:25:42.272726777 +0200
+@@ -67,6 +67,11 @@
+ 	return 0;
+ }
+ 
++static int __verify_planes_array_core(struct vb2_buffer *vb, const void *pb)
++{
++	return __verify_planes_array(vb, pb);
++}
++
+ /**
+  * __verify_length() - Verify that the bytesused value for each plane fits in
+  * the plane length and that the data offset doesn't exceed the bytesused value.
+@@ -432,6 +437,7 @@
+ }
+ 
+ static const struct vb2_buf_ops v4l2_buf_ops = {
++	.verify_planes_array	= __verify_planes_array_core,
+ 	.fill_user_buffer	= __fill_v4l2_buffer,
+ 	.fill_vb2_buffer	= __fill_vb2_buffer,
+ 	.set_timestamp		= __set_timestamp,

--- a/recipes-kernel/linux/4.4/patches/cve-2016-4569-ALSA-timer-Fix-leak-in-SNDRV_TIMER_IOCTL_PARAMS.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-4569-ALSA-timer-Fix-leak-in-SNDRV_TIMER_IOCTL_PARAMS.patch
@@ -1,0 +1,30 @@
+From cec8f96e49d9be372fdb0c3836dcf31ec71e457e Mon Sep 17 00:00:00 2001
+From: Kangjie Lu <kangjielu@gmail.com>
+Date: Tue, 3 May 2016 16:44:07 -0400
+Subject: [PATCH] ALSA: timer: Fix leak in SNDRV_TIMER_IOCTL_PARAMS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The stack object “tread” has a total size of 32 bytes. Its field
+“event” and “val” both contain 4 bytes padding. These 8 bytes
+padding bytes are sent to user without being initialized.
+
+Signed-off-by: Kangjie Lu <kjlu@gatech.edu>
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/core/timer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+Index: linux-4.4.15/sound/core/timer.c
+===================================================================
+--- linux-4.4.15.orig/sound/core/timer.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/sound/core/timer.c	2016-07-25 18:26:46.485199489 +0200
+@@ -1746,6 +1746,7 @@
+ 	if (tu->timeri->flags & SNDRV_TIMER_IFLG_EARLY_EVENT) {
+ 		if (tu->tread) {
+ 			struct snd_timer_tread tread;
++			memset(&tread, 0, sizeof(tread));
+ 			tread.event = SNDRV_TIMER_EVENT_EARLY;
+ 			tread.tstamp.tv_sec = 0;
+ 			tread.tstamp.tv_nsec = 0;

--- a/recipes-kernel/linux/4.4/patches/cve-2016-4578-1-ALSA-timer-Fix-leak-in-events-via-snd_timer_user_cca.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-4578-1-ALSA-timer-Fix-leak-in-events-via-snd_timer_user_cca.patch
@@ -1,0 +1,31 @@
+From 9a47e9cff994f37f7f0dbd9ae23740d0f64f9fe6 Mon Sep 17 00:00:00 2001
+From: Kangjie Lu <kangjielu@gmail.com>
+Date: Tue, 3 May 2016 16:44:20 -0400
+Subject: [PATCH 10/11] ALSA: timer: Fix leak in events via
+ snd_timer_user_ccallback
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The stack object “r1” has a total size of 32 bytes. Its field
+“event” and “val” both contain 4 bytes padding. These 8 bytes
+padding bytes are sent to user without being initialized.
+
+Signed-off-by: Kangjie Lu <kjlu@gatech.edu>
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/core/timer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+Index: linux-4.4.15/sound/core/timer.c
+===================================================================
+--- linux-4.4.15.orig/sound/core/timer.c	2016-07-25 18:26:46.485199489 +0200
++++ linux-4.4.15/sound/core/timer.c	2016-07-25 18:28:33.877093297 +0200
+@@ -1247,6 +1247,7 @@
+ 		tu->tstamp = *tstamp;
+ 	if ((tu->filter & (1 << event)) == 0 || !tu->tread)
+ 		return;
++	memset(&r1, 0, sizeof(r1));
+ 	r1.event = event;
+ 	r1.tstamp = *tstamp;
+ 	r1.val = resolution;

--- a/recipes-kernel/linux/4.4/patches/cve-2016-4578-2-ALSA-timer-Fix-leak-in-events-via-snd_timer_user_tin.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-4578-2-ALSA-timer-Fix-leak-in-events-via-snd_timer_user_tin.patch
@@ -1,0 +1,31 @@
+From e4ec8cc8039a7063e24204299b462bd1383184a5 Mon Sep 17 00:00:00 2001
+From: Kangjie Lu <kangjielu@gmail.com>
+Date: Tue, 3 May 2016 16:44:32 -0400
+Subject: [PATCH 11/11] ALSA: timer: Fix leak in events via
+ snd_timer_user_tinterrupt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The stack object “r1” has a total size of 32 bytes. Its field
+“event” and “val” both contain 4 bytes padding. These 8 bytes
+padding bytes are sent to user without being initialized.
+
+Signed-off-by: Kangjie Lu <kjlu@gatech.edu>
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/core/timer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+Index: linux-4.4.15/sound/core/timer.c
+===================================================================
+--- linux-4.4.15.orig/sound/core/timer.c	2016-07-25 18:28:33.877093297 +0200
++++ linux-4.4.15/sound/core/timer.c	2016-07-25 18:28:54.606815401 +0200
+@@ -1282,6 +1282,7 @@
+ 	}
+ 	if ((tu->filter & (1 << SNDRV_TIMER_EVENT_RESOLUTION)) &&
+ 	    tu->last_resolution != resolution) {
++		memset(&r1, 0, sizeof(r1));
+ 		r1.event = SNDRV_TIMER_EVENT_RESOLUTION;
+ 		r1.tstamp = tstamp;
+ 		r1.val = resolution;

--- a/recipes-kernel/linux/4.4/patches/cve-2016-5244-rds-fix-an-infoleak-in-rds_inc_info_copy.patch
+++ b/recipes-kernel/linux/4.4/patches/cve-2016-5244-rds-fix-an-infoleak-in-rds_inc_info_copy.patch
@@ -1,0 +1,28 @@
+From 4116def2337991b39919f3b448326e21c40e0dbb Mon Sep 17 00:00:00 2001
+From: Kangjie Lu <kangjielu@gmail.com>
+Date: Thu, 2 Jun 2016 04:11:20 -0400
+Subject: [PATCH] rds: fix an infoleak in rds_inc_info_copy
+
+The last field "flags" of object "minfo" is not initialized.
+Copying this object out may leak kernel stack data.
+Assign 0 to it to avoid leak.
+
+Signed-off-by: Kangjie Lu <kjlu@gatech.edu>
+Acked-by: Santosh Shilimkar <santosh.shilimkar@oracle.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/rds/recv.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+Index: linux-4.4.15/net/rds/recv.c
+===================================================================
+--- linux-4.4.15.orig/net/rds/recv.c	2016-07-11 18:31:24.000000000 +0200
++++ linux-4.4.15/net/rds/recv.c	2016-07-25 18:29:35.169604939 +0200
+@@ -545,5 +545,7 @@
+ 		minfo.fport = inc->i_hdr.h_dport;
+ 	}
+ 
++	minfo.flags = 0;
++
+ 	rds_info_copy(iter, &minfo, sizeof(minfo));
+ }

--- a/recipes-kernel/linux/4.4/patches/extra-mt-input-devices.patch
+++ b/recipes-kernel/linux/4.4/patches/extra-mt-input-devices.patch
@@ -34,10 +34,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.4.10/drivers/hid/hid-ids.h
+Index: linux-4.4.16/drivers/hid/hid-ids.h
 ===================================================================
---- linux-4.4.10.orig/drivers/hid/hid-ids.h	2016-05-11 11:23:26.000000000 +0200
-+++ linux-4.4.10/drivers/hid/hid-ids.h	2016-05-12 12:12:28.235060253 +0200
+--- linux-4.4.16.orig/drivers/hid/hid-ids.h	2016-07-29 16:15:44.855144379 +0200
++++ linux-4.4.16/drivers/hid/hid-ids.h	2016-07-29 16:15:46.918449344 +0200
 @@ -948,6 +948,7 @@
  #define USB_VENDOR_ID_TURBOX		0x062a
  #define USB_DEVICE_ID_TURBOX_KEYBOARD	0x0201
@@ -46,11 +46,11 @@ Index: linux-4.4.10/drivers/hid/hid-ids.h
  
  #define USB_VENDOR_ID_TWINHAN		0x6253
  #define USB_DEVICE_ID_TWINHAN_IR_REMOTE	0x0100
-Index: linux-4.4.10/drivers/hid/hid-multitouch.c
+Index: linux-4.4.16/drivers/hid/hid-multitouch.c
 ===================================================================
---- linux-4.4.10.orig/drivers/hid/hid-multitouch.c	2016-05-11 11:23:26.000000000 +0200
-+++ linux-4.4.10/drivers/hid/hid-multitouch.c	2016-05-12 12:12:28.235060253 +0200
-@@ -1356,6 +1356,9 @@
+--- linux-4.4.16.orig/drivers/hid/hid-multitouch.c	2016-07-29 16:15:44.855144379 +0200
++++ linux-4.4.16/drivers/hid/hid-multitouch.c	2016-07-29 16:15:46.918449344 +0200
+@@ -1368,6 +1368,9 @@
  	{ .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
  		MT_USB_DEVICE(USB_VENDOR_ID_TURBOX,
  			USB_DEVICE_ID_TURBOX_TOUCHSCREEN_MOSART) },


### PR DESCRIPTION
Address CVEs reported in 2016, but not upstream yet:
- CVE-2016-0758
- CVE-2016-3135
- CVE-2016-3672
- CVE-2016-3951
- CVE-2016-4482
- CVE-2016-4568
- CVE-2016-4569
- CVE-2016-4578
- CVE-2016-5244

OXT-697

(cherry picked from commit fd976eca603395c914dcf879dbc6b491106191bb)
