### PR TITLE
refpolicy: Address denials triggered by libxl

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.qemu.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.qemu.diff
@@ -104,12 +104,29 @@ Index: refpolicy/policy/modules/contrib/qemu.te
 ===================================================================
 --- refpolicy.orig/policy/modules/contrib/qemu.te
 +++ refpolicy/policy/modules/contrib/qemu.te
-@@ -27,6 +27,44 @@ role qemu_roles types qemu_t;
+@@ -27,6 +27,61 @@ role qemu_roles types qemu_t;
  # Local policy
  #
  
 +dbus_system_bus_client(qemu_t)
 +dbus_connect_system_bus(qemu_t)
++
++xc_read_etc_files(qemu_t)
++
++# For appending to /var/log/xen/qemu-dm-linux.log.
++# The init module does not provide any interfaces for this type.
++gen_require(`
++	type initrc_var_log_t;
++')
++allow qemu_t initrc_var_log_t:file append;
++# Likely isatty() check.
++allow qemu_t initrc_var_log_t:file ioctl;
++
++# Create /var/run/qmp-libxl-N socket
++type qemu_var_run_t;
++files_pid_file(qemu_var_run_t)
++files_pid_filetrans(qemu_t, qemu_var_run_t, sock_file)
++allow qemu_t qemu_var_run_t:sock_file manage_file_perms;
 +
 +# XC begin: qmeu reads & writes /dev/bsg/stuff
 +storage_read_scsi_generic(qemu_t)
@@ -149,7 +166,7 @@ Index: refpolicy/policy/modules/contrib/qemu.te
  tunable_policy(`qemu_full_network',`
  	corenet_udp_sendrecv_generic_if(qemu_t)
  	corenet_udp_sendrecv_generic_node(qemu_t)
-@@ -41,6 +79,21 @@ optional_policy(`
+@@ -41,6 +96,21 @@ optional_policy(`
  	xserver_user_x_domain_template(qemu, qemu_t, qemu_tmpfs_t)
  ')
  

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/blktap.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/blktap.te
@@ -51,6 +51,10 @@ files_pid_filetrans(tapctl_t, tapdisk_var_run_t, { dir })
 allow tapdisk_t self:capability { ipc_lock sys_resource sys_nice };
 allow tapdisk_t self:process { setrlimit setsched };
 
+# For opening xc-tools.iso with O_RDWR; see if we can patch tapdisk2
+# to only open it O_RDONLY.
+allow tapdisk_t self:capability dac_override;
+
 # leaked file descriptor
 xen_dontaudit_rw_unix_stream_sockets(tapdisk_t)
 
@@ -77,11 +81,25 @@ xc_read_sync_client_config_files(tapdisk_t)
 xc_getattr_sync_client_config_files(tapdisk_t)
 xc_read_all_disks(tapdisk_t)
 xc_write_all_disks(tapdisk_t)
+xc_read_iso_files(tapdisk_t)
+xc_write_iso_files(tapdisk_t)
 
 # consider dontaudit
 kernel_search_debugfs(tapdisk_t)
 logging_search_logs(tapdisk_t)
 logging_send_syslog_msg(tapdisk_t)
+
+# inherited descriptor to /dev/console
+init_dontaudit_use_fds(tapdisk_t)
+
+fs_getattr_xattr_fs(tapdisk_t)
+
+optional_policy(`
+	updatemgr_dontaudit_use_fd(tapdisk_t)
+	updatemgr_dontaudit_rw_fifo_files(tapdisk_t)
+	updatemgr_dontaudit_rw_stream_sockets(tapdisk_t)
+')
+
 
 #######################################
 #
@@ -123,10 +141,5 @@ optional_policy(`
 	updatemgr_dontaudit_rw_stream_sockets(tapctl_t)
 ')
 
-fs_getattr_xattr_fs(tapdisk_t)
-
-optional_policy(`
-	updatemgr_dontaudit_use_fd(tapdisk_t)
-	updatemgr_dontaudit_rw_fifo_files(tapdisk_t)
-	updatemgr_dontaudit_rw_stream_sockets(tapdisk_t)
-')
+# inherited descriptor to /dev/console
+init_dontaudit_use_fds(tapctl_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/stubdom-helpers.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/stubdom-helpers.te
@@ -79,6 +79,8 @@ storage_write_scsi_generic(atapi_helper_t)
 xc_files_rw_v4v_chr(atapi_helper_t)
 xen_dontaudit_rw_unix_stream_sockets(atapi_helper_t)
 logging_send_syslog_msg(atapi_helper_t)
+init_dontaudit_use_fds(atapi_helper_t)
+xc_read_etc_files(atapi_helper_t)
 
 ########################################
 #

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/stubdom-helpers.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/stubdom-helpers.te
@@ -80,7 +80,7 @@ xc_files_rw_v4v_chr(atapi_helper_t)
 xen_dontaudit_rw_unix_stream_sockets(atapi_helper_t)
 logging_send_syslog_msg(atapi_helper_t)
 init_dontaudit_use_fds(atapi_helper_t)
-xc_read_etc_files(atapi_helper_t)
+xc_dontaudit_read_etc_files(atapi_helper_t)
 
 ########################################
 #
@@ -116,3 +116,5 @@ allow audio_helper_t self:fifo_file rw_fifo_file_perms;
 allow audio_helper_t self:sem create_sem_perms;
 allow audio_helper_t self:shm create_shm_perms;
 
+init_dontaudit_use_fds(audio_helper_t)
+xc_dontaudit_read_etc_files(audio_helper_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/xc-files.if
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/system/xc-files.if
@@ -1168,6 +1168,23 @@ interface(`xc_read_iso_files',`
 
 ########################################
 ## <summary>
+##	Write XC iso files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xc_write_iso_files',`
+	gen_require(`
+		attribute xc_iso;
+	')
+	write_files_pattern($1, xc_iso, xc_iso)
+')
+
+########################################
+## <summary>
 ##	Do not audit attempts to get ISO file attributes.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
Addresses the following denials:

avc:  denied  { use } for  pid=1126 comm="tap-ctl" path="/dev/console" dev="devtmpfs" ino=9226 scontext=system_u:system_r:tapctl_t:s0-s0:c0.c1023 tcontext=system_u:system_r:init_t:s0 tclass=fd permissive=1

avc:  denied  { use } for  pid=1320 comm="tapdisk2" path="/dev/console" dev="devtmpfs" ino=9226 scontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tcontext=system_u:system_r:init_t:s0 tclass=fd permissive=1

avc:  denied  { dac_override } for  pid=12517 comm="tapdisk2" capability=1  scontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tcontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tclass=capability permissive=1

avc:  denied  { read write } for  pid=12517 comm="tapdisk2" name="xc-tools.iso" dev="dm-7" ino=17666 scontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xc_iso_t:s0 tclass=file permissive=1

avc:  denied  { open } for  pid=12517 comm="tapdisk2" path="/storage/isos/xc-tools.iso" dev="dm-7" ino=17666 scontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xc_iso_t:s0 tclass=file permissive=1

avc:  denied  { getattr } for  pid=12517 comm="tapdisk2" path="/storage/isos/xc-tools.iso" dev="dm-7" ino=17666 scontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xc_iso_t:s0 tclass=file permissive=1

avc:  denied  { use } for  pid=12569 comm="atapi_pt_helper" path="/dev/console" dev="devtmpfs" ino=9226 scontext=system_u:system_r:atapi_helper_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=fd permissive=1

avc:  denied  { read } for  pid=12569 comm="atapi_pt_helper" path="/etc/xenclient.conf" dev="dm-3" ino=3295 scontext=system_u:system_r:atapi_helper_t:s0 tcontext=system_u:object_r:xc_etc_t:s0 tclass=file permissive=1

avc:  denied  { append } for  pid=14150 comm="qemu-system-i38" path="/var/log/xen/qemu-dm-linux.log" dev="dm-9" ino=12290 scontext=system_u:system_r:qemu_t:s0-s0:c0.c1023 tcontext=system_u:object_r:initrc_var_log_t:s0 tclass=file permissive=1

avc:  denied  { read } for  pid=14150 comm="qemu-system-i38" path="/etc/xenclient.conf" dev="dm-3" ino=3295 scontext=system_u:system_r:qemu_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xc_etc_t:s0 tclass=file permissive=1

avc:  denied  { create } for  pid=14150 comm="qemu-system-i38" name="qmp-libxl-5" scontext=system_u:system_r:qemu_t:s0-s0:c0.c1023 tcontext=system_u:object_r:var_run_t:s0 tclass=sock_file permissive=1

avc:  denied  { ioctl } for  pid=14150 comm="qemu-system-i38" path="/var/log/xen/qemu-dm-linux.log" dev="dm-9" ino=12290 ioctlcmd=5401 scontext=system_u:system_r:qemu_t:s0-s0:c0.c1023 tcontext=system_u:object_r:initrc_var_log_t:s0 tclass=file permissive=1

OXT-459

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>