### PR TITLE
STABLE-6: Linux recipes cleanup and mirror change

### DIFF
--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_4.4.27.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_4.4.27.bb
@@ -2,7 +2,7 @@ require linux-libc-headers.inc
 
 PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
 
-SRC_URI = "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel"
+SRC_URI = "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel"
 
 SRC_URI[kernel.md5sum] = "3132b13f70447a85d70f58037db3a770"
 SRC_URI[kernel.sha256sum] = "0f995462425258b7fc50c03398a8f961d13a7e1df7955e7889ad1edd89da1882"

--- a/recipes-kernel/linux/4.4/linux-openxt_4.4.27.bb
+++ b/recipes-kernel/linux/4.4/linux-openxt_4.4.27.bb
@@ -8,7 +8,7 @@ PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
 PV_MINOR = "${@"${PV}".split('.', 3)[1]}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:${THISDIR}/defconfigs:"
-SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel \
+SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.gz;name=kernel \
     file://bridge-carrier-follow-prio0.patch;patch=1 \
     file://privcmd-mmapnocache-ioctl.patch;patch=1 \
     file://xenkbd-tablet-resolution.patch;patch=1 \


### PR DESCRIPTION
Use KERNELORG_MIRROR variable instead of static path.

Remove defunct and unmaintained linux versions.

Use MAJOR.MINOR linux-libc-headers tarball to make micro updates easier.