### PR TITLE
[libxl] Don't rm state node, causes xs race

### DIFF
--- a/recipes-extended/xen/files/libxl-domain-state.patch
+++ b/recipes-extended/xen/files/libxl-domain-state.patch
@@ -114,7 +114,7 @@ Index: xen-4.6.4/tools/libxl/libxl_utils.c
 ===================================================================
 --- xen-4.6.4.orig/tools/libxl/libxl_utils.c
 +++ xen-4.6.4/tools/libxl/libxl_utils.c
-@@ -1195,6 +1195,75 @@ int libxl_domid_valid_guest(uint32_t dom
+@@ -1195,6 +1195,63 @@ int libxl_domid_valid_guest(uint32_t dom
      return domid > 0 && domid < DOMID_FIRST_RESERVED;
  }
  
@@ -129,12 +129,6 @@ Index: xen-4.6.4/tools/libxl/libxl_utils.c
 +    if (!xs_write(ctx->xsh, XBT_NULL, path, state, strlen(state)))
 +    {
 +        fprintf(stderr, "Failed to write the xenstore node: %s with state: %s\n", path, state);
-+    }
-+
-+    if (!strcmp(state, "shutdown")){
-+        memset(path, 0, sizeof(path));
-+        sprintf(path, "/state/%s", uuid);
-+        xs_rm(ctx->xsh, XBT_NULL, path);
 +    }
 +
 +    return 0;
@@ -175,12 +169,6 @@ Index: xen-4.6.4/tools/libxl/libxl_utils.c
 +    if (!xs_write(ctx->xsh, XBT_NULL, path, state, strlen(state)))
 +    {
 +        fprintf(stderr, "Failed to write the xenstore node: %s with state: %s\n", path, state);
-+    }
-+
-+    if (!strcmp(state, "shutdown")){
-+        memset(path, 0, sizeof(path));
-+        sprintf(path, "/state/%s", uuid);
-+        xs_rm(ctx->xsh, XBT_NULL, path);
 +    }
 +
 +    free(dominfo);


### PR DESCRIPTION
  After shutdown, immediately removing the state node caused a race
  with listeners using xs_watch, the watch would never fire, sending
  a state update notify. The xs_rm isn't really necessary here since
  xenmgr can just cleanup the state node when/if the domain is deleted.

  OXT-1003

Signed-off-by: Chris <rogersc@ainfosec.com>