### PR TITLE
OXT-1047: xen-libxl: Do not build tests.

### DIFF
--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -67,6 +67,7 @@ FILES_${PN}-staticdev = " \
 
 EXTRA_OEMAKE += "CROSS_SYS_ROOT=${STAGING_DIR_HOST} CROSS_COMPILE=${HOST_PREFIX}"
 EXTRA_OEMAKE += "CONFIG_IOEMU=n"
+EXTRA_OEMAKE += "CONFIG_TESTS=n"
 EXTRA_OEMAKE += "DESTDIR=${D}"
 
 #Make sure we disable all compiler optimizations to avoid a nasty segfault in the 


### PR DESCRIPTION
Add CONFIG_TESTS=n to avoid building tests when building xen tools.