### PR TITLE
refpolicy: Harden SELinux policy for surfman

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/surfman.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/surfman.te
@@ -26,9 +26,7 @@ type surfman_exec_t;
 type surfman_conf_t;
 files_type(surfman_conf_t)
 
-init_domain(surfman_t, surfman_exec_t)
 init_daemon_domain(surfman_t, surfman_exec_t)
-domain_mmap_low(surfman_t)
 
 type surfman_var_run_t;
 files_pid_file(surfman_var_run_t)
@@ -50,14 +48,8 @@ fs_rw_xenfs_files(surfman_t)
 dev_rw_framebuffer(surfman_t)
 dev_rw_dri(surfman_t)
 dev_rw_sysfs(surfman_t)
-dev_rw_mtrr(surfman_t)
 dev_rw_xen(surfman_t)
-dev_rwx_zero(surfman_t)
-dev_read_raw_memory(surfman_t)
-dev_wx_raw_memory(surfman_t)
 kernel_read_system_state(surfman_t)
-kernel_write_xen_state(surfman_t)
-kernel_read_xen_state(surfman_t)
 logging_send_syslog_msg(surfman_t)
 xen_stream_connect_xenstore(surfman_t)  # /var/run/xenstored/socket
 allow surfman_t usr_t:lnk_file read;
@@ -78,8 +70,9 @@ statusreport_create_tmp_files(surfman_t)
 # allow reading of own configuration file(s)
 allow surfman_t surfman_conf_t:file read_file_perms;
 
-# don't fully understand this permission
-allow surfman_t	self:capability	{ ipc_lock sys_admin dac_override sys_rawio };
+# needed for ioctl on /dev/dri/card0, possibly others.
+allow surfman_t	self:capability	sys_admin;
+
 allow surfman_t self:unix_dgram_socket create_socket_perms;
 allow surfman_t self:fifo_file rw_fifo_file_perms;
 allow surfman_t self:process signal;


### PR DESCRIPTION
surfman presents an attack surface that is exposed to stubdoms (via dmbus/v4v) and
to uivm (via dbus/rpc-proxy/v4v).  Audit and harden the SELinux policy for surfman
to limit the impact of a vulnerability in it.  In particular, surfman appears to
hold a number of dangerous permissions that would allow it to subvert dom0 kernel
integrity.

The following changes are made by this patch:
1. Remove init_domain() call.  This is not needed when using init_daemon_domain().

2. Remove domain_mmap_low() call.  This call was allowing surfman
to map low memory addresses, making it easier to exploit kernel NULL
pointer dereferences, and does not seem to be needed, based on testing.

3. Remove dev_rw_mtrr() call. This call was allowing surfman
to read and write /proc/mtrr or /dev/cpu/mtrr and thereby
giving it control over the Memory Type Range Register.  This also
does not appear to be needed, as neither file exists in dom0.

4. Remove dev_rwx_zero() call. This call allowed surfman to map
/dev/zero with read, write, and execute permissions.  Read and write
permissions for /dev/zero are already allowed to all domains by the
refpolicy domain module. Execute permission should be avoided if
possible since it otherwise introduces the potential for runtime
code injection via a /dev/zero mapping.  Since this did not show up in
testing, it was removed.

5. Remove dev_read_raw_memory() and dev_wx_raw_memory() calls.  These
calls allowed surfman to map /dev/mem and /dev/kmem with read, write, and
execute permissions.  This is undesirable since it exposes physical memory
to surfman, and did not appear to be required for operation.

6. Remove the kernel_{write,read}_xen_state() calls.  These calls
were allowing surfman to read and write /proc/xen files when /proc/xen
was still part of proc.  This is no longer needed since there is now
a separate xenfs filesystem mounted on /proc/xen and access is granted
through other interfaces.

7. Remove ipc_lock, dac_override, and sys_rawio capabilities. These
capabilities did not appear to be required for operation in testing.
In particular, dac_override (ability to override DAC for read, write, and
execute access) should be minimized, as should sys_rawio (likely originally
included for the same reason as domain_mmap_low above).

8. Documented the particular operation that appears to be triggering the
sys_admin capability check.

OXT-815

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>