### PR TITLE
STABLE-6: Xen XSA-185 and 187.

### DIFF
--- a/recipes-extended/xen/files/xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch
+++ b/recipes-extended/xen/files/xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch
@@ -1,0 +1,43 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-185 (http://xenbits.xen.org/xsa/advisory-185.html)
+Disallow L3 recursive pagetable for 32-bit PV guests.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-185.html
+Patches: xsa185.patch
+
+On real hardware, a 32-bit PAE guest must leave the USER and RW bit clear in L3
+pagetable entries, but the pagetable walk behaves as if they were set.  (The L3
+entries are cached in processor registers, and don't actually form part
+of the pagewalk.)
+
+When running a 32-bit PV guest on a 64-bit Xen, Xen must always OR in the USER
+and RW bits for L3 updates for the guest to observe architectural behaviour.
+This is unsafe in combination with recursive pagetables.
+
+As there is no way to construct an L3 recursive pagetable in native 32-bit PAE
+mode, disallow this option in 32-bit PV guests.
+
+################################################################################
+PATCHES 
+################################################################################
+
+Index: xen-4.3.4/xen/arch/x86/mm.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/mm.c	2016-08-26 15:52:49.862633320 +0200
++++ xen-4.3.4/xen/arch/x86/mm.c	2016-08-31 16:43:01.006691879 +0200
+@@ -1003,7 +1003,9 @@
+ 
+     rc = get_page_and_type_from_pagenr(
+         l3e_get_pfn(l3e), PGT_l2_page_table, d, partial, 1);
+-    if ( unlikely(rc == -EINVAL) && get_l3_linear_pagetable(l3e, pfn, d) )
++    if ( unlikely(rc == -EINVAL) &&
++         !is_pv_32bit_domain(d) &&
++         get_l3_linear_pagetable(l3e, pfn, d) )
+         rc = 0;
+ 
+     return rc;

--- a/recipes-extended/xen/files/xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch
+++ b/recipes-extended/xen/files/xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch
@@ -1,0 +1,70 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+XSA-187 (http://xenbits.xen.org/xsa/advisory-187.html)
+HVM Overflow of sh_ctxt->seg_reg[].
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-187.html
+Patches: xsa187-0001-x86-shadow-Avoid-overflowing-sh_ctxt-seg_reg.patch
+         xsa187-4.6-0002-x86-segment-Bounds-check-accesses-to-emulation-ctx.patch
+     
+x86 HVM guests running with shadow paging use a subset of the x86 emulator to
+handle the guest writing to its own pagetables.  There are situations a guest
+can provoke which result in exceeding the space allocated for internal state.
+     
+################################################################################
+PATCHES 
+################################################################################
+Index: xen-4.3.4/xen/arch/x86/mm/shadow/common.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/mm/shadow/common.c	2016-08-31 17:35:37.323531691 +0200
++++ xen-4.3.4/xen/arch/x86/mm/shadow/common.c	2016-08-31 17:35:37.530196436 +0200
+@@ -137,9 +137,18 @@
+     struct sh_emulate_ctxt *sh_ctxt,
+     unsigned long *paddr)
+ {
+-    struct segment_register *reg = hvm_get_seg_reg(seg, sh_ctxt);
++    const struct segment_register *reg;
+     int okay;
+ 
++    /*
++     * Can arrive here with non-user segments.  However, no such cirucmstance
++     * is part of a legitimate pagetable update, so fail the emulation.
++     */
++    if ( !is_x86_user_segment(seg) )
++        return X86EMUL_UNHANDLEABLE;
++
++    reg = hvm_get_seg_reg(seg, sh_ctxt);
++
+     okay = hvm_virtual_to_linear_addr(
+         seg, reg, offset, bytes, access_type, sh_ctxt->ctxt.addr_size, paddr);
+ 
+Index: xen-4.3.4/xen/arch/x86/hvm/hvm.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/hvm/hvm.c	2016-08-31 17:50:27.978569162 +0200
++++ xen-4.3.4/xen/arch/x86/hvm/hvm.c	2016-08-31 17:50:35.378500114 +0200
+@@ -1966,7 +1966,7 @@
+ 
+ int hvm_virtual_to_linear_addr(
+     enum x86_segment seg,
+-    struct segment_register *reg,
++    const struct segment_register *reg,
+     unsigned long offset,
+     unsigned int bytes,
+     enum hvm_access_type access_type,
+Index: xen-4.3.4/xen/include/asm-x86/hvm/hvm.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/asm-x86/hvm/hvm.h	2016-08-31 17:50:27.995235674 +0200
++++ xen-4.3.4/xen/include/asm-x86/hvm/hvm.h	2016-08-31 17:50:35.528498714 +0200
+@@ -441,7 +441,7 @@
+ };
+ int hvm_virtual_to_linear_addr(
+     enum x86_segment seg,
+-    struct segment_register *reg,
++    const struct segment_register *reg,
+     unsigned long offset,
+     unsigned int bytes,
+     enum hvm_access_type access_type,

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -125,6 +125,8 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://openxt-xen-xsmv4vuse.patch \
     file://xsa-154-x86-inconsistent-cachability-flags-on-guest-mappings.patch \
     file://xsa-182-x86-privilege-escalation-in-pv-guests.patch \
+    file://xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch \
+    file://xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"


### PR DESCRIPTION
XSA-183 does not affect Xen 4.3.4 (https://xenbits.xen.org/xsa/advisory-183.html)
XSA-184 is not in the scope of OpenXT (https://xenbits.xen.org/xsa/advisory-184.html).
XSA-186 does not affect Xen 4.3.4 (https://xenbits.xen.org/xsa/advisory-186.html)

OXT-742
