### PR TITLE
[OXT-580] Updated acpid to use bbappend to pull from openembedded as …

### DIFF
--- a/recipes-bsp/acpid/acpid.inc
+++ b/recipes-bsp/acpid/acpid.inc
@@ -1,32 +1,6 @@
-SUMMARY = "A daemon for delivering ACPI events"
-HOMEPAGE = "http://sourceforge.net/projects/acpid2/"
-BUGTRACKER = "http://sourceforge.net/p/acpid2/tickets/" 
-SECTION = "base"
-LICENSE = "GPLv2+"
-
 SRC_URI = "${SOURCEFORGE_MIRROR}/acpid2/acpid-${PV}.tar.xz \
            file://init \
            file://powerbtn \
            file://ac \
            file://ac_actions \
           "
-
-inherit autotools update-rc.d
-
-INITSCRIPT_NAME = "acpid"
-INITSCRIPT_PARAMS = "defaults"
-
-do_install_append () {
-    install -d ${D}${sysconfdir}/init.d
-    sed -e 's,/usr/sbin,${sbindir},g' ${WORKDIR}/init > ${D}${sysconfdir}/init.d/acpid
-    chmod 755 ${D}${sysconfdir}/init.d/acpid
-
-    install -d ${D}${sysconfdir}/acpi
-    install -d ${D}${sysconfdir}/acpi/events
-    install -m 644 ${WORKDIR}/powerbtn ${D}${sysconfdir}/acpi/events
-    install -m 644 ${WORKDIR}/ac ${D}${sysconfdir}/acpi/events
-
-    install -m 755 ${WORKDIR}/ac_actions ${D}${sysconfdir}/acpi/ac 
-
-    install -d ${D}${sysconfdir}/acpi/actions
-}

--- a/recipes-bsp/acpid/acpid_2.0.23.bb
+++ b/recipes-bsp/acpid/acpid_2.0.23.bb
@@ -1,8 +1,0 @@
-# Copied from a more recent commit on openembedded-core
-require acpid.inc
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=8ca43cbc842c2336e835926c2166c28b \
-                    file://acpid.h;endline=24;md5=324a9cf225ae69ddaad1bf9d942115b5"
-
-SRC_URI[md5sum] = "d7bcdcdefcd53b03730e50ba842554ea"
-SRC_URI[sha256sum] = "4396aaec13510c3a1faa941a15a4b5335b6ae4fbec8438b9249b88c3b66187ee"

--- a/recipes-bsp/acpid/acpid_2.0.23.bbappend
+++ b/recipes-bsp/acpid/acpid_2.0.23.bbappend
@@ -1,0 +1,28 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+
+SRC_URI = "${SOURCEFORGE_MIRROR}/acpid2/acpid-${PV}.tar.xz \
+           file://init \
+           file://powerbtn \
+           file://ac \
+           file://ac_actions \
+	   file://acpid.service \
+          "
+
+
+inherit autotools update-rc.d
+
+do_install_append () {
+    install -d ${D}${sysconfdir}/init.d
+    sed -e 's,/usr/sbin,${sbindir},g' ${WORKDIR}/init > ${D}${sysconfdir}/init.d/acpid
+    chmod 755 ${D}${sysconfdir}/init.d/acpid
+
+    install -d ${D}${sysconfdir}/acpi
+    install -d ${D}${sysconfdir}/acpi/events
+    install -m 644 ${WORKDIR}/powerbtn ${D}${sysconfdir}/acpi/events
+    install -m 644 ${WORKDIR}/ac ${D}${sysconfdir}/acpi/events
+
+    install -m 755 ${WORKDIR}/ac_actions ${D}${sysconfdir}/acpi/ac 
+
+    install -d ${D}${sysconfdir}/acpi/actions
+}


### PR DESCRIPTION
[OXT-580] Changed acpid to use bbappend files instead of bb. This allows us to get updates from upstream as requested.