### PR TITLE
openxt-oe: move kernel provider to distro config

### DIFF
--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -16,6 +16,7 @@
 # require conf/sanity.conf
 #
 
+PREFERRED_PROVIDER_virtual/kernel = "linux-openxt"
 PREFERRED_VERSION_linux-openxt ?= "4.4%"
 
 # Down the road this should probably be a machine config thing so it is possible

--- a/conf/machine/xenclient-common.conf
+++ b/conf/machine/xenclient-common.conf
@@ -5,7 +5,5 @@
 IMAGE_CMD_cpio.bz2 = "cd ${IMAGE_ROOTFS} && (find . | cpio -o -H newc | bzip2 -c -9 >${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.cpio.bz2) ${EXTRA_IMAGECMD}"
 EXTRA_IMAGECMD_cpio.bz2 = ""
 
-PREFERRED_PROVIDER_virtual/kernel = "linux-openxt"
-
 # Tune for Core 2 CPU
 require conf/machine/include/tune-core2.inc


### PR DESCRIPTION
Selecting the kernel provider should be done in the distro config.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>

OXT-817