### PR TITLE
OXT-899: Silence TPM warnings.

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
@@ -66,7 +66,6 @@ read_args() {
             debug)
                 set -x ;;
             fbcon)
-                depmod -a
                 modprobe fbcon
                 FBCON=true
                 ;;
@@ -165,10 +164,7 @@ fatal() {
 
 tpm_setup() {
     CMDLINE="ro measured" read_args
-    insmod /lib/modules/$(uname -r)/kernel/drivers/char/tpm/tpm.ko
-    insmod /lib/modules/$(uname -r)/kernel/drivers/char/tpm/tpm_tis_core.ko
-    insmod /lib/modules/$(uname -r)/kernel/drivers/char/tpm/tpm_tis.ko
-    mknod /dev/tpm0 c 10 224
+    modprobe tpm_tis
     echo -n "initramfs measuring $ROOT_DEVICE ...  "
     s=$(sha1sum $ROOT_DEVICE)
     echo "done"


### PR DESCRIPTION
use modprobe instead of insmods, TPM modules should be reported in
modules.dep, and depmod should have been run at initramfs image
creation.

The tpm_tis module will create the dev node.

OXT-899