### PR TITLE
Stable 6: OXT-688 : xen v4v: fix missing put_page in v4v_find_ring_mfns

### DIFF
--- a/recipes-extended/xen/files/xc-xt-v4v.patch
+++ b/recipes-extended/xen/files/xc-xt-v4v.patch
@@ -135,10 +135,10 @@ index e22a41b..7ad5db0 100644
      int port;
 diff --git xen-4.3.4.orig/xen/common/v4v.c xen-4.3.4/xen/common/v4v.c
 new file mode 100644
-index 0000000..1549ac6
+index 0000000..aaa8cba
 --- /dev/null
 +++ xen-4.3.4/xen/common/v4v.c
-@@ -0,0 +1,1976 @@
+@@ -0,0 +1,1977 @@
 +/******************************************************************************
 + * v4v.c
 + * 
@@ -1202,6 +1202,7 @@ index 0000000..1549ac6
 +          printk(KERN_ERR "v4v domain %d passed wrong type mfn %"PRI_mfn" ring %p seq %d\n",
 +          d->domain_id, mfn, ring_info, i);
 +          ret = -EINVAL;
++          put_page(page);
 +          break;
 +        }
 +      mfns[i] = _mfn(mfn);


### PR DESCRIPTION
Fixes edge case error handling where page type is incorrect.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>