### PR TITLE
key-functions: make rsa key ref's relative

### DIFF
--- a/recipes-openxt/openxt/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt/openxt-keymanagement/key-functions
@@ -454,6 +454,7 @@ is_xc_scheme() {
 recovery_unlock() {
     local part="${1}"
     local name="${2}"
+    local root="${3}"
 
     setup_keystore
 
@@ -462,8 +463,8 @@ recovery_unlock() {
         key=$(recovery_prompt "$tries")
 
         if is_xc_scheme; then
-            local rsa_priv_key="/boot/system/config/recovery-private-key.conf"
-            local wrapped_key="/boot/system/config/recovery-disk-key.ssl"
+            local rsa_priv_key="${root}/boot/system/config/recovery-private-key.conf"
+            local wrapped_key="${root}/boot/system/config/recovery-disk-key.ssl"
 
             cat ${key} | openssl rsautl -decrypt -inkey ${rsa_priv_key} \
               -in ${wrapped_key} -passin stdin 2>/dev/null | cryptsetup -q \


### PR DESCRIPTION
The call into recovery_unlock in certain upgrade use cases from the
old xc scheme may have the target rootfs mounted on an alternative
location. Allow the passing of the alternative mount point as the
third argument.

OXT-955

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>