### PR TITLE
Fix the battery op region PRT4 to use correct port 0x84

### DIFF
--- a/recipes-extended/xen/files/acpi-pm-feature.patch
+++ b/recipes-extended/xen/files/acpi-pm-feature.patch
@@ -79,7 +79,17 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
   *
   * This program is free software; you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by
-@@ -35,16 +36,41 @@
+@@ -15,7 +16,8 @@
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+- * along with this program; If not, see <http://www.gnu.org/licenses/>.
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  */
+ 
+ /*
+@@ -35,16 +37,41 @@
   *
   * Following are the battery ports read/written to in order to implement
   * battery support:
@@ -125,7 +135,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
   */
  
  DefinitionBlock ("SSDT_PM.aml", "SSDT", 2, "Xen", "HVM", 0)
-@@ -75,11 +101,10 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -75,11 +102,10 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              DBG4,   8,
          }
  
@@ -139,11 +149,11 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
          }
  
          OperationRegion (PRT2, SystemIO, 0x86, 0x01)
-@@ -94,6 +119,31 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -94,6 +120,31 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              P88,  8
          }
  
-+        OperationRegion (PRT4, SystemIO, 0x90, 0x01)
++        OperationRegion (PRT4, SystemIO, 0x84, 0x01)
 +        Field (PRT4, ByteAcc, NoLock, Preserve)
 +        {
 +            P84,  8
@@ -171,7 +181,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
  
          Mutex (SYNC, 0x01)
          Name (BUF0, Buffer (0x0100) {})
-@@ -124,30 +174,30 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -124,30 +175,30 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
          }
  
          /*
@@ -208,7 +218,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
           * Value 1 or 2 written to port 0x86.  1 for BIF (batterry info) and 2 
           * for BST (battery status).
           */
-@@ -161,7 +211,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -161,7 +212,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
          }
  
          /*
@@ -217,7 +227,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
           * indicating battery info initialization request.  First thing written
           * to battery port before querying for further information pertaining
           * to the battery.
-@@ -178,7 +228,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -178,7 +229,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
          }
  
          /*
@@ -226,7 +236,24 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
           * indicating request of battery data returned through battery data
           * port 0x86.
           */
-@@ -289,8 +339,114 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -275,13 +326,14 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+                 HLP8 (Arg0, Local0)
+                 Increment (Local0)
+             }
+-            Return (Arg0)
+         }
+ 
+         Method (HLPA, 0, NotSerialized)
+         {
+             Store (HLP6 (), Local0)
+-            Return (HLP9 (Buffer (Local0) {}, Local0))
++            Name (TMP, Buffer (Local0) {})
++            HLP9 (TMP, Local0)
++            Return (TMP)
+         }
+ 
+         Method (REL, 0, NotSerialized)
+@@ -289,8 +341,114 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              Release (SYNC)
          }
  
@@ -343,7 +370,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
          Device (AC)
          {
              Name (_HID, "ACPI0003")
-@@ -302,11 +458,23 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -302,11 +460,23 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              })
              Method (_PSR, 0, NotSerialized)
              {
@@ -367,7 +394,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
                  Return (0x0F)
              }
          }
-@@ -318,6 +486,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -318,6 +488,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              ACQR ()
              INIT (0x01)
              INIT (Arg0)
@@ -375,7 +402,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
              HLP5 ()
              Store (HLP7 (), Index (BIFP, 0x00))
              Store (HLP7 (), Index (BIFP, 0x01))
-@@ -336,7 +505,30 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -336,7 +507,30 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              Return (BIFP)
          }
  
@@ -407,7 +434,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
          Device (BAT0)
          {
              Name (_HID, EisaId ("PNP0C0A"))
-@@ -346,12 +538,22 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -346,12 +540,22 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
                  \_SB
              })
  
@@ -433,7 +460,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
  
              /* Battery generic info: design capacity, voltage, model # etc. */
              Method (_BIF, 0, NotSerialized)
-@@ -366,9 +568,11 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -366,22 +570,24 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              Method (_BST, 0, NotSerialized)
              {
                  Store (1, \_SB.DBG1)
@@ -443,9 +470,20 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
                  INIT (0x01)
 +                Store (0x01, PB5)
                  HLP5 ()
-                 Store (Package (0x04) {}, Local0)
-                 Store (HLP7 (), Index (Local0, 0x00))
-@@ -381,7 +585,7 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+-                Store (Package (0x04) {}, Local0)
+-                Store (HLP7 (), Index (Local0, 0x00))
+-                Store (HLP7 (), Index (Local0, 0x01))
+-                Store (HLP7 (), Index (Local0, 0x02))
+-                Store (HLP7 (), Index (Local0, 0x03))
++                Name (BST0, Package (0x04) {})
++                Store (HLP7 (), Index (BST0, 0x00))
++                Store (HLP7 (), Index (BST0, 0x01))
++                Store (HLP7 (), Index (BST0, 0x02))
++                Store (HLP7 (), Index (BST0, 0x03))
+                 REL ()
+                 Store (2, \_SB.DBG1)
+-                Return (Local0)
++                Return (BST0)
              }
          }
  
@@ -454,7 +492,7 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
          Device (BAT1)
          {
              Name (_HID, EisaId ("PNP0C0A"))
-@@ -392,20 +596,35 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+@@ -392,30 +598,86 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
              })
              Method (_STA, 0, NotSerialized)
              {
@@ -490,9 +528,19 @@ Index: xen-4.6.1/tools/firmware/hvmloader/acpi/ssdt_pm.asl
                  INIT (0x02)
 +                Store (0x02, PB5)
                  HLP5 ()
-                 Store (Package (0x04) {}, Local0)
-                 Store (HLP7 (), Index (Local0, 0x00))
-@@ -417,5 +636,46 @@ DefinitionBlock ("SSDT_PM.aml", "SSDT",
+-                Store (Package (0x04) {}, Local0)
+-                Store (HLP7 (), Index (Local0, 0x00))
+-                Store (HLP7 (), Index (Local0, 0x01))
+-                Store (HLP7 (), Index (Local0, 0x02))
+-                Store (HLP7 (), Index (Local0, 0x03))
++                Name (BST1, Package (0x04) {})
++                Store (HLP7 (), Index (BST1, 0x00))
++                Store (HLP7 (), Index (BST1, 0x01))
++                Store (HLP7 (), Index (BST1, 0x02))
++                Store (HLP7 (), Index (BST1, 0x03))
+                 REL ()
+-                Return (Local0)
++                Return (BST1)
              }
          }
      }


### PR DESCRIPTION
I also reverted a couple of other miscellaneous changes that were really not
needed. The presumably came from upstream. It is better to keep ssdt_pm.asl the
way it has been tested and working for years. Since this stuff got completely
removed the latest Xen it doesn't really matter.

OXT-793

Signed-off-by: Ross Philipson philipsonr@ainfosec.com
