### PR TITLE
refpolicy: move changes for OpenXT-added policy files to those files

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/xen4.6-uprev.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/xen4.6-uprev.patch
@@ -55,29 +55,3 @@ Index: refpolicy/policy/modules/kernel/devices.if
  ##      Unconfined readonly access to devices.
  ## </summary>
  ## <param name="domain">
-Index: refpolicy/policy/modules/services/network-daemon.te
-===================================================================
---- refpolicy.orig/policy/modules/services/network-daemon.te
-+++ refpolicy/policy/modules/services/network-daemon.te
-@@ -124,6 +124,8 @@ allow network_slave_t self:capability da
- kernel_read_xen_state(network_slave_t)
- kernel_write_xen_state(network_slave_t)
- fs_rw_xenfs_files(network_slave_t)
-+# xen 4.6 uses /dev/xen/xenbus
-+dev_rw_xen(network_slave_t)
- 
- sysnet_manage_config(network_slave_t)
- read_fifo_files_pattern(network_slave_t, network_slave_t, network_slave_t)
-Index: refpolicy/policy/modules/services/dbusbouncer.te
-===================================================================
---- refpolicy.orig/policy/modules/services/dbusbouncer.te
-+++ refpolicy/policy/modules/services/dbusbouncer.te
-@@ -48,6 +48,8 @@ vusbd_dbus_chat(dbusbouncer_t)
- updatemgr_dbus_chat(dbusbouncer_t)
- logging_send_syslog_msg(dbusbouncer_t)
- fs_rw_xenfs_files(dbusbouncer_t)
-+# xen 4.6 uses /dev/xen/xenbus
-+dev_rw_xen(dbusbouncer_t)
- 
- xc_files_rw_v4v_chr(dbusbouncer_t)
- 

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/dbusbouncer.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/dbusbouncer.te
@@ -48,6 +48,8 @@ vusbd_dbus_chat(dbusbouncer_t)
 updatemgr_dbus_chat(dbusbouncer_t)
 logging_send_syslog_msg(dbusbouncer_t)
 fs_rw_xenfs_files(dbusbouncer_t)
+# xen 4.6 uses /dev/xen/xenbus
+dev_rw_xen(dbusbouncer_t)
 
 xc_files_rw_v4v_chr(dbusbouncer_t)
 

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/network-daemon.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/network-daemon.te
@@ -124,6 +124,8 @@ allow network_slave_t self:capability dac_override;
 kernel_read_xen_state(network_slave_t)
 kernel_write_xen_state(network_slave_t)
 fs_rw_xenfs_files(network_slave_t)
+# xen 4.6 uses /dev/xen/xenbus
+dev_rw_xen(network_slave_t)
 
 sysnet_manage_config(network_slave_t)
 read_fifo_files_pattern(network_slave_t, network_slave_t, network_slave_t)


### PR DESCRIPTION
OpenXT-added policy files are managed directly rather than as patches.
Move the changes from xen4.6-uprev.patch for OpenXT-added policy files
to those files.

This should yield no change in the final policy.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>