### PR TITLE
XSA 183, 185 and 187

### DIFF
--- a/recipes-extended/xen/files/xsa-183-x86-missing-smap-whitelisting-in-32-bit-exception-event-delivery.patch
+++ b/recipes-extended/xen/files/xsa-183-x86-missing-smap-whitelisting-in-32-bit-exception-event-delivery.patch
@@ -1,0 +1,67 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-183 (http://xenbits.xen.org/xsa/advisory-183.html)
+Missing SMAP whitelisting in 32-bit exception / event delivery.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-183.html
+Patches: xsa183-4.6.patch
+
+Supervisor Mode Access Prevention is a hardware feature designed to make an
+Operating System more robust, by raising a pagefault rather than accidentally
+following a pointer into userspace.  However, legitimate accesses into
+userspace require whitelisting, and the exception delivery mechanism for 32bit
+PV guests wasn't whitelisted.
+
+CVE-2016-6259
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.6.1/xen/arch/x86/x86_64/compat/entry.S
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/x86_64/compat/entry.S	2016-08-31 16:33:27.238877183 +0200
++++ xen-4.6.1/xen/arch/x86/x86_64/compat/entry.S	2016-08-31 16:38:57.585698435 +0200
+@@ -280,6 +280,7 @@
+ compat_create_bounce_frame:
+         ASSERT_INTERRUPTS_ENABLED
+         mov   %fs,%edi
++        ASM_STAC
+         testb $2,UREGS_cs+8(%rsp)
+         jz    1f
+         /* Push new frame at registered guest-OS stack base. */
+@@ -333,6 +334,7 @@
+         movl  %ds,%eax
+ .Lft12: movl  %eax,%fs:0*4(%rsi)        # DS
+ UNLIKELY_END(compat_bounce_failsafe)
++        ASM_CLAC
+         /* Rewrite our stack frame and return to guest-OS mode. */
+         /* IA32 Ref. Vol. 3: TF, VM, RF and NT flags are cleared on trap. */
+         andl  $~(X86_EFLAGS_VM|X86_EFLAGS_RF|\
+@@ -378,6 +380,7 @@
+         addl  $4,%esi
+ compat_crash_page_fault:
+ .Lft14: mov   %edi,%fs
++        ASM_CLAC
+         movl  %esi,%edi
+         call  show_page_walk
+         jmp   dom_crash_sync_extable
+Index: xen-4.6.1/xen/arch/x86/x86_64/entry.S
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/x86_64/entry.S	2016-08-31 16:33:27.262210292 +0200
++++ xen-4.6.1/xen/arch/x86/x86_64/entry.S	2016-08-31 16:38:57.682364172 +0200
+@@ -462,9 +462,11 @@
+ domain_crash_page_fault_8:
+         addq  $8,%rsi
+ domain_crash_page_fault:
++        ASM_CLAC
+         movq  %rsi,%rdi
+         call  show_page_walk
+ ENTRY(dom_crash_sync_extable)
++        ASM_CLAC
+         # Get out of the guest-save area of the stack.
+         GET_STACK_BASE(%rax)
+         leaq  STACK_CPUINFO_FIELD(guest_cpu_user_regs)(%rax),%rsp

--- a/recipes-extended/xen/files/xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch
+++ b/recipes-extended/xen/files/xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch
@@ -1,0 +1,42 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-185 (http://xenbits.xen.org/xsa/advisory-185.html)
+Disallow L3 recursive pagetable for 32-bit PV guests.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-185.html
+Patches: xsa185.patch
+
+On real hardware, a 32-bit PAE guest must leave the USER and RW bit clear in L3
+pagetable entries, but the pagetable walk behaves as if they were set.  (The L3
+entries are cached in processor registers, and don't actually form part of the
+pagewalk.)
+
+When running a 32-bit PV guest on a 64-bit Xen, Xen must always OR in the USER
+and RW bits for L3 updates for the guest to observe architectural behaviour.
+This is unsafe in combination with recursive pagetables.
+
+As there is no way to construct an L3 recursive pagetable in native 32-bit PAE
+mode, disallow this option in 32-bit PV guests.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.6.1/xen/arch/x86/mm.c
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/mm.c	2016-08-31 17:03:50.981169869 +0200
++++ xen-4.6.1/xen/arch/x86/mm.c	2016-08-31 17:03:53.351146744 +0200
+@@ -1043,7 +1043,9 @@
+ 
+     rc = get_page_and_type_from_pagenr(
+         l3e_get_pfn(l3e), PGT_l2_page_table, d, partial, 1);
+-    if ( unlikely(rc == -EINVAL) && get_l3_linear_pagetable(l3e, pfn, d) )
++    if ( unlikely(rc == -EINVAL) &&
++         !is_pv_32bit_domain(d) &&
++         get_l3_linear_pagetable(l3e, pfn, d) )
+         rc = 0;
+ 
+     return rc;

--- a/recipes-extended/xen/files/xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch
+++ b/recipes-extended/xen/files/xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch
@@ -1,0 +1,184 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-187 (http://xenbits.xen.org/xsa/advisory-187.html)
+HVM Overflow of sh_ctxt->seg_reg[].
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-187.html
+Patches: xsa187-0001-x86-shadow-Avoid-overflowing-sh_ctxt-seg_reg.patch
+	 xsa187-4.6-0002-x86-segment-Bounds-check-accesses-to-emulation-ctx.patch
+
+x86 HVM guests running with shadow paging use a subset of the x86 emulator to
+handle the guest writing to its own pagetables.  There are situations a guest
+can provoke which result in exceeding the space allocated for internal state.
+
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.6.1/xen/arch/x86/mm/shadow/common.c
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/mm/shadow/common.c	2016-08-31 17:28:32.384130639 +0200
++++ xen-4.6.1/xen/arch/x86/mm/shadow/common.c	2016-08-31 17:31:10.766004139 +0200
+@@ -125,10 +125,19 @@
+ /* x86 emulator support for the shadow code
+  */
+ 
+-struct segment_register *hvm_get_seg_reg(
++/*
++ * Callers which pass a known in-range x86_segment can rely on the return
++ * pointer being valid.  Other callers must explicitly check for errors.
++ */
++static struct segment_register *hvm_get_seg_reg(
+     enum x86_segment seg, struct sh_emulate_ctxt *sh_ctxt)
+ {
+-    struct segment_register *seg_reg = &sh_ctxt->seg_reg[seg];
++    struct segment_register *seg_reg;
++
++    if ( seg < 0 || seg >= ARRAY_SIZE(sh_ctxt->seg_reg) )
++        return ERR_PTR(-X86EMUL_UNHANDLEABLE);
++
++    seg_reg = &sh_ctxt->seg_reg[seg];
+     if ( !__test_and_set_bit(seg, &sh_ctxt->valid_seg_regs) )
+         hvm_get_segment_register(current, seg, seg_reg);
+     return seg_reg;
+@@ -142,9 +151,13 @@
+     struct sh_emulate_ctxt *sh_ctxt,
+     unsigned long *paddr)
+ {
+-    struct segment_register *reg = hvm_get_seg_reg(seg, sh_ctxt);
++    const struct segment_register *reg;
+     int okay;
+ 
++    reg = hvm_get_seg_reg(seg, sh_ctxt);
++    if ( IS_ERR(reg) )
++        return -PTR_ERR(reg);
++
+     okay = hvm_virtual_to_linear_addr(
+         seg, reg, offset, bytes, access_type, sh_ctxt->ctxt.addr_size, paddr);
+ 
+@@ -245,9 +258,6 @@
+     unsigned long addr;
+     int rc;
+ 
+-    if ( !is_x86_user_segment(seg) )
+-        return X86EMUL_UNHANDLEABLE;
+-
+     /* How many emulations could we save if we unshadowed on stack writes? */
+     if ( seg == x86_seg_ss )
+         perfc_incr(shadow_fault_emulate_stack);
+@@ -275,9 +285,6 @@
+     unsigned long addr, old[2], new[2];
+     int rc;
+ 
+-    if ( !is_x86_user_segment(seg) )
+-        return X86EMUL_UNHANDLEABLE;
+-
+     rc = hvm_translate_linear_addr(
+         seg, offset, bytes, hvm_access_write, sh_ctxt, &addr);
+     if ( rc )
+Index: xen-4.6.1/xen/arch/x86/hvm/emulate.c
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/hvm/emulate.c	2016-08-31 17:30:58.746114983 +0200
++++ xen-4.6.1/xen/arch/x86/hvm/emulate.c	2016-08-31 17:31:10.612672219 +0200
+@@ -517,6 +517,8 @@
+                            ? 1 : 4096);
+ 
+     reg = hvmemul_get_seg_reg(seg, hvmemul_ctxt);
++    if ( IS_ERR(reg) )
++        return -PTR_ERR(reg);
+ 
+     if ( (hvmemul_ctxt->ctxt.regs->eflags & X86_EFLAGS_DF) && (*reps > 1) )
+     {
+@@ -1347,6 +1349,10 @@
+     struct hvm_emulate_ctxt *hvmemul_ctxt =
+         container_of(ctxt, struct hvm_emulate_ctxt, ctxt);
+     struct segment_register *sreg = hvmemul_get_seg_reg(seg, hvmemul_ctxt);
++
++    if ( IS_ERR(sreg) )
++         return -PTR_ERR(sreg);
++
+     memcpy(reg, sreg, sizeof(struct segment_register));
+     return X86EMUL_OKAY;
+ }
+@@ -1360,6 +1366,9 @@
+         container_of(ctxt, struct hvm_emulate_ctxt, ctxt);
+     struct segment_register *sreg = hvmemul_get_seg_reg(seg, hvmemul_ctxt);
+ 
++    if ( IS_ERR(sreg) )
++         return -PTR_ERR(sreg);
++
+     memcpy(sreg, reg, sizeof(struct segment_register));
+     __set_bit(seg, &hvmemul_ctxt->seg_reg_dirty);
+ 
+@@ -1852,10 +1861,17 @@
+     }
+ }
+ 
++/*
++ * Callers which pass a known in-range x86_segment can rely on the return
++ * pointer being valid.  Other callers must explicitly check for errors.
++ */
+ struct segment_register *hvmemul_get_seg_reg(
+     enum x86_segment seg,
+     struct hvm_emulate_ctxt *hvmemul_ctxt)
+ {
++    if ( seg < 0 || seg >= ARRAY_SIZE(hvmemul_ctxt->seg_reg) )
++        return ERR_PTR(-X86EMUL_UNHANDLEABLE);
++
+     if ( !__test_and_set_bit(seg, &hvmemul_ctxt->seg_reg_accessed) )
+         hvm_get_segment_register(current, seg, &hvmemul_ctxt->seg_reg[seg]);
+     return &hvmemul_ctxt->seg_reg[seg];
+Index: xen-4.6.1/xen/arch/x86/hvm/hvm.c
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/hvm/hvm.c	2016-08-31 17:30:56.899465345 +0200
++++ xen-4.6.1/xen/arch/x86/hvm/hvm.c	2016-08-31 17:31:16.225953785 +0200
+@@ -3583,7 +3583,7 @@
+ 
+ int hvm_virtual_to_linear_addr(
+     enum x86_segment seg,
+-    struct segment_register *reg,
++    const struct segment_register *reg,
+     unsigned long offset,
+     unsigned int bytes,
+     enum hvm_access_type access_type,
+Index: xen-4.6.1/xen/arch/x86/mm/shadow/private.h
+===================================================================
+--- xen-4.6.1.orig/xen/arch/x86/mm/shadow/private.h	2016-08-31 17:30:58.712781957 +0200
++++ xen-4.6.1/xen/arch/x86/mm/shadow/private.h	2016-08-31 17:31:10.872669821 +0200
+@@ -731,8 +731,6 @@
+     struct sh_emulate_ctxt *sh_ctxt, struct cpu_user_regs *regs);
+ void shadow_continue_emulation(
+     struct sh_emulate_ctxt *sh_ctxt, struct cpu_user_regs *regs);
+-struct segment_register *hvm_get_seg_reg(
+-    enum x86_segment seg, struct sh_emulate_ctxt *sh_ctxt);
+ 
+ #if (SHADOW_OPTIMIZATIONS & SHOPT_VIRTUAL_TLB)
+ /**************************************************************************/
+Index: xen-4.6.1/xen/include/asm-x86/hvm/emulate.h
+===================================================================
+--- xen-4.6.1.orig/xen/include/asm-x86/hvm/emulate.h	2016-08-31 17:30:58.762781496 +0200
++++ xen-4.6.1/xen/include/asm-x86/hvm/emulate.h	2016-08-31 17:31:10.939335874 +0200
+@@ -13,6 +13,7 @@
+ #define __ASM_X86_HVM_EMULATE_H__
+ 
+ #include <xen/config.h>
++#include <xen/err.h>
+ #include <asm/hvm/hvm.h>
+ #include <asm/x86_emulate.h>
+ 
+Index: xen-4.6.1/xen/include/asm-x86/hvm/hvm.h
+===================================================================
+--- xen-4.6.1.orig/xen/include/asm-x86/hvm/hvm.h	2016-08-31 17:30:56.916131858 +0200
++++ xen-4.6.1/xen/include/asm-x86/hvm/hvm.h	2016-08-31 17:31:16.372619099 +0200
+@@ -436,7 +436,7 @@
+ };
+ int hvm_virtual_to_linear_addr(
+     enum x86_segment seg,
+-    struct segment_register *reg,
++    const struct segment_register *reg,
+     unsigned long offset,
+     unsigned int bytes,
+     enum hvm_access_type access_type,

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -57,6 +57,9 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://openxt-xen-xsmv4vuse.patch \
     file://xsa-154-x86-inconsistent-cachability-flags-on-guest-mappings.patch \
     file://xsa-182-x86-privilege-escalation-in-pv-guests.patch \
+    file://xsa-183-x86-missing-smap-whitelisting-in-32-bit-exception-event-delivery.patch \
+    file://xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch \
+    file://xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"


### PR DESCRIPTION
XSA-184 is not in the scope of OpenXT (https://xenbits.xen.org/xsa/advisory-184.html).
XSA-186 does not affect Xen 4.6.1 (https://xenbits.xen.org/xsa/advisory-186.html)

OXT-742