### PR TITLE
STABLE-6: Turn off switcher debug logging.

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-1.4/0008-switcher.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4/0008-switcher.patch
@@ -143,7 +143,7 @@ Index: qemu-1.4.0/ui/xen-input.c
 +#include "xen-input.h"
 +#include "sysemu/sysemu.h"
 +
-+#define DEBUG_INPUT
++//#define DEBUG_INPUT
 +
 +#ifdef DEBUG_INPUT
 +# define DEBUG_MSG(...) printf("XenInput:" __VA_ARGS__)


### PR DESCRIPTION
"XenInput:direct event handler"
"XenInput:send led keycode 0x0"
... are very noisy otherwise.

OXT-857

(cherry picked from commit 75e19618263b8dda340398f990fe662dd05f6716)
