### PR TITLE
refpolicy: allow xenconsoled to increase fd limit

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
@@ -406,12 +406,12 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  tunable_policy(`xen_use_fusefs',`
  	fs_manage_fusefs_dirs(xend_t)
-@@ -360,12 +459,14 @@ optional_policy(`
+@@ -360,12 +457,14 @@ optional_policy(`
  # Xen console local policy
  #
  
 -allow xenconsoled_t self:capability { dac_override fsetid ipc_lock };
-+allow xenconsoled_t self:capability { dac_override fsetid ipc_lock sys_tty_config };
++allow xenconsoled_t self:capability { dac_override fsetid ipc_lock sys_tty_config sys_resource };
  allow xenconsoled_t self:process setrlimit;
  allow xenconsoled_t self:unix_stream_socket create_stream_socket_perms;
  allow xenconsoled_t self:fifo_file rw_fifo_file_perms;
@@ -422,7 +422,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_dirs_pattern(xenconsoled_t, xend_var_log_t, xend_var_log_t)
  append_files_pattern(xenconsoled_t, xend_var_log_t, xend_var_log_t)
-@@ -401,10 +502,12 @@ init_use_fds(xenconsoled_t)
+@@ -401,10 +500,12 @@ init_use_fds(xenconsoled_t)
  init_use_script_ptys(xenconsoled_t)
  
  logging_search_logs(xenconsoled_t)
@@ -435,7 +435,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  optional_policy(`
  	ptchown_domtrans(xenconsoled_t)
-@@ -416,7 +519,8 @@ optional_policy(`
+@@ -416,7 +517,8 @@ optional_policy(`
  #
  
  allow xenstored_t self:capability { dac_override ipc_lock sys_resource };
@@ -445,7 +445,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
  manage_dirs_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
-@@ -430,6 +534,7 @@ files_pid_filetrans(xenstored_t, xenstor
+@@ -430,6 +532,7 @@ files_pid_filetrans(xenstored_t, xenstor
  manage_dirs_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  append_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  create_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
@@ -453,7 +453,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  setattr_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  manage_sock_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  logging_log_filetrans(xenstored_t, xenstored_var_log_t, { sock_file file dir })
-@@ -447,6 +552,9 @@ kernel_read_xen_state(xenstored_t)
+@@ -447,6 +550,9 @@ kernel_read_xen_state(xenstored_t)
  dev_filetrans_xen(xenstored_t)
  dev_rw_xen(xenstored_t)
  dev_read_sysfs(xenstored_t)
@@ -463,7 +463,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  files_read_etc_files(xenstored_t)
  files_read_usr_files(xenstored_t)
-@@ -454,7 +562,12 @@ files_read_usr_files(xenstored_t)
+@@ -454,7 +560,12 @@ files_read_usr_files(xenstored_t)
  fs_search_xenfs(xenstored_t)
  fs_manage_xenfs_files(xenstored_t)
  
@@ -476,7 +476,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  init_use_fds(xenstored_t)
  init_use_script_ptys(xenstored_t)
-@@ -473,8 +586,8 @@ xen_append_log(xenstored_t)
+@@ -473,8 +584,8 @@ xen_append_log(xenstored_t)
  allow xm_t self:capability { setpcap dac_override ipc_lock sys_nice sys_tty_config };
  allow xm_t self:process { getcap getsched setsched setcap signal };
  allow xm_t self:fifo_file rw_fifo_file_perms;
@@ -487,7 +487,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
  manage_fifo_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
-@@ -544,6 +657,10 @@ miscfiles_read_localization(xm_t)
+@@ -544,6 +655,10 @@ miscfiles_read_localization(xm_t)
  
  sysnet_dns_name_resolve(xm_t)
  
@@ -498,7 +498,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  tunable_policy(`xen_use_fusefs',`
  	fs_manage_fusefs_dirs(xm_t)
  	fs_manage_fusefs_files(xm_t)
-@@ -601,4 +718,23 @@ optional_policy(`
+@@ -601,4 +716,23 @@ optional_policy(`
  
  	fs_manage_xenfs_dirs(xm_ssh_t)
  	fs_manage_xenfs_files(xm_ssh_t)


### PR DESCRIPTION
xenconsoled attempts to increase its fd limit, triggering the following
SELinux denial:
  avc:  denied  { sys_resource } for  pid=919 comm="xenconsoled" capability=24  scontext=system_u:system_r:xenconsoled_t:s0 tcontext=system_u:system_r:xenconsoled_t:s0 tclass=capability permissive=0
and the following log message from xenconsoled:
  xenconsoled: Unable to increase fd limit from {1024, 4096} to {132008, 132008}: (Operation not permitted) - May run out with lots of domains

Allow this capability for xenconsoled.

OXT-784

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>