### PR TITLE
STABLE-6: Bump dom0 memory from 320M to 420M

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
@@ -30,7 +30,7 @@ else
 fi
 
 TBOOT_COMMON_CMD="min_ram=0x2000000 loglvl=all serial=115200,8n1,0x3f8 logging=serial,memory"
-XEN_COMMON_CMD="console=com1 dom0_mem=min:320M,max:320M,320M com1=115200,8n1,pci mbi-video vga=current flask_enforcing=1 loglvl=debug guest_loglvl=debug"
+XEN_COMMON_CMD="console=com1 dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask_enforcing=1 loglvl=debug guest_loglvl=debug"
 LINUX_COMMON_CMD="console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3"
 
 menuentry "XenClient: Normal" {


### PR DESCRIPTION
OXT-855

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit f4f28b72b0f4a7b559c4aea81a08a17890e9108a)
Signed-off-by: Jed <lejosnej@ainfosec.com>

Conflicts:
	recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg