### PR TITLE
refpolicy: fix OTA-related denials

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/updatemgr.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/updatemgr.te
@@ -82,3 +82,4 @@ allow updatemgr_t updatemgr_sync_client_storage_t:file manage_file_perms;
 allow updatemgr_t updatemgr_tmp_t:file manage_file_perms;
 allow updatemgr_t self:capability { dac_override chown fowner fsetid };
 
+kernel_request_load_module(updatemgr_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/xc-installer.fc
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/xc-installer.fc
@@ -18,5 +18,5 @@
 #
 #############################################################################
 
-/storage/update/upgrade		--	gen_context(system_u:object_r:xc_installer_t,s0)
+/storage/update/upgrade		--	gen_context(system_u:object_r:xc_installer_storage_t,s0)
 /usr/share/xenclient/post-upgrade.sh	--	gen_context(system_u:object_r:xc_installer_exec_t,s0)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/xc-installer.if
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/xc-installer.if
@@ -48,6 +48,7 @@ interface(`xc_installer_domtrans',`
 	corecmd_search_bin($1)
 	domtrans_pattern($1, updatemgr_storage_t, xc_installer_t)
 	domtrans_pattern($1, xc_installer_exec_t, xc_installer_t)
+	allow $1 xc_installer_t:process { noatsecure siginh rlimitinh };
 ')
 ########################################
 ## <summary>
@@ -61,10 +62,11 @@ interface(`xc_installer_domtrans',`
 #
 interface(`xc_installer_delete',`
 	gen_require(`
-		type xc_installer_t;
+		type xc_installer_storage_t;
 	')
 
-	allow $1 xc_installer_t:file delete_file_perms;
+	allow $1 xc_installer_storage_t:dir manage_dir_perms;
+	allow $1 xc_installer_storage_t:file delete_file_perms;
 ')
 ########################################
 ## <summary>


### PR DESCRIPTION
Allow updatemgr to trigger module auto-load if needed.

Allow updatemgr to manage the /storage/update/upgrade-data directory;
this was supposed to already be allowed but the wrong type was used in
the xc-installer.if and xc-installer.fc files.

Allow updatemgr to convey environment variables, signal
masks, and resource limits to the installer across a domain transition.

OXT-734

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>