### PR TITLE
refpolicy: fix default label of /config/xenclient.conf

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/dbd.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/dbd.te
@@ -43,7 +43,7 @@ role system_r types db_upgrade_t;
 
 type db_backup_t;
 files_type(db_backup_t)
-xc_config_filetrans(db_upgrade_t, db_backup_t, { dir file })
+xc_config_filetrans(db_upgrade_t, db_backup_t, dir)
 
 ################################
 #


### PR DESCRIPTION
restorecon -Rnv /config reports one mislabeled file after a fresh
install:
  restorecon reset /config/xenclient.conf context system_u:object_r:db_backup_t:s0->system_u:object_r:xc_config_t:s0

/config/xenclient.conf is created by upgrade-db, which simply does a:
  cp /etc/xenclient.conf /config/xenclient.conf

However, the domain in which upgrade-db runs (db_upgrade_t)
has a file transition rule to label directories and files it
creates under /config with db_backup_t.  This rule is intended
for the /config/backups directory and its contents, but is also
applied when /config/xenclient.conf is created by upgrade-db.

Modify the rule to only apply to directory creation, since
once /config/backups is created in the right type, all files
created within it will also default to that type.  This leaves
files created directly in /config inheriting the type of /config.
We could also refine these to be name-based transitions if needed,
but that does not appear to be necessary here.

This will only fix the label on fresh installs; to address on prior
installs upon upgrade, we would need to add restorecon /config/xenclient.conf
to the firstboot.sh script or to the migration scripts.

OXT-783

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>