### PR TITLE
OXT-580: ionice: Use util-linux recipe upstream.

### DIFF
--- a/recipes-core/util-linux/util-linux_2.26.2.bbappend
+++ b/recipes-core/util-linux/util-linux_2.26.2.bbappend
@@ -1,8 +1,0 @@
-PR .= ".1"
-
-# make ionice a separate package
-PACKAGES =+ "util-linux-ionice"
-FILES_util-linux-ionice = "${bindir}/ionice"
-PROVIDES += "util-linux-ionice"
-RRECOMMENDS_${PN} += "util-linux-ionice"
-

--- a/recipes-openxt/xenclient/xenclient-preload-hs-libs_1.0.bb
+++ b/recipes-openxt/xenclient/xenclient-preload-hs-libs_1.0.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit xenclient
-RDEPENDS_${PN} += " util-linux-ionice "
+RDEPENDS_${PN} += "util-linux"
 PACKAGES = "${PN}"
 
 SRC_URI = "file://preload \


### PR DESCRIPTION
No need to split the package if it is deployed anyway in dom0.