### PR TITLE
hs-vhd: make recipe support offline mirroring

### DIFF
--- a/recipes-openxt/xenclient/hs-vhd_git.bb
+++ b/recipes-openxt/xenclient/hs-vhd_git.bb
@@ -8,7 +8,9 @@ LIC_FILES_CHKSUM = "file://LICENCE;md5=cc8224b3041a54c20bd7becce249bb02"
 DEPENDS = "ghc-native ghc-vhd"
 RDEPENDS_${PN} += "glibc-gconv-utf-32 ghc-runtime"
 
-SRC_URI = "git://github.com/jonathanknowles/hs-vhd;protocol=git;tag=0.2"
+SRC_URI = "git://github.com/jonathanknowles/hs-vhd;protocol=git"
+# SRCREV is pointing to tag v0.2
+SRCREV = "842d34b0f451330ea7abeb9ef3557a73281aa024"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This makes the hs-vhd recipe amenable to people that want to use the
enable the BB_GENERATE_MIRROR_TARBALLS variable to generate offline
download mirrors.

Singed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>

OXT-816