### PR TITLE
OXT-923: Do not store WPA PSK keys in plaintext in the dom-store.

### DIFF
--- a/recipes-connectivity/network-manager-applet/network-manager-applet/always-use-psk-hash.patch
+++ b/recipes-connectivity/network-manager-applet/network-manager-applet/always-use-psk-hash.patch
@@ -1,0 +1,48 @@
+--- network-manager-applet-0.9.2.0/src/wireless-security/ws-wpa-psk.c	2017-01-13 10:49:45.618800964 -0500
++++ network-manager-applet-0.9.2.0/src/wireless-security/ws-wpa-psk.c	2017-01-17 15:54:49.099333090 -0500
+@@ -27,6 +27,8 @@
+ #include "wireless-security.h"
+ #include "helpers.h"
+ 
++#include <openssl/evp.h>
++
+ #define WPA_PMK_LEN 32
+ 
+ struct _WirelessSecurityWPAPSK {
+@@ -87,6 +89,17 @@
+ 	gtk_size_group_add_widget (group, widget);
+ }
+ 
++//adapted from stackoverflow.com/a/22795472
++static void
++PBKDF2_HMAC_SHA_1nat_string (const char* pass, const char* salt, int iterations, unsigned int outputBytes, char* hexResult)
++{
++    unsigned int i;
++    unsigned char digest[outputBytes];
++    PKCS5_PBKDF2_HMAC_SHA1 (pass, strlen (pass), (const unsigned char*) salt, strlen (salt), iterations, outputBytes, digest);
++    for (i = 0; i < sizeof (digest); i++)
++        snprintf (hexResult + (i * 2), 3, "%02x", digest[i]);
++}
++
+ static void
+ fill_connection (WirelessSecurity *parent, NMConnection *connection)
+ {
+@@ -112,6 +125,18 @@
+ 
+ 	widget = GTK_WIDGET (gtk_builder_get_object (parent->builder, "wpa_psk_entry"));
+ 	key = gtk_entry_get_text (GTK_ENTRY (widget));
++
++	if (strlen (key) < 64) {
++		char keyHash[64 + 1];
++		const GByteArray *ssid = nm_setting_wireless_get_ssid (s_wireless);
++		GString *ssidNullTerminated = g_string_new_len ((const gchar *)ssid->data, ssid->len);
++
++		PBKDF2_HMAC_SHA_1nat_string (key, ssidNullTerminated->str, 4096, 32, keyHash);
++		key = keyHash;
++
++		g_string_free (ssidNullTerminated, TRUE);
++	}
++
+ 	g_object_set (s_wireless_sec, NM_SETTING_WIRELESS_SECURITY_PSK, key, NULL);
+ 
+ 	wireless_security_clear_ciphers (connection);

--- a/recipes-connectivity/network-manager-applet/network-manager-applet/disable-show-password.patch
+++ b/recipes-connectivity/network-manager-applet/network-manager-applet/disable-show-password.patch
@@ -1,0 +1,39 @@
+--- network-manager-applet-0.9.2.0/src/wireless-security/wireless-security.c	2017-01-13 10:50:54.830968023 -0500
++++ network-manager-applet-0.9.2.0/src/wireless-security/wireless-security.c	2017-01-16 15:23:41.424841517 -0500
+@@ -37,6 +37,20 @@
+ #include "wireless-security.h"
+ #include "eap-method.h"
+ 
++static void
++removeCheckboxes (GtkBuilder *builder)
++{
++	GSList *objects;
++	const char showCheckbuttonPrefix[] = "show_checkbutton_";
++
++	for (objects = gtk_builder_get_objects (builder); objects != NULL; objects = objects->next) {
++		const gchar *id = gtk_buildable_get_name (objects->data);
++		if (id && strncmp (id, showCheckbuttonPrefix, sizeof (showCheckbuttonPrefix) - 1) == 0)
++			gtk_widget_hide (GTK_WIDGET (objects->data));
++	}
++	g_slist_free(objects);
++}
++
+ GType
+ wireless_security_get_g_type (void)
+ {
+@@ -197,6 +211,7 @@
+ 	}
+ 	g_object_ref_sink (sec->ui_widget);
+ 
++	removeCheckboxes (sec->builder);
+ 	return sec;
+ }
+ 
+@@ -314,6 +329,7 @@
+ 		if (eap_default_widget)
+ 			gtk_widget_grab_focus (eap_default_widget);
+ 	}
++	removeCheckboxes (eap->builder);
+ 
+ 	eap_method_unref (eap);
+ 

--- a/recipes-connectivity/network-manager-applet/network-manager-applet/disable-show-password.patch
+++ b/recipes-connectivity/network-manager-applet/network-manager-applet/disable-show-password.patch
@@ -1,39 +1,50 @@
---- network-manager-applet-0.9.2.0/src/wireless-security/wireless-security.c	2017-01-13 10:50:54.830968023 -0500
-+++ network-manager-applet-0.9.2.0/src/wireless-security/wireless-security.c	2017-01-16 15:23:41.424841517 -0500
-@@ -37,6 +37,20 @@
- #include "wireless-security.h"
- #include "eap-method.h"
+--- network-manager-applet-0.9.2.0/src/wireless-security/ws-wpa-psk.c	2017-01-17 15:54:49.099333090 -0500
++++ network-manager-applet-0.9.2.0/src/wireless-security/ws-wpa-psk.c	2017-03-09 16:42:05.820231216 -0500
+@@ -36,6 +36,24 @@
+ };
  
