### PR TITLE
OXT-1050: Attend errors in stub-domain init script

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
@@ -43,7 +43,20 @@ mount -t proc proc /proc
 mount -t xenfs none /proc/xen
 mount -t sysfs sysfs /sys
 
-lsmod
+# Cmdline parsing.
+KERNEL_CMDLINE=`cat /proc/cmdline`
+for arg in $KERNEL_CMDLINE; do
+    case "$arg" in
+        guest_agent=*) AGENT=${arg##*=} ;;
+        guest_domid=*)  DOMID=${arg##*=} ;;
+        debug) LOGLVL="1";;
+        *) continue ;;
+    esac
+done
+
+if [ "${LOGLVL}" = "debug" ]; then
+    cut -f1,2,3,4,5 -d ' ' /proc/modules
+fi
 
 echo "0" > /sys/bus/pci/drivers_autoprobe
 for pci_dev in `ls /sys/bus/pci/devices/`
@@ -66,16 +79,6 @@ export USE_INTEL_SB=1
 export INTEL_DBUS=1
 
 rsyslogd -f /etc/rsyslog.conf
-
-# Agent cmdline parsing.
-KERNEL_CMDLINE=`cat /proc/cmdline`
-for arg in $KERNEL_CMDLINE; do
-    case "$arg" in
-        guest_agent=*) AGENT=${arg##*=} ;;
-        guest_domid=*)  DOMID=${arg##*=} ;;
-        *) continue ;;
-    esac
-done
 
 # Start requested agent.
 case "$AGENT" in

--- a/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
@@ -99,9 +99,8 @@ case "$AGENT" in
             KERNEL_CMDLINE_STRIPPED="${KERNEL_CMDLINE##*openxt_qemu_args=\"}"
             # Remove the last quote of the qemu args and everything after
             QEMU_CMDLINE="${KERNEL_CMDLINE_STRIPPED%%\"*}"
-            DOMID=`echo $QEMU_CMDLINE | cut -d' ' -f2 `
-            echo "Invoking qemu wrapper with QEMU_CMDLINE = ${QEMU_CMDLINE}"
-            /usr/bin/qemu-dm-wrapper ${DOMID} ${QEMU_CMDLINE}
+            echo "Invoking qemu with QEMU_CMDLINE = ${QEMU_CMDLINE}"
+            /usr/bin/qemu-system-i386 ${QEMU_CMDLINE}
             poweroff
         fi
         ;;

--- a/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
@@ -63,14 +63,13 @@ for pci_dev in `ls /sys/bus/pci/devices/`
 do
  if [ -e /sys/bus/pci/devices/$pci_dev/driver/unbind ]
  then
-    echo pci device $pci_dev is bound, unbounding it!
+    echo "pci device $pci_dev is bound, unbind it!"
     echo "$pci_dev" > /sys/bus/pci/devices/$pci_dev/driver/unbind
  fi
 done
 
 ln -s /proc/self/fd/2 /dev/stderr
 
-echo $*
 echo 1 > /proc/sys/net/ipv4/ip_forward
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 

--- a/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/xenclient-stubdomain/init.sh
@@ -65,7 +65,7 @@ mkdir -p /var/run
 export USE_INTEL_SB=1
 export INTEL_DBUS=1
 
-rsyslogd -f /etc/rsyslog.conf -c4
+rsyslogd -f /etc/rsyslog.conf
 
 # Agent cmdline parsing.
 KERNEL_CMDLINE=`cat /proc/cmdline`


### PR DESCRIPTION
Silence warning and errors in the stub-domain output while using tools and binaries available in the stub-domain current initramfs.
Also change debug output to be configurable through "debug" kernel cmdline argument.