### PR TITLE
[libxl] Support read-only vhds on domains with

### DIFF
--- a/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
+++ b/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
@@ -1,0 +1,43 @@
+Index: xen-4.6.4/tools/libxl/libxl_dm.c
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl_dm.c
++++ xen-4.6.4/tools/libxl/libxl_dm.c
+@@ -1148,11 +1148,6 @@ static int libxl__build_device_model_arg
+                         (gc, "file=%s,if=ide,index=%d,readonly=%s,media=cdrom,format=%s,cache=writeback,id=ide-%i",
+                          disks[i].pdev_path, disk, disks[i].readwrite ? "off" : "on", format, dev_number);
+             } else {
+-                if (!disks[i].readwrite) {
+-                    LIBXL__LOG(ctx, LIBXL__LOG_ERROR, "qemu-xen doesn't support read-only disk drivers");
+-                    return ERROR_INVAL;
+-                }
+-
+                 if (disks[i].format == LIBXL_DISK_FORMAT_EMPTY) {
+                     LIBXL__LOG(ctx, LIBXL__LOG_WARNING, "cannot support"
+                                " empty disk format for %s", disks[i].vdev);
+@@ -1192,14 +1187,21 @@ static int libxl__build_device_model_arg
+                     continue;
+                 }
+                 else if (disk < 4) {
+-                    if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX)
+-                        drive = libxl__sprintf
+-                                (gc, "file=%s%c,if=ide,index=%d,media=disk,cache=writeback,format=%s",
+-                                 "/dev/xvd", 'a' + disk, disk, format);
+-                    else
++                    if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {
++                        if(disks[i].readwrite) {
++                            drive = libxl__sprintf
++                                    (gc, "file=%s%c,if=ide,index=%d,media=disk,cache=writeback,format=%s",
++                                     "/dev/xvd", 'a' + disk, disk, format);
++                        } else {
++                            drive = libxl__sprintf
++                                    (gc, "file=%s%c,if=ide,index=%d,media=disk,readonly,format=%s",
++                                     "/dev/xvd", 'a' + disk, disk, format);
++                        }
++                    } else {
+                         drive = libxl__sprintf
+                                 (gc, "file=%s,if=ide,index=%d,media=disk,format=%s,cache=writeback",
+                                  pdev_path, disk, format);
++                    }
+                 }
+                 else
+                     continue; /* Do not emulate this disk */

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -76,6 +76,7 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://libxl-move-extra-qemu-args-to-the-end.patch \
     file://libxl-stubdom-options.patch \
     file://libxl-add-cores-per-socket-support.patch \
+    file://libxl-support-hvm-readonly-disks.patch \
     file://xsa-191-x86-null-segments-not-always-treated-as-unusable.patch \
     file://xsa-192-x86-task-switch-to-vm86-mode-mis-handled.patch \
     file://xsa-193-x86-segment-base-write-emulation-lacking-canonical-address-checks.patch \


### PR DESCRIPTION
  linux-based stubdoms. There is an unnecessary restriction in xl
  on enforcing rw for vhds.  As long as the filesystem in the guest
  is ok with being mounted ro, there's no reason not to support it.

  OXT-435

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>