### PR TITLE
refpolicy: adjust for qtdbd

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.booleans.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.booleans.diff
@@ -1,0 +1,13 @@
+Index: refpolicy/policy/booleans.conf
+===================================================================
+--- refpolicy.orig/policy/booleans.conf
++++ refpolicy/policy/booleans.conf
+@@ -1223,7 +1223,7 @@ console_login = true
+ # stack smashing protection.  All domains will
+ # be allowed to read from /dev/urandom.
+ # 
+-global_ssp = false
++global_ssp = true
+ 
+ #
+ # Allow email client to various content.

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.kernel.devices.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.kernel.devices.diff
@@ -239,7 +239,15 @@ Index: refpolicy/policy/modules/kernel/devices.te
  
  #
  # device_t is the type of /dev.
-@@ -328,3 +329,11 @@ files_associate_tmp(device_node)
+@@ -65,6 +66,7 @@ dev_node(cpu_device_t)
+ type cpu_online_t;
+ files_type(cpu_online_t)
+ dev_associate_sysfs(cpu_online_t)
++genfscon sysfs /devices/system/cpu/online gen_context(system_u:object_r:cpu_online_t,s0)
+ 
+ #
+ # Type for /dev/crash
+@@ -328,3 +330,11 @@ files_associate_tmp(device_node)
  allow devices_unconfined_type self:capability sys_rawio;
  allow devices_unconfined_type device_node:{ blk_file chr_file } *;
  allow devices_unconfined_type mtrr_device_t:file *;


### PR DESCRIPTION
Adjust the policy for accesses qtdbd require.

OXT-787

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>