### PR TITLE
STABLE-6: XSAs, november 2016

### DIFF
--- a/recipes-extended/xen/files/xsa-191-x86-null-segments-not-always-treated-as-unusable.patch
+++ b/recipes-extended/xen/files/xsa-191-x86-null-segments-not-always-treated-as-unusable.patch
@@ -1,0 +1,153 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-191 http://xenbits.xen.org/xsa/advisory-191.html
+x86 software interrupt injection mis-handled
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-191.html
+Patch: xsa191-4.6.patch
+
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: x86/hvm: Fix the handling of non-present segments
+
+In 32bit, the data segments may be NULL to indicate that the segment is
+ineligible for use.  In both 32bit and 64bit, the LDT selector may be NULL to
+indicate that the entire LDT is ineligible for use.  However, nothing in Xen
+actually checks for this condition when performing other segmentation
+checks.  (Note however that limit and writeability checks are correctly
+performed).
+
+Neither Intel nor AMD specify the exact behaviour of loading a NULL segment.
+Experimentally, AMD zeroes all attributes but leaves the base and limit
+unmodified.  Intel zeroes the base, sets the limit to 0xfffffff and resets the
+attributes to just .G and .D/B.
+
+The use of the segment information in the VMCB/VMCS is equivalent to a native
+pipeline interacting with the segment cache.  The present bit can therefore
+have a subtly different meaning, and it is now cooked to uniformly indicate
+whether the segment is usable or not.
+
+GDTR and IDTR don't have access rights like the other segments, but for
+consistency, they are treated as being present so no special casing is needed
+elsewhere in the segmentation logic.
+
+AMD hardware does not consider the present bit for %cs and %tr, and will
+function as if they were present.  They are therefore unconditionally set to
+present when reading information from the VMCB, to maintain the new meaning of
+usability.
+
+Intel hardware has a separate unusable bit in the VMCS segment attributes.
+This bit is inverted and stored in the present field, so the hvm code can work
+with architecturally-common state.
+
+This is XSA-191.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+################################################################################
+PATCHES
+################################################################################
+--- a/xen/arch/x86/hvm/hvm.c
++++ b/xen/arch/x86/hvm/hvm.c
+@@ -1992,6 +1992,10 @@ int hvm_virtual_to_linear_addr(
+          * COMPATIBILITY MODE: Apply segment checks and add base.
+          */
+ 
++        /* Segment not valid for use (cooked meaning of .p)? */
++        if ( !reg->attr.fields.p )
++            return 0;
++
+         switch ( access_type )
+         {
+         case hvm_access_read:
+@@ -2189,6 +2193,10 @@ static int hvm_load_segment_selector(
+     hvm_get_segment_register(
+         v, (sel & 4) ? x86_seg_ldtr : x86_seg_gdtr, &desctab);
+ 
++    /* Segment not valid for use (cooked meaning of .p)? */
++    if ( !desctab.attr.fields.p )
++        goto fail;
++
+     /* Check against descriptor table limit. */
+     if ( ((sel & 0xfff8) + 7) > desctab.limit )
+         goto fail;
+--- a/xen/arch/x86/hvm/svm/svm.c
++++ b/xen/arch/x86/hvm/svm/svm.c
+@@ -522,6 +522,7 @@ static void svm_get_segment_register(str
+     {
+     case x86_seg_cs:
+         memcpy(reg, &vmcb->cs, sizeof(*reg));
++        reg->attr.fields.p = 1;
+         reg->attr.fields.g = reg->limit > 0xFFFFF;
+         break;
+     case x86_seg_ds:
+@@ -555,13 +556,16 @@ static void svm_get_segment_register(str
+     case x86_seg_tr:
+         svm_sync_vmcb(v);
+         memcpy(reg, &vmcb->tr, sizeof(*reg));
++        reg->attr.fields.p = 1;
+         reg->attr.fields.type |= 0x2;
+         break;
+     case x86_seg_gdtr:
+         memcpy(reg, &vmcb->gdtr, sizeof(*reg));
++        reg->attr.bytes = 0x80;
+         break;
+     case x86_seg_idtr:
+         memcpy(reg, &vmcb->idtr, sizeof(*reg));
++        reg->attr.bytes = 0x80;
+         break;
+     case x86_seg_ldtr:
+         svm_sync_vmcb(v);
+--- a/xen/arch/x86/hvm/vmx/vmx.c
++++ b/xen/arch/x86/hvm/vmx/vmx.c
+@@ -764,10 +764,12 @@ void vmx_get_segment_register(struct vcp
+ 
+     vmx_vmcs_exit(v);
+ 
+-    reg->attr.bytes = (attr & 0xff) | ((attr >> 4) & 0xf00);
+-    /* Unusable flag is folded into Present flag. */
+-    if ( attr & (1u<<16) )
+-        reg->attr.fields.p = 0;
++    /*
++     * Fold VT-x representation into Xen's representation.  The Present bit is
++     * unconditionally set to the inverse of unusable.
++     */
++    reg->attr.bytes =
++        (!(attr & (1u << 16)) << 7) | (attr & 0x7f) | ((attr >> 4) & 0xf00);
+ 
+     /* Adjust for virtual 8086 mode */
+     if ( v->arch.hvm_vmx.vmx_realmode && seg <= x86_seg_tr 
+@@ -847,11 +849,11 @@ static void vmx_set_segment_register(str
+         }
+     }
+ 
+-    attr = ((attr & 0xf00) << 4) | (attr & 0xff);
+-
+-    /* Not-present must mean unusable. */
+-    if ( !reg->attr.fields.p )
+-        attr |= (1u << 16);
++    /*
++     * Unfold Xen representation into VT-x representation.  The unusable bit
++     * is unconditionally set to the inverse of present.
++     */
++    attr = (!(attr & (1u << 7)) << 16) | ((attr & 0xf00) << 4) | (attr & 0xff);
+ 
+     /* VMX has strict consistency requirement for flag G. */
+     attr |= !!(limit >> 20) << 15;
+--- a/xen/arch/x86/x86_emulate/x86_emulate.c
++++ b/xen/arch/x86/x86_emulate/x86_emulate.c
+@@ -1175,6 +1175,10 @@ protmode_load_seg(
+                                  &desctab, ctxt)) )
+         return rc;
+ 
++    /* Segment not valid for use (cooked meaning of .p)? */
++    if ( !desctab.attr.fields.p )
++        goto raise_exn;
++
+     /* Check against descriptor table limit. */
+     if ( ((sel & 0xfff8) + 7) > desctab.limit )
+         goto raise_exn;

--- a/recipes-extended/xen/files/xsa-192-x86-task-switch-to-vm86-mode-mis-handled.patch
+++ b/recipes-extended/xen/files/xsa-192-x86-task-switch-to-vm86-mode-mis-handled.patch
@@ -1,0 +1,78 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-192 http://xenbits.xen.org/xsa/advisory-192.html
+x86 task switch to VM86 mode mis-handled
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-192.html
+Patch: xsa192-4.5.patch
+
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86/HVM: don't load LDTR with VM86 mode attrs during task switch
+
+Just like TR, LDTR is purely a protected mode facility and hence needs
+to be loaded accordingly. Also move its loading to where it
+architecurally belongs.
+
+This is XSA-192.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Tested-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+################################################################################
+PATCHES
+################################################################################
+--- a/xen/arch/x86/hvm/hvm.c
++++ b/xen/arch/x86/hvm/hvm.c
+@@ -2156,16 +2156,15 @@ static void hvm_unmap_entry(void *p)
+ }
+ 
+ static int hvm_load_segment_selector(
+-    enum x86_segment seg, uint16_t sel)
++    enum x86_segment seg, uint16_t sel, unsigned int eflags)
+ {
+     struct segment_register desctab, cs, segr;
+     struct desc_struct *pdesc, desc;
+     u8 dpl, rpl, cpl;
+     int fault_type = TRAP_invalid_tss;
+-    struct cpu_user_regs *regs = guest_cpu_user_regs();
+     struct vcpu *v = current;
+ 
+-    if ( regs->eflags & X86_EFLAGS_VM )
++    if ( eflags & X86_EFLAGS_VM )
+     {
+         segr.sel = sel;
+         segr.base = (uint32_t)sel << 4;
+@@ -2416,6 +2415,8 @@ void hvm_task_switch(
+     if ( rc != HVMCOPY_okay )
+         goto out;
+ 
++    if ( hvm_load_segment_selector(x86_seg_ldtr, tss.ldt, 0) )
++        goto out;
+ 
+     if ( hvm_set_cr3(tss.cr3) )
+         goto out;
+@@ -2438,13 +2439,12 @@ void hvm_task_switch(
+     }
+ 
+     exn_raised = 0;
+-    if ( hvm_load_segment_selector(x86_seg_ldtr, tss.ldt) ||
+-         hvm_load_segment_selector(x86_seg_es, tss.es) ||
+-         hvm_load_segment_selector(x86_seg_cs, tss.cs) ||
+-         hvm_load_segment_selector(x86_seg_ss, tss.ss) ||
+-         hvm_load_segment_selector(x86_seg_ds, tss.ds) ||
+-         hvm_load_segment_selector(x86_seg_fs, tss.fs) ||
+-         hvm_load_segment_selector(x86_seg_gs, tss.gs) )
++    if ( hvm_load_segment_selector(x86_seg_es, tss.es, tss.eflags) ||
++         hvm_load_segment_selector(x86_seg_cs, tss.cs, tss.eflags) ||
++         hvm_load_segment_selector(x86_seg_ss, tss.ss, tss.eflags) ||
++         hvm_load_segment_selector(x86_seg_ds, tss.ds, tss.eflags) ||
++         hvm_load_segment_selector(x86_seg_fs, tss.fs, tss.eflags) ||
++         hvm_load_segment_selector(x86_seg_gs, tss.gs, tss.eflags) )
+         exn_raised = 1;
+ 
+     rc = hvm_copy_to_guest_virt(

--- a/recipes-extended/xen/files/xsa-193-x86-segment-base-write-emulation-lacking-canonical-address-checks.patch
+++ b/recipes-extended/xen/files/xsa-193-x86-segment-base-write-emulation-lacking-canonical-address-checks.patch
@@ -1,0 +1,81 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-193 http://xenbits.xen.org/xsa/advisory-193.html
+x86 segment base write emulation lacking canonical address checks
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-193.html
+Patch: xsa193-4.5.patch
+
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86/PV: writes of %fs and %gs base MSRs require canonical addresses
+
+Commit c42494acb2 ("x86: fix FS/GS base handling when using the
+fsgsbase feature") replaced the use of wrmsr_safe() on these paths
+without recognizing that wr{f,g}sbase() use just wrmsrl() and that the
+WR{F,G}SBASE instructions also raise #GP for non-canonical input.
+
+Similarly arch_set_info_guest() needs to prevent non-canonical
+addresses from getting stored into state later to be loaded by context
+switch code. For consistency also check stack pointers and LDT base.
+DR0..3, otoh, already get properly checked in set_debugreg() (albeit
+we discard the error there).
+
+The SHADOW_GS_BASE check isn't strictly necessary, but I think we
+better avoid trying the WRMSR if we know it's going to fail.
+
+This is XSA-193.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+################################################################################
+PATCHES
+################################################################################
+--- a/xen/arch/x86/domain.c
++++ b/xen/arch/x86/domain.c
+@@ -682,7 +682,13 @@ int arch_set_info_guest(
+     {
+         if ( !compat )
+         {
+-            if ( !is_canonical_address(c.nat->user_regs.eip) ||
++            if ( !is_canonical_address(c.nat->user_regs.rip) ||
++                 !is_canonical_address(c.nat->user_regs.rsp) ||
++                 !is_canonical_address(c.nat->kernel_sp) ||
++                 (c.nat->ldt_ents && !is_canonical_address(c.nat->ldt_base)) ||
++                 !is_canonical_address(c.nat->fs_base) ||
++                 !is_canonical_address(c.nat->gs_base_kernel) ||
++                 !is_canonical_address(c.nat->gs_base_user) ||
+                  !is_canonical_address(c.nat->event_callback_eip) ||
+                  !is_canonical_address(c.nat->syscall_callback_eip) ||
+                  !is_canonical_address(c.nat->failsafe_callback_eip) )
+--- a/xen/arch/x86/traps.c
++++ b/xen/arch/x86/traps.c
+@@ -2408,21 +2408,21 @@ static int emulate_privileged_op(struct
+         switch ( (u32)regs->ecx )
+         {
+         case MSR_FS_BASE:
+-            if ( is_pv_32on64_vcpu(v) )
++            if ( is_pv_32on64_vcpu(v) || !is_canonical_address(msr_content) )
+                 goto fail;
+             if ( wrmsr_safe(MSR_FS_BASE, msr_content) )
+                 goto fail;
+             v->arch.pv_vcpu.fs_base = msr_content;
+             break;
+         case MSR_GS_BASE:
+-            if ( is_pv_32on64_vcpu(v) )
++            if ( is_pv_32on64_vcpu(v) || !is_canonical_address(msr_content) )
+                 goto fail;
+             if ( wrmsr_safe(MSR_GS_BASE, msr_content) )
+                 goto fail;
+             v->arch.pv_vcpu.gs_base_kernel = msr_content;
+             break;
+         case MSR_SHADOW_GS_BASE:
+-            if ( is_pv_32on64_vcpu(v) )
++            if ( is_pv_32on64_vcpu(v) || !is_canonical_address(msr_content) )
+                 goto fail;
+             if ( wrmsr_safe(MSR_SHADOW_GS_BASE, msr_content) )
+                 goto fail;

--- a/recipes-extended/xen/files/xsa-195-x86-64-bit-bit-test-instruction-emulation-broken.patch
+++ b/recipes-extended/xen/files/xsa-195-x86-64-bit-bit-test-instruction-emulation-broken.patch
@@ -1,0 +1,59 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-195 http://xenbits.xen.org/xsa/advisory-195.html
+x86 64-bit bit test instruction emulation broken
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-195.html
+Patch: xsa195.patch
+
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86emul: fix huge bit offset handling
+
+We must never chop off the high 32 bits.
+
+This is XSA-195.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+################################################################################
+PATCHES
+################################################################################
+--- a/xen/arch/x86/x86_emulate/x86_emulate.c
++++ b/xen/arch/x86/x86_emulate/x86_emulate.c
+@@ -1795,6 +1795,12 @@ x86_emulate(
+         else
+         {
+             /*
++             * Instructions such as bt can reference an arbitrary offset from
++             * their memory operand, but the instruction doing the actual
++             * emulation needs the appropriate op_bytes read from memory.
++             * Adjust both the source register and memory operand to make an
++             * equivalent instruction.
++             *
+              * EA       += BitOffset DIV op_bytes*8
+              * BitOffset = BitOffset MOD op_bytes*8
+              * DIV truncates towards negative infinity.
+@@ -1806,14 +1812,15 @@ x86_emulate(
+                 src.val = (int32_t)src.val;
+             if ( (long)src.val < 0 )
+             {
+-                unsigned long byte_offset;
+-                byte_offset = op_bytes + (((-src.val-1) >> 3) & ~(op_bytes-1));
++                unsigned long byte_offset =
++                    op_bytes + (((-src.val - 1) >> 3) & ~(op_bytes - 1L));
++
+                 ea.mem.off -= byte_offset;
+                 src.val = (byte_offset << 3) + src.val;
+             }
+             else
+             {
+-                ea.mem.off += (src.val >> 3) & ~(op_bytes - 1);
++                ea.mem.off += (src.val >> 3) & ~(op_bytes - 1L);
+                 src.val &= (op_bytes << 3) - 1;
+             }
+         }

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -128,6 +128,10 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://xsa-185-x86-Disallow-L3-recursive-pagetable-for-32-bit-PV-guests.patch \
     file://xsa-187-x86-hvm-overflow-of-sh_ctxt-seg_reg.patch \
     file://xsa-190-x86-hvm-instr-emul-guest-user-mode-missing-exception.patch \
+    file://xsa-191-x86-null-segments-not-always-treated-as-unusable.patch \
+    file://xsa-192-x86-task-switch-to-vm86-mode-mis-handled.patch \
+    file://xsa-193-x86-segment-base-write-emulation-lacking-canonical-address-checks.patch \
+    file://xsa-195-x86-64-bit-bit-test-instruction-emulation-broken.patch \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"

--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-197-qemu-incautious-about-shared-ring-processing.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/xsa-197-qemu-incautious-about-shared-ring-processing.patch
@@ -1,0 +1,76 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-197 http://xenbits.xen.org/xsa/advisory-197.html
+x86 software interrupt injection mis-handled
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-197.html
+Patch: xsa197-4.4-qemuu.patch
+
+xen: fix ioreq handling
+
+Avoid double fetches and bounds check size to avoid overflowing
+internal variables.
+
+This is XSA-197.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Stefano Stabellini <sstabellini@kernel.org>
+
+################################################################################
+PATCHES
+################################################################################
+--- a/xen-all.c
++++ b/xen-all.c
+@@ -770,6 +770,10 @@ static void cpu_ioreq_pio(ioreq_t *req)
+ {
+     uint32_t i;
+ 
++    if (req->size > sizeof(uint32_t)) {
++        hw_error("PIO: bad size (%u)", req->size);
++    }
++
+     if (req->dir == IOREQ_READ) {
+         if (!req->data_is_ptr) {
+             req->data = do_inp(req->addr, req->size);
+@@ -799,6 +803,10 @@ static void cpu_ioreq_move(ioreq_t *req)
+ {
+     uint32_t i;
+ 
++    if (req->size > sizeof(req->data)) {
++        hw_error("MMIO: bad size (%u)", req->size);
++    }
++
+     if (!req->data_is_ptr) {
+         if (req->dir == IOREQ_READ) {
+             for (i = 0; i < req->count; i++) {
+@@ -916,11 +924,13 @@ static int handle_buffered_iopage(XenIOS
+         req.df = 1;
+         req.type = buf_req->type;
+         req.data_is_ptr = 0;
++        xen_rmb();
+         qw = (req.size == 8);
+         if (qw) {
+             buf_req = &state->buffered_io_page->buf_ioreq[
+                 (state->buffered_io_page->read_pointer + 1) % IOREQ_BUFFER_SLOT_NUM];
+             req.data |= ((uint64_t)buf_req->data) << 32;
++            xen_rmb();
+         }
+ 
+         handle_ioreq(&req);
+@@ -952,7 +962,11 @@ static void cpu_handle_ioreq(void *opaqu
+ 
+     handle_buffered_iopage(state);
+     if (req) {
+-        handle_ioreq(req);
++        ioreq_t copy = *req;
++
++        xen_rmb();
++        handle_ioreq(&copy);
++        req->data = copy.data;
+ 
+         if (req->state != STATE_IOREQ_INPROCESS) {
+             fprintf(stderr, "Badness in I/O request ... not in service?!: "

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -64,6 +64,7 @@ SRC_URI += "file://xsa-126-unmediated-pci-command-register-access-in-qemu.patch;
             file://0033-acpi-pm-feature.patch;striplevel=1 \
             file://0034-maintain-time-offset.patch;striplevel=1 \
             file://0035-add-acpi-wakeup.patch;striplevel=1 \
+            file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
             "
 
 SRC_URI[md5sum] = "78f13b774814b6b7ebcaf4f9b9204318"


### PR DESCRIPTION
XSA-194: Xen 4.4 is not affected.
XSA-196: Xen 4.4 is not affected.
XSA-198: OpenXT does not use pygrub.

OXT-843