### PR TITLE
[refpolicy] Allow tapctl to unlink xen_device_t

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/blktap.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/blktap.te
@@ -143,3 +143,10 @@ optional_policy(`
 
 # inherited descriptor to /dev/console
 init_dontaudit_use_fds(tapctl_t)
+
+gen_require(`
+	type xen_device_t;
+')
+
+allow tapctl_t xen_device_t:chr_file unlink;
+allow tapctl_t xen_device_t:blk_file unlink;


### PR DESCRIPTION
  This rule blocks service vms, such as the ndvm, from rebooting.
  The blktapX node is unable to be removed, and thus the domain
  remains in a 'creating' state indefinitely.

  OXT-954

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>