### PR TITLE
OXT-980: fix xenstat-disable-tmem-use patch to avoid compile warning

### DIFF
--- a/recipes-extended/xen/files/xenstat-disable-tmem-use.patch
+++ b/recipes-extended/xen/files/xenstat-disable-tmem-use.patch
@@ -52,7 +52,17 @@ Index: xen-4.6.1/tools/xenstat/libxenstat/src/xenstat.c
  
  xenstat_node *xenstat_get_node(xenstat_handle * handle, unsigned int flags)
  {
-@@ -190,9 +192,12 @@ xenstat_node *xenstat_get_node(xenstat_h
+@@ -166,7 +168,9 @@ xenstat_node *xenstat_get_node(xenstat_handle * handle, unsigned int flags)
+	xc_domaininfo_t domaininfo[DOMAIN_CHUNK_SIZE];
+	int new_domains;
+	unsigned int i;
++#ifdef TMEM_STATS
+	int rc;
++#endif
+ 
+	/* Create the node */
+	node = (xenstat_node *) calloc(1, sizeof(xenstat_node));
+@@ -190,9 +194,12 @@ xenstat_node *xenstat_get_node(xenstat_h
  	node->free_mem = ((unsigned long long)physinfo.free_pages)
  	    * handle->page_size;
  
@@ -65,7 +75,7 @@ Index: xen-4.6.1/tools/xenstat/libxenstat/src/xenstat.c
  	/* malloc(0) is not portable, so allocate a single domain.  This will
  	 * be resized below. */
  	node->domains = malloc(sizeof(xenstat_domain));
-@@ -260,7 +265,9 @@ xenstat_node *xenstat_get_node(xenstat_h
+@@ -260,7 +267,9 @@ xenstat_node *xenstat_get_node(xenstat_h
  			domain->networks = NULL;
  			domain->num_vbds = 0;
  			domain->vbds = NULL;
@@ -75,7 +85,7 @@ Index: xen-4.6.1/tools/xenstat/libxenstat/src/xenstat.c
  
  			domain++;
  			node->num_domains++;
-@@ -342,10 +349,12 @@ unsigned long long xenstat_node_free_mem
+@@ -342,10 +351,12 @@ unsigned long long xenstat_node_free_mem
  	return node->free_mem;
  }
  
@@ -88,7 +98,7 @@ Index: xen-4.6.1/tools/xenstat/libxenstat/src/xenstat.c
  
  unsigned int xenstat_node_num_domains(xenstat_node * node)
  {
-@@ -729,6 +738,7 @@ unsigned long long xenstat_vbd_wr_sects(
+@@ -729,6 +740,7 @@ unsigned long long xenstat_vbd_wr_sects(
  	return vbd->wr_sects;
  }
  
@@ -96,7 +106,7 @@ Index: xen-4.6.1/tools/xenstat/libxenstat/src/xenstat.c
  /*
   * Tmem functions
   */
-@@ -761,7 +771,7 @@ unsigned long long xenstat_tmem_succ_per
+@@ -761,7 +773,7 @@ unsigned long long xenstat_tmem_succ_per
  {
  	return tmem->succ_pers_gets;
  }


### PR DESCRIPTION
about a variable declared but not used.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>