### PR TITLE
Fix the readonly-ide patch to write out the config option to the make file

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/readonly-ide.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/readonly-ide.patch
@@ -65,6 +65,24 @@ Index: qemu-2.6.2/configure
    --with-sdlabi=*) sdlabi="$optarg"
    ;;
    --disable-qom-cast-debug) qom_cast_debug="no"
+@@ -4769,6 +4779,7 @@ if test "$darwin" = "yes" ; then
+ fi
+ echo "pixman            $pixman"
+ echo "SDL support       $sdl"
++echo "readonly IDE support       $readonly_ide"
+ echo "GTK support       $gtk"
+ echo "GTK GL support    $gtk_gl"
+ echo "GNUTLS support    $gnutls"
+@@ -5042,6 +5054,9 @@ if test "$sdl" = "yes" ; then
+   echo "CONFIG_SDLABI=$sdlabi" >> $config_host_mak
+   echo "SDL_CFLAGS=$sdl_cflags" >> $config_host_mak
+ fi
++if test "$readonly_ide" = "yes" ; then
++  echo "CONFIG_READONLY_IDE=y" >> $config_host_mak
++fi
+ if test "$cocoa" = "yes" ; then
+   echo "CONFIG_COCOA=y" >> $config_host_mak
+ fi
 Index: qemu-2.6.2/hw/ide/core.c
 ===================================================================
 --- qemu-2.6.2.orig/hw/ide/core.c


### PR DESCRIPTION
Without this fix you can't have readonly ide disks with the QEmu 2.6.2 uprev

Signed-off-by: Richard Turner <turnerr@ainfosec.com>