### PR TITLE
Turn off switcher debug logging.

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/switcher.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/switcher.patch
@@ -117,7 +117,7 @@ Index: qemu-2.6.2/ui/xen-input.c
 +#include "ui/xen-input.h"
 +#include "sysemu/sysemu.h"
 +
-+#define DEBUG_INPUT
++//#define DEBUG_INPUT
 +
 +#ifdef DEBUG_INPUT
 +# define DEBUG_MSG(...) printf("XenInput:" __VA_ARGS__)


### PR DESCRIPTION
"XenInput:direct event handler"
"XenInput:send led keycode 0x0"
... are very noisy otherwise.

OXT-857