### PR TITLE
dom0-tweaks: remove FIXME from command lines

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
@@ -36,9 +36,9 @@ LINUX_COMMON_CMD="console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapp
 menuentry "XenClient: Normal" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD autostart
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
+        module /boot/bzImage $LINUX_COMMON_CMD autostart
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -60,9 +60,9 @@ menuentry "XenClient: Normal" {
 menuentry "XenClient Technical Support Option: Safe graphics" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD autostart safe-graphic nomodeset
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
+        module /boot/bzImage $LINUX_COMMON_CMD autostart safe-graphic nomodeset
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -81,9 +81,9 @@ menuentry "XenClient Technical Support Option: Safe graphics" {
 menuentry "XenClient Technical Support Option: Safe Mode (no autostart of VMs)" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
+        module /boot/bzImage $LINUX_COMMON_CMD
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -103,9 +103,9 @@ menuentry "XenClient Technical Support Option: Safe Mode (no autostart of VMs)" 
 menuentry "XenClient Technical Support Option: Safe Mode with AMT serial" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD com1=115200,8n1,pci console=com1 com1=115200,8n1,amt
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD com1=115200,8n1,pci console=com1 com1=115200,8n1,amt
+        module /boot/bzImage $LINUX_COMMON_CMD
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -125,9 +125,9 @@ menuentry "XenClient Technical Support Option: Safe Mode with AMT serial" {
 menuentry "XenClient Technical Support Option: Normal Mode with synchronised console" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD com1=115200,8n1,pci console=com1 sync_console
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD autostart
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD com1=115200,8n1,pci console=com1 sync_console
+        module /boot/bzImage $LINUX_COMMON_CMD autostart
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -147,9 +147,9 @@ menuentry "XenClient Technical Support Option: Normal Mode with synchronised con
 menuentry "XenClient Technical Support Option: console access" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD com1=115200,8n1,pci
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD console=tty0 no-graphics fbcon
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD com1=115200,8n1,pci
+        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 no-graphics fbcon
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -169,9 +169,9 @@ menuentry "XenClient Technical Support Option: console access" {
 menuentry "XenClient Technical Support Option: console access with AMT serial" {
         background_image /grub/booting.png
         set root=lvm/xenclient-root
-        multiboot /boot/tboot.gz FIXME $TBOOT_COMMON_CMD
-        module /boot/xen-debug.gz FIXME $XEN_COMMON_CMD console=com1,vga com1=115200,8n1,amt
-        module /boot/bzImage FIXME $LINUX_COMMON_CMD console=tty0 no-graphics fbcon
+        multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
+        module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1,vga com1=115200,8n1,amt
+        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 no-graphics fbcon
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN


### PR DESCRIPTION
It is no longer necessary to use the FIXME postional holder.

OXT-920

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>