### PR TITLE
Update the snapshot and scan functions to use the vhd realpath

### DIFF
--- a/recipes-extended/xen/files/blktap2-vhd-icbinn-support.patch
+++ b/recipes-extended/xen/files/blktap2-vhd-icbinn-support.patch
@@ -1091,3 +1091,29 @@ Index: xen-4.6.1/tools/blktap2/drivers/Makefile
  
  install: all
  	$(INSTALL_DIR) -p $(DESTDIR)$(INST_DIR)
+Index: xen-4.6.1/tools/blktap2/vhd/lib/vhd-util-snapshot.c
+===================================================================
+--- xen-4.6.1.orig/tools/blktap2/vhd/lib/vhd-util-snapshot.c
++++ xen-4.6.1/tools/blktap2/vhd/lib/vhd-util-snapshot.c
+@@ -152,7 +152,7 @@ vhd_util_snapshot(int argc, char **argv)
+ 		goto usage;
+ 	}
+ 
+-	ppath = realpath(pname, NULL);
++	ppath = vhd_realpath(pname, NULL);
+ 	if (!ppath)
+ 		return -errno;
+ 
+Index: xen-4.6.1/tools/blktap2/vhd/lib/vhd-util-scan.c
+===================================================================
+--- xen-4.6.1.orig/tools/blktap2/vhd/lib/vhd-util-scan.c
++++ xen-4.6.1/tools/blktap2/vhd/lib/vhd-util-scan.c
+@@ -772,7 +772,7 @@ vhd_util_scan_open(vhd_context_t *vhd, struct vhd_image *image)
+ 	if (target_volume(image->target->type) || !(flags & VHD_SCAN_PRETTY))
+ 		image->name = target->name;
+ 	else {
+-		image->name = realpath(target->name, NULL);
++		image->name = vhd_realpath(target->name, NULL);
+ 		if (!image->name) {
+ 			image->name    = target->name;
+ 			image->message = "resolving name";


### PR DESCRIPTION
The snapshot and scan functions needed to use vhd_realpath to use icbinn when necessary. Without this commit the synchronizer will never create the snapshot disk after downloading the base vhd.

See OXT-785

To test this, run vhd-util for a dom0 snapshot from the synchronizer with the correct LIBVHD_ICBINN_VHD_SERVER and LIBVHD_ICBINN_KEY_SERVER set. Before this change, you will receive an error code ENOENT. After this change the vhd-util snapshot function should recognize the existence of the icbinn server set and execute the function using icbinn.

Signed-off-by: Richard Turner <turnerr@ainfosec.com>