### PR TITLE
[libxl] Only create 1 vkb.

### DIFF
--- a/recipes-extended/xen/files/libxl-stubdom-options.patch
+++ b/recipes-extended/xen/files/libxl-stubdom-options.patch
@@ -107,7 +107,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/xl_cmdimpl.c
 +++ xen-4.6.1/tools/libxl/xl_cmdimpl.c
-@@ -2167,6 +2167,17 @@ skip_nic:
+@@ -2165,6 +2165,17 @@ skip_nic:
      }
  
  

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -269,7 +269,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
      switch(b_info->type) {
      case LIBXL_DOMAIN_TYPE_HVM:
          kernel_basename = libxl_basename(b_info->kernel);
-@@ -1955,64 +1961,38 @@ skip_nic:
+@@ -1955,64 +1961,36 @@ skip_nic:
          fprintf(stderr, "WARNING: vif2: netchannel2 is deprecated and not supported by xl\n");
      }
  
@@ -337,16 +337,14 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 +        d_config->vkbs = NULL;
 +        
 +        if (vkb_flag == 1) {
-+            for(i = 0; i < 2; i++) {
-+                libxl_device_vkb *vkb;
-+                fprintf(stderr, "WARNING: init vkb device\n");
-+                d_config->vkbs = (libxl_device_vkb *) realloc(d_config->vkbs,                          sizeof(libxl_device_vkb) * (d_config->num_vkbs + 1));
-+                vkb = d_config->vkbs + d_config->num_vkbs;
-+                libxl_device_vkb_init(vkb);
-+                vkb->devid = d_config->num_vkbs;
-+                fprintf(stderr, "WARNING: vkb device of devid %d created.\n", vkb->devid);
-+                d_config->num_vkbs++;
-+            }
++            libxl_device_vkb *vkb;
++            fprintf(stderr, "WARNING: init vkb device\n");
++            d_config->vkbs = (libxl_device_vkb *) realloc(d_config->vkbs,                          sizeof(libxl_device_vkb) * (d_config->num_vkbs + 1));
++            vkb = d_config->vkbs + d_config->num_vkbs;
++            libxl_device_vkb_init(vkb);
++            vkb->devid = d_config->num_vkbs;
++            fprintf(stderr, "WARNING: vkb device of devid %d created.\n", vkb->devid);
++            d_config->num_vkbs++;
 +        }
 +    }
 +    
@@ -366,7 +364,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
          }
      }
  
-@@ -3018,8 +2998,6 @@ start:
+@@ -3018,8 +2996,6 @@ start:
                   */
                  dom_info->console_autoconnect = 0;
  
@@ -375,7 +373,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
                  if (common_domname
                      && strcmp(d_config.c_info.name, common_domname)) {
                      d_config.c_info.name = strdup(common_domname);
-@@ -3696,13 +3674,17 @@ static void unpause_domain(uint32_t domi
+@@ -3696,13 +3672,17 @@ static void unpause_domain(uint32_t domi
  static void destroy_domain(uint32_t domid, int force)
  {
      int rc;
@@ -393,7 +391,7 @@ Index: xen-4.6.1/tools/libxl/xl_cmdimpl.c
 +
      rc = libxl_domain_destroy(ctx, domid, 0);
      if (rc) { fprintf(stderr,"destroy failed (rc=%d)\n",rc); exit(-1); }
-     libxl_update_state_direct(ctx, *uuid, "shutdown");
+     libxl_update_state_direct(ctx, uuid, "shutdown");
 Index: xen-4.6.1/tools/libxl/libxl_device.c
 ===================================================================
 --- xen-4.6.1.orig/tools/libxl/libxl_device.c


### PR DESCRIPTION
UIVM tries to probe xenbus for the second vkb device, which it
doesn't use, therefore increasing boot time significantly. This
commit removes the loop that creates two devices, something our
platform doesn't need.

OXT-435

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>