-+static void
-+removeCheckboxes (GtkBuilder *builder)
+ static void
++setCheckboxVisibility (GtkBuilder *builder, gboolean visible)
 +{
 +	GSList *objects;
 +	const char showCheckbuttonPrefix[] = "show_checkbutton_";
 +
 +	for (objects = gtk_builder_get_objects (builder); objects != NULL; objects = objects->next) {
 +		const gchar *id = gtk_buildable_get_name (objects->data);
-+		if (id && strncmp (id, showCheckbuttonPrefix, sizeof (showCheckbuttonPrefix) - 1) == 0)
-+			gtk_widget_hide (GTK_WIDGET (objects->data));
++		if (id && strncmp (id, showCheckbuttonPrefix, sizeof (showCheckbuttonPrefix) - 1) == 0) {
++			if (visible)
++				gtk_widget_show (GTK_WIDGET (objects->data));
++			else
++				gtk_widget_hide (GTK_WIDGET (objects->data));
++		}
 +	}
 +	g_slist_free(objects);
 +}
 +
- GType
- wireless_security_get_g_type (void)
++static void
+ show_toggled_cb (GtkCheckButton *button, WirelessSecurity *sec)
  {
-@@ -197,6 +211,7 @@
+ 	GtkWidget *widget;
+@@ -61,8 +79,6 @@
+ 
+ 	key = gtk_entry_get_text (GTK_ENTRY (entry));
+ 	len = strlen (key);
+-	if ((len < 8) || (len > 64))
+-		return FALSE;
+ 
+ 	if (len == 64) {
+ 		/* Hex PSK */
+@@ -70,7 +86,13 @@
+ 			if (!isxdigit (key[i]))
+ 				return FALSE;
+ 		}
++		setCheckboxVisibility(parent->builder, FALSE);
  	}
- 	g_object_ref_sink (sec->ui_widget);
++	else
++		setCheckboxVisibility(parent->builder, TRUE);
++
++	if ((len < 8) || (len > 64))
++		return FALSE;
  
-+	removeCheckboxes (sec->builder);
- 	return sec;
- }
- 
-@@ -314,6 +329,7 @@
- 		if (eap_default_widget)
- 			gtk_widget_grab_focus (eap_default_widget);
- 	}
-+	removeCheckboxes (eap->builder);
- 
- 	eap_method_unref (eap);
+ 	/* passphrase can be between 8 and 63 characters inclusive */
  

--- a/recipes-connectivity/network-manager-applet/network-manager-applet_0.9.2.0.bb
+++ b/recipes-connectivity/network-manager-applet/network-manager-applet_0.9.2.0.bb
@@ -2,7 +2,9 @@ DESCRIPTION = "GTK+ applet for NetworkManager"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
 
-DEPENDS = "gnome-bluetooth libnotify networkmanager dbus-glib libglade gconf gnome-keyring libgnome-keyring iso-codes"
+DEPENDS = "gnome-bluetooth libnotify networkmanager dbus-glib libglade gconf gnome-keyring libgnome-keyring iso-codes openssl"
+
+LDFLAGS += "-lcrypto"
 
 inherit gnome
 

--- a/recipes-connectivity/network-manager-applet/network-manager-applet_0.9.2.0.bbappend
+++ b/recipes-connectivity/network-manager-applet/network-manager-applet_0.9.2.0.bbappend
@@ -36,6 +36,7 @@ SRC_URI += " \
            file://disable_available_to_all_users_checkbox.patch;patch=1 \
            file://default-certs-dir.patch;patch=1 \
            file://always-use-psk-hash.patch;patch=1 \
+           file://disable-show-password.patch;patch=1 \
            file://nm-signal-00.png \
            file://nm-signal-25.png \
            file://nm-signal-50.png \

--- a/recipes-connectivity/network-manager-applet/network-manager-applet_0.9.2.0.bbappend
+++ b/recipes-connectivity/network-manager-applet/network-manager-applet_0.9.2.0.bbappend
@@ -35,6 +35,7 @@ SRC_URI += " \
            file://xc-menus.patch;patch=1 \
            file://disable_available_to_all_users_checkbox.patch;patch=1 \
            file://default-certs-dir.patch;patch=1 \
+           file://always-use-psk-hash.patch;patch=1 \
            file://nm-signal-00.png \
            file://nm-signal-25.png \
            file://nm-signal-50.png \


### PR DESCRIPTION
This patches network-manager-applet so that PSK passwords are only ever dealt with in their hashed form. A separate commit also disables the "show password" checkboxes.