### PR TITLE
ocaml: backport crash fix

### DIFF
--- a/recipes-devtools/ocaml/ocaml-cross/finaliser-on-weak-array-gives-dangling-pointers.patch
+++ b/recipes-devtools/ocaml/ocaml-cross/finaliser-on-weak-array-gives-dangling-pointers.patch
@@ -1,0 +1,37 @@
+commit fe137eedb508d4acaad6a0be4dbb2ec8e432af5d
+Author: Damien Doligez <damien.doligez-inria.fr>
+Date:   Thu Jun 21 14:30:11 2012 +0000
+
+    PR#5233: finaliser on weak array gives dangling pointers (crash)
+    
+    git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@12627 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02
+
+diff --git a/byterun/major_gc.c b/byterun/major_gc.c
+index aeb192f..1d290a5 100644
+--- a/byterun/major_gc.c
++++ b/byterun/major_gc.c
+@@ -233,7 +233,11 @@ static void mark_slice (intnat work)
+           weak_prev = &Field (cur, 0);
+           work -= Whsize_hd (hd);
+         }else{
+-          /* Subphase_weak1 is done.  Start removing dead weak arrays. */
++          /* Subphase_weak1 is done.
++             Handle finalised values and start removing dead weak arrays. */
++          gray_vals_cur = gray_vals_ptr;
++          caml_final_update ();
++          gray_vals_ptr = gray_vals_cur;
+           caml_gc_subphase = Subphase_weak2;
+           weak_prev = &caml_weak_list_head;
+         }
+@@ -254,10 +258,7 @@ static void mark_slice (intnat work)
+           }
+           work -= 1;
+         }else{
+-          /* Subphase_weak2 is done.  Handle finalised values. */
+-          gray_vals_cur = gray_vals_ptr;
+-          caml_final_update ();
+-          gray_vals_ptr = gray_vals_cur;
++          /* Subphase_weak2 is done.  Go to Subphase_final. */
+           caml_gc_subphase = Subphase_final;
+         }
+       }

--- a/recipes-devtools/ocaml/ocaml-cross_git.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_git.bb
@@ -11,6 +11,7 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/ocaml.git;protocol=${OPENXT_GIT_PROTOCOL};
            file://0007-Fix-ocamlopt-w.r.t.-binutils-2.21.patch;patch=1 \
 	   file://config.patch \
            file://remove-absolute-linker-path-from-lib.patch \
+           file://finaliser-on-weak-array-gives-dangling-pointers.patch \
 "
 
 inherit xenclient


### PR DESCRIPTION
This backport seems to fix random dbd crashes that have been observed on machines with very fast disks (NVMe).

Signed-off-by: Jed <lejosnej@ainfosec.com>