### PR TITLE
[libxl] Fix tapdisk cleanup

### DIFF
--- a/recipes-extended/xen/files/libxl-do-not-destroy-in-use-tapdevs.patch
+++ b/recipes-extended/xen/files/libxl-do-not-destroy-in-use-tapdevs.patch
@@ -40,7 +40,7 @@ Index: xen-4.6.4/tools/libxl/libxl_blktap2.c
 ===================================================================
 --- xen-4.6.4.orig/tools/libxl/libxl_blktap2.c
 +++ xen-4.6.4/tools/libxl/libxl_blktap2.c
-@@ -50,6 +50,35 @@ char *libxl__blktap_devpath(libxl__gc *g
+@@ -50,6 +50,37 @@ char *libxl__blktap_devpath(libxl__gc *g
      return NULL;
  }
  
@@ -48,6 +48,7 @@ Index: xen-4.6.4/tools/libxl/libxl_blktap2.c
 +{
 +    char **domids, **vbds;
 +    char *tp;
++    char *type;
 +    unsigned int count1, count2, i, j;
 +    unsigned int total = 0;
 +
@@ -61,7 +62,8 @@ Index: xen-4.6.4/tools/libxl/libxl_blktap2.c
 +                for (j = 0; j < count2; ++j) {
 +                    /* If the params are the same, we have a match */
 +                    tp = libxl__xs_read(gc, XBT_NULL, libxl__sprintf(gc, "backend/vbd/%s/%s/tapdisk-params", domids[i], vbds[j]));
-+                    if (tp != NULL && !strcmp(tp, params)) {
++                    type = libxl__xs_read(gc, XBT_NULL, libxl__sprintf(gc, "backend/vbd/%s/%s/device-type", domids[i], vbds[j]));
++                    if (tp != NULL && type != NULL && !strcmp(tp, params) && !strcmp(type, "cdrom")) {
 +                        total++;
 +                        if (total == 2)
 +                            return true;
@@ -76,7 +78,7 @@ Index: xen-4.6.4/tools/libxl/libxl_blktap2.c
  
  int libxl__device_destroy_tapdisk(libxl__gc *gc, const char *params)
  {
-@@ -74,6 +103,12 @@ int libxl__device_destroy_tapdisk(libxl_
+@@ -74,6 +105,12 @@ int libxl__device_destroy_tapdisk(libxl_
          return ERROR_FAIL;
      }
  

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -396,22 +396,6 @@ Index: xen-4.6.4/tools/libxl/xl_cmdimpl.c
      rc = libxl_domain_destroy(ctx, domid, 0);
      if (rc) { fprintf(stderr,"destroy failed (rc=%d)\n",rc); exit(-1); }
      libxl_update_state_direct(ctx, uuid, "shutdown");
-Index: xen-4.6.4/tools/libxl/libxl_device.c
-===================================================================
---- xen-4.6.4.orig/tools/libxl/libxl_device.c
-+++ xen-4.6.4/tools/libxl/libxl_device.c
-@@ -904,6 +904,11 @@ void libxl__initiate_device_remove(libxl
-             }
-         }
- 
-+        if(!libxl__xs_read_checked(gc, t, libxl__device_backend_path(gc, aodev->dev), &state))
-+        {
-+            libxl__xs_path_cleanup(gc, t, libxl__device_backend_path(gc, aodev->dev));
-+        }
-+
-         rc = libxl__xs_transaction_commit(gc, &t);
-         if (!rc) break;
-         if (rc < 0) goto out;
 Index: xen-4.6.4/tools/libxl/libxl_internal.h
 ===================================================================
 --- xen-4.6.4.orig/tools/libxl/libxl_internal.h


### PR DESCRIPTION
  This commit fixes two issues. First, we remove the call to
  clean the backend xenstore path in initiate_device_remove. When
  the devices are actually called for removal, the xs path no longer
  exists, so tapdisk destruction fails since it needs the tapdisk-params
  xs entry.  Second, the tapdisk_is_shared really should only apply to
  cdroms.  A domain and its stubdomain have the same value for
  tapdisk-params; therefore, the function will think the vhd is shared and
  the tap device will not be cleaned up.

  OXT-435

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>