### PR TITLE
OXT-1026 : Configure Xenstored logging

### DIFF
--- a/recipes-extended/xen/files/oxenstored.conf
+++ b/recipes-extended/xen/files/oxenstored.conf
@@ -22,15 +22,10 @@ quota-transaction = 10
 # Activate filed base backend
 persistent = false
 
-# Logs
-log = error;general;syslog:xenstored
-log = warn;general;syslog:xenstored
-# log = debug;io;file:/var/log/xenstored-io.log
-
 # Xenstored logs
 # xenstored-log-file = /var/log/xenstored.log
-# xenstored-log-level = null
-# xenstored-log-nb-files = 10
+# xenstored-log-level = error
+xenstored-log-nb-files = 0
 
 # Xenstored access logs
 # access-log-file = /var/log/xenstored-access.log

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
@@ -454,17 +454,19 @@ Index: refpolicy/policy/modules/contrib/xen.te
  setattr_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  manage_sock_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  logging_log_filetrans(xenstored_t, xenstored_var_log_t, { sock_file file dir })
-@@ -447,6 +550,9 @@ kernel_read_xen_state(xenstored_t)
+@@ -447,6 +550,11 @@ kernel_read_xen_state(xenstored_t)
  dev_filetrans_xen(xenstored_t)
  dev_rw_xen(xenstored_t)
  dev_read_sysfs(xenstored_t)
 +dev_create_generic_dirs(xenstored_t)
 +dev_manage_xen(xenstored_t)
 +corecmd_search_bin(xenstored_t)
++kernel_read_fs_sysctls(xenstored_t)
++virt_search_dirs(xenstored_t)
  
  files_read_etc_files(xenstored_t)
  files_read_usr_files(xenstored_t)
-@@ -454,7 +560,12 @@ files_read_usr_files(xenstored_t)
+@@ -454,7 +562,12 @@ files_read_usr_files(xenstored_t)
  fs_search_xenfs(xenstored_t)
  fs_manage_xenfs_files(xenstored_t)
  
@@ -477,7 +479,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  init_use_fds(xenstored_t)
  init_use_script_ptys(xenstored_t)
-@@ -473,8 +584,8 @@ xen_append_log(xenstored_t)
+@@ -473,8 +586,8 @@ xen_append_log(xenstored_t)
  allow xm_t self:capability { setpcap dac_override ipc_lock sys_nice sys_tty_config };
  allow xm_t self:process { getcap getsched setsched setcap signal };
  allow xm_t self:fifo_file rw_fifo_file_perms;
@@ -488,7 +490,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
  manage_fifo_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
-@@ -544,6 +655,10 @@ miscfiles_read_localization(xm_t)
+@@ -544,6 +657,10 @@ miscfiles_read_localization(xm_t)
  
  sysnet_dns_name_resolve(xm_t)
  
@@ -499,7 +501,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  tunable_policy(`xen_use_fusefs',`
  	fs_manage_fusefs_dirs(xm_t)
  	fs_manage_fusefs_files(xm_t)
-@@ -601,4 +716,23 @@ optional_policy(`
+@@ -601,4 +718,23 @@ optional_policy(`
  
  	fs_manage_xenfs_dirs(xm_ssh_t)
  	fs_manage_xenfs_files(xm_ssh_t)


### PR DESCRIPTION
Update OCaml Xenstored config file log settings.
Grant SELinux permissions required by the daemon.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>