### PR TITLE
OXT-1024: Disable xenstored fault injection

### DIFF
--- a/recipes-extended/xen/files/oxenstored.conf
+++ b/recipes-extended/xen/files/oxenstored.conf
@@ -4,7 +4,9 @@
 pid-file = /var/run/xenstored.pid
 
 # Randomly failed a transaction with EAGAIN. Used for testing Xs user
-test-eagain = false
+# Note: this flag is boneheadedly inversed: "true" is the correct
+# production setting that *disables* the fault injection behaviour.
+test-eagain = true
 
 # Activate transaction merge support
 merge-activate = true


### PR DESCRIPTION
The logic within xenstored for operating on the config file flag is
inverted, so set the config value to the right value to obtain the
intended disabled behaviour.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>