### PR TITLE
Remove idldir conf from surfman EXTRA_OECONF.

### DIFF
--- a/recipes-openxt/xenclient/surfman_git.bb
+++ b/recipes-openxt/xenclient/surfman_git.bb
@@ -12,8 +12,6 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/surfman.git;protocol=${OPENXT_GIT_PROTOCOL
            file://surfman.initscript \
            file://surfman.conf"
 
-EXTRA_OECONF += "--with-idldir=${STAGING_IDLDIR}"
-
 CFLAGS_append = " -Wno-unused-parameter "
 
 S = "${WORKDIR}/git/surfman"


### PR DESCRIPTION
Surfman does not use the idl stubs, silence a warning.