### PR TITLE
OXT-1051: linux-openxt: micro-upgrade to 4.9.18

### DIFF
--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-dom0/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-dom0/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.11 Kernel Configuration
+# Linux/x86 4.9.18 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-ndvm/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-ndvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.11 Kernel Configuration
+# Linux/x86 4.9.18 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-nilfvm/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-nilfvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.11 Kernel Configuration
+# Linux/x86 4.9.18 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-stubdomain/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-stubdomain/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.11 Kernel Configuration
+# Linux/x86 4.9.18 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-syncvm/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-syncvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.11 Kernel Configuration
+# Linux/x86 4.9.18 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-uivm/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-uivm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.11 Kernel Configuration
+# Linux/x86 4.9.18 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.9/linux-openxt_4.9.18.bb
+++ b/recipes-kernel/linux/4.9/linux-openxt_4.9.18.bb
@@ -47,7 +47,7 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://defconfig \
     "
 
-SRC_URI[kernel.md5sum] = "98761ce71c603199fe6fcce600c60772"
-SRC_URI[kernel.sha256sum] = "512fc1089078e8c08741b9b48427c46c47afc2087f22e4668cca1f211742f2b3"
+SRC_URI[kernel.md5sum] = "40807e59b9609f89a0a6791b34e34416"
+SRC_URI[kernel.sha256sum] = "a10eea12a85667636ea2503aebcdae3005c821333c489fc54e2a4e9fc44261d1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"

--- a/recipes-kernel/linux/4.9/patches/acpi-video-delay-init.patch
+++ b/recipes-kernel/linux/4.9/patches/acpi-video-delay-init.patch
@@ -34,10 +34,10 @@ xenclient-dom0-tweak adds delay_init on grub's kernel cmdline.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/acpi/acpi_video.c
+Index: linux-4.9.18/drivers/acpi/acpi_video.c
 ===================================================================
---- linux-4.9.11.orig/drivers/acpi/acpi_video.c
-+++ linux-4.9.11/drivers/acpi/acpi_video.c
+--- linux-4.9.18.orig/drivers/acpi/acpi_video.c
++++ linux-4.9.18/drivers/acpi/acpi_video.c
 @@ -90,6 +90,9 @@ module_param(device_id_scheme, bool, 044
  static bool only_lcd = false;
  module_param(only_lcd, bool, 0444);

--- a/recipes-kernel/linux/4.9/patches/allow-service-vms.patch
+++ b/recipes-kernel/linux/4.9/patches/allow-service-vms.patch
@@ -35,10 +35,10 @@ NDVM and NILFVM kernels have XEN_BACKEND in their defconfig.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/xen/Kconfig
+Index: linux-4.9.18/drivers/xen/Kconfig
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/Kconfig
-+++ linux-4.9.11/drivers/xen/Kconfig
+--- linux-4.9.18.orig/drivers/xen/Kconfig
++++ linux-4.9.18/drivers/xen/Kconfig
 @@ -101,7 +101,6 @@ config XEN_DEV_EVTCHN
  
  config XEN_BACKEND

--- a/recipes-kernel/linux/4.9/patches/blktap2.patch
+++ b/recipes-kernel/linux/4.9/patches/blktap2.patch
@@ -36,10 +36,10 @@ Guest block devices handling.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/block/Kconfig
+Index: linux-4.9.18/drivers/block/Kconfig
 ===================================================================
---- linux-4.9.11.orig/drivers/block/Kconfig
-+++ linux-4.9.11/drivers/block/Kconfig
+--- linux-4.9.18.orig/drivers/block/Kconfig
++++ linux-4.9.18/drivers/block/Kconfig
 @@ -537,4 +537,13 @@ config BLK_DEV_RSXX
  	  To compile this driver as a module, choose M here: the
  	  module will be called rsxx.
@@ -54,10 +54,10 @@ Index: linux-4.9.11/drivers/block/Kconfig
 +         as files, in memory, or on other hosts across the network.
 +
  endif # BLK_DEV
-Index: linux-4.9.11/drivers/block/Makefile
+Index: linux-4.9.18/drivers/block/Makefile
 ===================================================================
---- linux-4.9.11.orig/drivers/block/Makefile
-+++ linux-4.9.11/drivers/block/Makefile
+--- linux-4.9.18.orig/drivers/block/Makefile
++++ linux-4.9.18/drivers/block/Makefile
 @@ -28,6 +28,7 @@ obj-$(CONFIG_BLK_DEV_UMEM)	+= umem.o
  obj-$(CONFIG_BLK_DEV_NBD)	+= nbd.o
  obj-$(CONFIG_BLK_DEV_CRYPTOLOOP) += cryptoloop.o
@@ -66,18 +66,18 @@ Index: linux-4.9.11/drivers/block/Makefile
  
  obj-$(CONFIG_BLK_DEV_SX8)	+= sx8.o
  obj-$(CONFIG_BLK_DEV_HD)	+= hd.o
-Index: linux-4.9.11/drivers/block/blktap/Makefile
+Index: linux-4.9.18/drivers/block/blktap/Makefile
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/Makefile
++++ linux-4.9.18/drivers/block/blktap/Makefile
 @@ -0,0 +1,3 @@
 +obj-$(CONFIG_BLK_DEV_TAP) := blktap.o
 +
 +blktap-objs := control.o ring.o device.o request.o sysfs.o
-Index: linux-4.9.11/drivers/block/blktap/blktap.h
+Index: linux-4.9.18/drivers/block/blktap/blktap.h
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/blktap.h
++++ linux-4.9.18/drivers/block/blktap/blktap.h
 @@ -0,0 +1,175 @@
 +#ifndef _BLKTAP_H_
 +#define _BLKTAP_H_
@@ -254,10 +254,10 @@ Index: linux-4.9.11/drivers/block/blktap/blktap.h
 +
 +
 +#endif
-Index: linux-4.9.11/drivers/block/blktap/control.c
+Index: linux-4.9.18/drivers/block/blktap/control.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/control.c
++++ linux-4.9.18/drivers/block/blktap/control.c
 @@ -0,0 +1,358 @@
 +#include <linux/module.h>
 +#include <linux/sched.h>
@@ -617,10 +617,10 @@ Index: linux-4.9.11/drivers/block/blktap/control.c
 +module_init(blktap_init);
 +module_exit(blktap_exit);
 +MODULE_LICENSE("Dual BSD/GPL");
-Index: linux-4.9.11/drivers/block/blktap/device.c
+Index: linux-4.9.18/drivers/block/blktap/device.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/device.c
++++ linux-4.9.18/drivers/block/blktap/device.c
 @@ -0,0 +1,684 @@
 +#include <linux/fs.h>
 +#include <linux/blkdev.h>
@@ -1306,10 +1306,10 @@ Index: linux-4.9.11/drivers/block/blktap/device.c
 +	if (blktap_device_major)
 +		unregister_blkdev(blktap_device_major, "tapdev");
 +}
-Index: linux-4.9.11/drivers/block/blktap/request.c
+Index: linux-4.9.18/drivers/block/blktap/request.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/request.c
++++ linux-4.9.18/drivers/block/blktap/request.c
 @@ -0,0 +1,419 @@
 +#include <linux/mempool.h>
 +#include <linux/spinlock.h>
@@ -1730,10 +1730,10 @@ Index: linux-4.9.11/drivers/block/blktap/request.c
 +		request_cache = NULL;
 +	}
 +}
-Index: linux-4.9.11/drivers/block/blktap/ring.c
+Index: linux-4.9.18/drivers/block/blktap/ring.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/ring.c
++++ linux-4.9.18/drivers/block/blktap/ring.c
 @@ -0,0 +1,806 @@
 +
 +#include <linux/device.h>
@@ -2541,10 +2541,10 @@ Index: linux-4.9.11/drivers/block/blktap/ring.c
 +
 +	blktap_ring_major = 0;
 +}
-Index: linux-4.9.11/drivers/block/blktap/sysfs.c
+Index: linux-4.9.18/drivers/block/blktap/sysfs.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/block/blktap/sysfs.c
++++ linux-4.9.18/drivers/block/blktap/sysfs.c
 @@ -0,0 +1,359 @@
 +#include <linux/types.h>
 +#include <linux/device.h>
@@ -2905,10 +2905,10 @@ Index: linux-4.9.11/drivers/block/blktap/sysfs.c
 +
 +	return err;
 +}
-Index: linux-4.9.11/include/linux/blktap.h
+Index: linux-4.9.18/include/linux/blktap.h
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/include/linux/blktap.h
++++ linux-4.9.18/include/linux/blktap.h
 @@ -0,0 +1,121 @@
 +/*
 + * Copyright (c) 2011, XenSource Inc.

--- a/recipes-kernel/linux/4.9/patches/break-8021d.patch
+++ b/recipes-kernel/linux/4.9/patches/break-8021d.patch
@@ -39,10 +39,10 @@ Required for 802.1X/EAPOL auth across NDVM's bridge.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/net/bridge/br_if.c
+Index: linux-4.9.18/net/bridge/br_if.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_if.c
-+++ linux-4.9.11/net/bridge/br_if.c
+--- linux-4.9.18.orig/net/bridge/br_if.c
++++ linux-4.9.18/net/bridge/br_if.c
 @@ -380,6 +380,7 @@ static struct net_bridge_port *new_nbp(s
  int br_add_bridge(struct net *net, const char *name)
  {
@@ -61,11 +61,11 @@ Index: linux-4.9.11/net/bridge/br_if.c
  	dev_net_set(dev, net);
  	dev->rtnl_link_ops = &br_link_ops;
  
-Index: linux-4.9.11/net/bridge/br_input.c
+Index: linux-4.9.18/net/bridge/br_input.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_input.c
-+++ linux-4.9.11/net/bridge/br_input.c
-@@ -282,7 +282,8 @@ rx_handler_result_t br_handle_frame(stru
+--- linux-4.9.18.orig/net/bridge/br_input.c
++++ linux-4.9.18/net/bridge/br_input.c
+@@ -283,7 +283,8 @@ rx_handler_result_t br_handle_frame(stru
  		case 0x00:	/* Bridge Group Address */
  			/* If STP is turned off,
  			   then must forward to keep loop detection */
@@ -75,10 +75,10 @@ Index: linux-4.9.11/net/bridge/br_input.c
  			    fwd_mask & (1u << dest[5]))
  				goto forward;
  			*pskb = skb;
-Index: linux-4.9.11/net/bridge/br_private.h
+Index: linux-4.9.18/net/bridge/br_private.h
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_private.h
-+++ linux-4.9.11/net/bridge/br_private.h
+--- linux-4.9.18.orig/net/bridge/br_private.h
++++ linux-4.9.18/net/bridge/br_private.h
 @@ -356,6 +356,8 @@ struct net_bridge
  #endif /* IS_ENABLED(CONFIG_IPV6) */
  #endif
@@ -88,10 +88,10 @@ Index: linux-4.9.11/net/bridge/br_private.h
  	struct timer_list		hello_timer;
  	struct timer_list		tcn_timer;
  	struct timer_list		topology_change_timer;
-Index: linux-4.9.11/net/bridge/br_sysfs_br.c
+Index: linux-4.9.18/net/bridge/br_sysfs_br.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_sysfs_br.c
-+++ linux-4.9.11/net/bridge/br_sysfs_br.c
+--- linux-4.9.18.orig/net/bridge/br_sysfs_br.c
++++ linux-4.9.18/net/bridge/br_sysfs_br.c
 @@ -790,6 +790,36 @@ static ssize_t vlan_stats_enabled_store(
  static DEVICE_ATTR_RW(vlan_stats_enabled);
  #endif

--- a/recipes-kernel/linux/4.9/patches/bridge-carrier-follow-prio0.patch
+++ b/recipes-kernel/linux/4.9/patches/bridge-carrier-follow-prio0.patch
@@ -1,7 +1,7 @@
-Index: linux-4.9.11/net/bridge/br_if.c
+Index: linux-4.9.18/net/bridge/br_if.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_if.c
-+++ linux-4.9.11/net/bridge/br_if.c
+--- linux-4.9.18.orig/net/bridge/br_if.c
++++ linux-4.9.18/net/bridge/br_if.c
 @@ -83,6 +83,7 @@ void br_port_carrier_check(struct net_br
  		if (p->state != BR_STATE_DISABLED)
  			br_stp_disable_port(p);
@@ -39,10 +39,10 @@ Index: linux-4.9.11/net/bridge/br_if.c
 +	}
 +	return 0;
 +}
-Index: linux-4.9.11/net/bridge/br_private.h
+Index: linux-4.9.18/net/bridge/br_private.h
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_private.h
-+++ linux-4.9.11/net/bridge/br_private.h
+--- linux-4.9.18.orig/net/bridge/br_private.h
++++ linux-4.9.18/net/bridge/br_private.h
 @@ -540,6 +540,7 @@ netdev_features_t br_features_recompute(
  					netdev_features_t features);
  void br_port_flags_change(struct net_bridge_port *port, unsigned long mask);
@@ -51,10 +51,10 @@ Index: linux-4.9.11/net/bridge/br_private.h
  
  /* br_input.c */
  int br_handle_frame_finish(struct net *net, struct sock *sk, struct sk_buff *skb);
-Index: linux-4.9.11/net/bridge/br_stp.c
+Index: linux-4.9.18/net/bridge/br_stp.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_stp.c
-+++ linux-4.9.11/net/bridge/br_stp.c
+--- linux-4.9.18.orig/net/bridge/br_stp.c
++++ linux-4.9.18/net/bridge/br_stp.c
 @@ -470,8 +470,13 @@ void br_port_state_selection(struct net_
  
  	if (liveports == 0)
@@ -71,10 +71,10 @@ Index: linux-4.9.11/net/bridge/br_stp.c
  }
  
  /* called under bridge lock */
-Index: linux-4.9.11/net/bridge/br_stp_if.c
+Index: linux-4.9.18/net/bridge/br_stp_if.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_stp_if.c
-+++ linux-4.9.11/net/bridge/br_stp_if.c
+--- linux-4.9.18.orig/net/bridge/br_stp_if.c
++++ linux-4.9.18/net/bridge/br_stp_if.c
 @@ -334,6 +334,7 @@ int br_stp_set_port_priority(struct net_
  		br_port_state_selection(p->br);
  	}
@@ -83,10 +83,10 @@ Index: linux-4.9.11/net/bridge/br_stp_if.c
  	return 0;
  }
  
-Index: linux-4.9.11/net/bridge/br_sysfs_br.c
+Index: linux-4.9.18/net/bridge/br_sysfs_br.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_sysfs_br.c
-+++ linux-4.9.11/net/bridge/br_sysfs_br.c
+--- linux-4.9.18.orig/net/bridge/br_sysfs_br.c
++++ linux-4.9.18/net/bridge/br_sysfs_br.c
 @@ -334,6 +334,23 @@ static ssize_t flush_store(struct device
  }
  static DEVICE_ATTR_WO(flush);

--- a/recipes-kernel/linux/4.9/patches/disable-csum-xennet.patch
+++ b/recipes-kernel/linux/4.9/patches/disable-csum-xennet.patch
@@ -34,10 +34,10 @@ Unknown.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/net/xen-netback/interface.c
+Index: linux-4.9.18/drivers/net/xen-netback/interface.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/xen-netback/interface.c
-+++ linux-4.9.11/drivers/net/xen-netback/interface.c
+--- linux-4.9.18.orig/drivers/net/xen-netback/interface.c
++++ linux-4.9.18/drivers/net/xen-netback/interface.c
 @@ -463,9 +463,7 @@ struct xenvif *xenvif_alloc(struct devic
  	INIT_LIST_HEAD(&vif->fe_mcast_addr);
  
@@ -49,10 +49,10 @@ Index: linux-4.9.11/drivers/net/xen-netback/interface.c
  	dev->features = dev->hw_features | NETIF_F_RXCSUM;
  	dev->ethtool_ops = &xenvif_ethtool_ops;
  
-Index: linux-4.9.11/drivers/net/xen-netfront.c
+Index: linux-4.9.18/drivers/net/xen-netfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/xen-netfront.c
-+++ linux-4.9.11/drivers/net/xen-netfront.c
+--- linux-4.9.18.orig/drivers/net/xen-netfront.c
++++ linux-4.9.18/drivers/net/xen-netfront.c
 @@ -1314,11 +1314,8 @@ static struct net_device *xennet_create_
  
  	netdev->netdev_ops	= &xennet_netdev_ops;

--- a/recipes-kernel/linux/4.9/patches/dont-suspend-xen-serial-port.patch
+++ b/recipes-kernel/linux/4.9/patches/dont-suspend-xen-serial-port.patch
@@ -36,10 +36,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/tty/serial/8250/8250_pnp.c
+Index: linux-4.9.18/drivers/tty/serial/8250/8250_pnp.c
 ===================================================================
---- linux-4.9.11.orig/drivers/tty/serial/8250/8250_pnp.c
-+++ linux-4.9.11/drivers/tty/serial/8250/8250_pnp.c
+--- linux-4.9.18.orig/drivers/tty/serial/8250/8250_pnp.c
++++ linux-4.9.18/drivers/tty/serial/8250/8250_pnp.c
 @@ -457,6 +457,10 @@ serial_pnp_probe(struct pnp_dev *dev, co
  	} else if (pnp_port_valid(dev, 0)) {
  		uart.port.iobase = pnp_port_start(dev, 0);

--- a/recipes-kernel/linux/4.9/patches/export-for-xenfb2.patch
+++ b/recipes-kernel/linux/4.9/patches/export-for-xenfb2.patch
@@ -32,10 +32,10 @@ Linux headers.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/arch/x86/xen/p2m.c
+Index: linux-4.9.18/arch/x86/xen/p2m.c
 ===================================================================
---- linux-4.9.11.orig/arch/x86/xen/p2m.c
-+++ linux-4.9.11/arch/x86/xen/p2m.c
+--- linux-4.9.18.orig/arch/x86/xen/p2m.c
++++ linux-4.9.18/arch/x86/xen/p2m.c
 @@ -812,6 +812,7 @@ static int p2m_dump_open(struct inode *i
  {
  	return single_open(filp, p2m_dump_show, NULL);
@@ -44,10 +44,10 @@ Index: linux-4.9.11/arch/x86/xen/p2m.c
  
  static const struct file_operations p2m_dump_fops = {
  	.open		= p2m_dump_open,
-Index: linux-4.9.11/mm/memory.c
+Index: linux-4.9.18/mm/memory.c
 ===================================================================
---- linux-4.9.11.orig/mm/memory.c
-+++ linux-4.9.11/mm/memory.c
+--- linux-4.9.18.orig/mm/memory.c
++++ linux-4.9.18/mm/memory.c
 @@ -1400,6 +1400,7 @@ void zap_page_range(struct vm_area_struc
  	mmu_notifier_invalidate_range_end(mm, start, end);
  	tlb_finish_mmu(&tlb, start, end);
@@ -56,10 +56,10 @@ Index: linux-4.9.11/mm/memory.c
  
  /**
   * zap_page_range_single - remove user pages in a given range
-Index: linux-4.9.11/drivers/video/fbdev/Kconfig
+Index: linux-4.9.18/drivers/video/fbdev/Kconfig
 ===================================================================
---- linux-4.9.11.orig/drivers/video/fbdev/Kconfig
-+++ linux-4.9.11/drivers/video/fbdev/Kconfig
+--- linux-4.9.18.orig/drivers/video/fbdev/Kconfig
++++ linux-4.9.18/drivers/video/fbdev/Kconfig
 @@ -2256,6 +2256,16 @@ config XEN_FBDEV_FRONTEND
  	  frame buffer driver.  It communicates with a back-end
  	  in another domain.

--- a/recipes-kernel/linux/4.9/patches/extra-mt-input-devices.patch
+++ b/recipes-kernel/linux/4.9/patches/extra-mt-input-devices.patch
@@ -34,10 +34,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/hid/hid-ids.h
+Index: linux-4.9.18/drivers/hid/hid-ids.h
 ===================================================================
---- linux-4.9.11.orig/drivers/hid/hid-ids.h
-+++ linux-4.9.11/drivers/hid/hid-ids.h
+--- linux-4.9.18.orig/drivers/hid/hid-ids.h
++++ linux-4.9.18/drivers/hid/hid-ids.h
 @@ -992,6 +992,7 @@
  #define USB_VENDOR_ID_TURBOX		0x062a
  #define USB_DEVICE_ID_TURBOX_KEYBOARD	0x0201
@@ -46,10 +46,10 @@ Index: linux-4.9.11/drivers/hid/hid-ids.h
  
  #define USB_VENDOR_ID_TWINHAN		0x6253
  #define USB_DEVICE_ID_TWINHAN_IR_REMOTE	0x0100
-Index: linux-4.9.11/drivers/hid/hid-multitouch.c
+Index: linux-4.9.18/drivers/hid/hid-multitouch.c
 ===================================================================
---- linux-4.9.11.orig/drivers/hid/hid-multitouch.c
-+++ linux-4.9.11/drivers/hid/hid-multitouch.c
+--- linux-4.9.18.orig/drivers/hid/hid-multitouch.c
++++ linux-4.9.18/drivers/hid/hid-multitouch.c
 @@ -1394,6 +1394,9 @@ static const struct hid_device_id mt_dev
  	{ .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
  		MT_USB_DEVICE(USB_VENDOR_ID_TURBOX,

--- a/recipes-kernel/linux/4.9/patches/fbcon-do-not-drag-detect-primary-option.patch
+++ b/recipes-kernel/linux/4.9/patches/fbcon-do-not-drag-detect-primary-option.patch
@@ -32,10 +32,10 @@ Is required by surfman/drm-plugin.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/gpu/drm/Kconfig
+Index: linux-4.9.18/drivers/gpu/drm/Kconfig
 ===================================================================
---- linux-4.9.11.orig/drivers/gpu/drm/Kconfig
-+++ linux-4.9.11/drivers/gpu/drm/Kconfig
+--- linux-4.9.18.orig/drivers/gpu/drm/Kconfig
++++ linux-4.9.18/drivers/gpu/drm/Kconfig
 @@ -44,7 +44,6 @@ config DRM_KMS_FB_HELPER
  	depends on DRM_KMS_HELPER
  	select FB

--- a/recipes-kernel/linux/4.9/patches/gem-foreign.patch
+++ b/recipes-kernel/linux/4.9/patches/gem-foreign.patch
@@ -40,10 +40,10 @@ drm-plugin 0-copy relies on that patch to manage guest display.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/gpu/drm/i915/Makefile
+Index: linux-4.9.18/drivers/gpu/drm/i915/Makefile
 ===================================================================
---- linux-4.9.11.orig/drivers/gpu/drm/i915/Makefile
-+++ linux-4.9.11/drivers/gpu/drm/i915/Makefile
+--- linux-4.9.18.orig/drivers/gpu/drm/i915/Makefile
++++ linux-4.9.18/drivers/gpu/drm/i915/Makefile
 @@ -41,6 +41,7 @@ i915-y += i915_cmd_parser.o \
  	  i915_gem_shrinker.o \
  	  i915_gem_stolen.o \
@@ -52,10 +52,10 @@ Index: linux-4.9.11/drivers/gpu/drm/i915/Makefile
  	  i915_gem_userptr.o \
  	  i915_gpu_error.o \
  	  i915_trace_points.o \
-Index: linux-4.9.11/drivers/gpu/drm/i915/i915_drv.h
+Index: linux-4.9.18/drivers/gpu/drm/i915/i915_drv.h
 ===================================================================
---- linux-4.9.11.orig/drivers/gpu/drm/i915/i915_drv.h
-+++ linux-4.9.11/drivers/gpu/drm/i915/i915_drv.h
+--- linux-4.9.18.orig/drivers/gpu/drm/i915/i915_drv.h
++++ linux-4.9.18/drivers/gpu/drm/i915/i915_drv.h
 @@ -2289,6 +2289,14 @@ struct drm_i915_gem_object {
  
  	/** for phys allocated objects */
@@ -80,10 +80,10 @@ Index: linux-4.9.11/drivers/gpu/drm/i915/i915_drv.h
  #define I915_SHRINK_PURGEABLE 0x1
  #define I915_SHRINK_UNBOUND 0x2
  #define I915_SHRINK_BOUND 0x4
-Index: linux-4.9.11/drivers/gpu/drm/i915/i915_gem_foreign.c
+Index: linux-4.9.18/drivers/gpu/drm/i915/i915_gem_foreign.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/gpu/drm/i915/i915_gem_foreign.c
++++ linux-4.9.18/drivers/gpu/drm/i915/i915_gem_foreign.c
 @@ -0,0 +1,412 @@
 +/*
 + * Copyright © 2013 Citrix Systems, Inc.
@@ -497,10 +497,10 @@ Index: linux-4.9.11/drivers/gpu/drm/i915/i915_gem_foreign.c
 +	return 0;
 +}
 +
-Index: linux-4.9.11/include/uapi/drm/i915_drm.h
+Index: linux-4.9.18/include/uapi/drm/i915_drm.h
 ===================================================================
---- linux-4.9.11.orig/include/uapi/drm/i915_drm.h
-+++ linux-4.9.11/include/uapi/drm/i915_drm.h
+--- linux-4.9.18.orig/include/uapi/drm/i915_drm.h
++++ linux-4.9.18/include/uapi/drm/i915_drm.h
 @@ -258,6 +258,7 @@ typedef struct _drm_i915_sarea {
  #define DRM_I915_GEM_USERPTR		0x33
  #define DRM_I915_GEM_CONTEXT_GETPARAM	0x34
@@ -532,10 +532,10 @@ Index: linux-4.9.11/include/uapi/drm/i915_drm.h
  struct drm_i915_gem_userptr {
  	__u64 user_ptr;
  	__u64 user_size;
-Index: linux-4.9.11/drivers/gpu/drm/i915/i915_drv.c
+Index: linux-4.9.18/drivers/gpu/drm/i915/i915_drv.c
 ===================================================================
---- linux-4.9.11.orig/drivers/gpu/drm/i915/i915_drv.c
-+++ linux-4.9.11/drivers/gpu/drm/i915/i915_drv.c
+--- linux-4.9.18.orig/drivers/gpu/drm/i915/i915_drv.c
++++ linux-4.9.18/drivers/gpu/drm/i915/i915_drv.c
 @@ -2561,6 +2561,7 @@ static const struct drm_ioctl_desc i915_
  	DRM_IOCTL_DEF_DRV(I915_GEM_USERPTR, i915_gem_userptr_ioctl, DRM_RENDER_ALLOW),
  	DRM_IOCTL_DEF_DRV(I915_GEM_CONTEXT_GETPARAM, i915_gem_context_getparam_ioctl, DRM_RENDER_ALLOW),

--- a/recipes-kernel/linux/4.9/patches/hvc-kgdb-fix.patch
+++ b/recipes-kernel/linux/4.9/patches/hvc-kgdb-fix.patch
@@ -34,10 +34,10 @@ None, allows kgdb over hvc for debugging.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/tty/hvc/hvc_console.c
+Index: linux-4.9.18/drivers/tty/hvc/hvc_console.c
 ===================================================================
---- linux-4.9.11.orig/drivers/tty/hvc/hvc_console.c
-+++ linux-4.9.11/drivers/tty/hvc/hvc_console.c
+--- linux-4.9.18.orig/drivers/tty/hvc/hvc_console.c
++++ linux-4.9.18/drivers/tty/hvc/hvc_console.c
 @@ -808,11 +808,13 @@ static int hvc_poll_init(struct tty_driv
  static int hvc_poll_get_char(struct tty_driver *driver, int line)
  {
@@ -71,10 +71,10 @@ Index: linux-4.9.11/drivers/tty/hvc/hvc_console.c
  	} while (n <= 0);
  }
  #endif
-Index: linux-4.9.11/kernel/debug/debug_core.c
+Index: linux-4.9.18/kernel/debug/debug_core.c
 ===================================================================
---- linux-4.9.11.orig/kernel/debug/debug_core.c
-+++ linux-4.9.11/kernel/debug/debug_core.c
+--- linux-4.9.18.orig/kernel/debug/debug_core.c
++++ linux-4.9.18/kernel/debug/debug_core.c
 @@ -595,6 +595,7 @@ return_normal:
  		kgdb_roundup_cpus(flags);
  #endif

--- a/recipes-kernel/linux/4.9/patches/intel-amt-support.patch
+++ b/recipes-kernel/linux/4.9/patches/intel-amt-support.patch
@@ -1,7 +1,7 @@
-Index: linux-4.9.11/drivers/net/ethernet/intel/e1000/e1000_hw.c
+Index: linux-4.9.18/drivers/net/ethernet/intel/e1000/e1000_hw.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/ethernet/intel/e1000/e1000_hw.c
-+++ linux-4.9.11/drivers/net/ethernet/intel/e1000/e1000_hw.c
+--- linux-4.9.18.orig/drivers/net/ethernet/intel/e1000/e1000_hw.c
++++ linux-4.9.18/drivers/net/ethernet/intel/e1000/e1000_hw.c
 @@ -4303,7 +4303,7 @@ static void e1000_init_rx_addrs(struct e
  	/* Setup the receive address. */
  	e_dbg("Programming MAC Address into RAR[0]\n");
@@ -11,10 +11,10 @@ Index: linux-4.9.11/drivers/net/ethernet/intel/e1000/e1000_hw.c
  
  	rar_num = E1000_RAR_ENTRIES;
  
-Index: linux-4.9.11/drivers/net/ethernet/intel/e1000/e1000_main.c
+Index: linux-4.9.18/drivers/net/ethernet/intel/e1000/e1000_main.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/ethernet/intel/e1000/e1000_main.c
-+++ linux-4.9.11/drivers/net/ethernet/intel/e1000/e1000_main.c
+--- linux-4.9.18.orig/drivers/net/ethernet/intel/e1000/e1000_main.c
++++ linux-4.9.18/drivers/net/ethernet/intel/e1000/e1000_main.c
 @@ -2216,7 +2216,7 @@ static int e1000_set_mac(struct net_devi
  	memcpy(netdev->dev_addr, addr->sa_data, netdev->addr_len);
  	memcpy(hw->mac_addr, addr->sa_data, netdev->addr_len);
@@ -24,10 +24,10 @@ Index: linux-4.9.11/drivers/net/ethernet/intel/e1000/e1000_main.c
  
  	if (hw->mac_type == e1000_82542_rev2_0)
  		e1000_leave_82542_rst(adapter);
-Index: linux-4.9.11/drivers/net/ethernet/intel/e1000e/mac.c
+Index: linux-4.9.18/drivers/net/ethernet/intel/e1000e/mac.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/ethernet/intel/e1000e/mac.c
-+++ linux-4.9.11/drivers/net/ethernet/intel/e1000e/mac.c
+--- linux-4.9.18.orig/drivers/net/ethernet/intel/e1000e/mac.c
++++ linux-4.9.18/drivers/net/ethernet/intel/e1000e/mac.c
 @@ -135,7 +135,7 @@ void e1000e_init_rx_addrs(struct e1000_h
  	/* Setup the receive address */
  	e_dbg("Programming MAC Address into RAR[0]\n");
@@ -37,10 +37,10 @@ Index: linux-4.9.11/drivers/net/ethernet/intel/e1000e/mac.c
  
  	/* Zero out the other (rar_entry_count - 1) receive addresses */
  	e_dbg("Clearing RAR[1-%u]\n", rar_count - 1);
-Index: linux-4.9.11/drivers/net/ethernet/intel/e1000e/netdev.c
+Index: linux-4.9.18/drivers/net/ethernet/intel/e1000e/netdev.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/ethernet/intel/e1000e/netdev.c
-+++ linux-4.9.11/drivers/net/ethernet/intel/e1000e/netdev.c
+--- linux-4.9.18.orig/drivers/net/ethernet/intel/e1000e/netdev.c
++++ linux-4.9.18/drivers/net/ethernet/intel/e1000e/netdev.c
 @@ -4730,7 +4730,8 @@ static int e1000_set_mac(struct net_devi
  	memcpy(netdev->dev_addr, addr->sa_data, netdev->addr_len);
  	memcpy(adapter->hw.mac.addr, addr->sa_data, netdev->addr_len);

--- a/recipes-kernel/linux/4.9/patches/konrad-ioperm.patch
+++ b/recipes-kernel/linux/4.9/patches/konrad-ioperm.patch
@@ -41,10 +41,10 @@ PIO passthrough in PV guests.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/arch/x86/include/asm/paravirt.h
+Index: linux-4.9.18/arch/x86/include/asm/paravirt.h
 ===================================================================
---- linux-4.9.11.orig/arch/x86/include/asm/paravirt.h
-+++ linux-4.9.11/arch/x86/include/asm/paravirt.h
+--- linux-4.9.18.orig/arch/x86/include/asm/paravirt.h
++++ linux-4.9.18/arch/x86/include/asm/paravirt.h
 @@ -270,11 +270,18 @@ static inline void write_idt_entry(gate_
  {
  	PVOP_VCALL3(pv_cpu_ops.write_idt_entry, dt, entry, g);
@@ -64,10 +64,10 @@ Index: linux-4.9.11/arch/x86/include/asm/paravirt.h
  /* The paravirtualized I/O functions */
  static inline void slow_down_io(void)
  {
-Index: linux-4.9.11/arch/x86/include/asm/paravirt_types.h
+Index: linux-4.9.18/arch/x86/include/asm/paravirt_types.h
 ===================================================================
---- linux-4.9.11.orig/arch/x86/include/asm/paravirt_types.h
-+++ linux-4.9.11/arch/x86/include/asm/paravirt_types.h
+--- linux-4.9.18.orig/arch/x86/include/asm/paravirt_types.h
++++ linux-4.9.18/arch/x86/include/asm/paravirt_types.h
 @@ -140,6 +140,8 @@ struct pv_cpu_ops {
  	void (*load_sp0)(struct tss_struct *tss, struct thread_struct *t);
  
@@ -77,10 +77,10 @@ Index: linux-4.9.11/arch/x86/include/asm/paravirt_types.h
  
  	void (*wbinvd)(void);
  	void (*io_delay)(void);
-Index: linux-4.9.11/arch/x86/include/asm/processor.h
+Index: linux-4.9.18/arch/x86/include/asm/processor.h
 ===================================================================
---- linux-4.9.11.orig/arch/x86/include/asm/processor.h
-+++ linux-4.9.11/arch/x86/include/asm/processor.h
+--- linux-4.9.18.orig/arch/x86/include/asm/processor.h
++++ linux-4.9.18/arch/x86/include/asm/processor.h
 @@ -466,6 +466,9 @@ static inline void native_set_iopl_mask(
  #endif
  }
@@ -109,10 +109,10 @@ Index: linux-4.9.11/arch/x86/include/asm/processor.h
  #endif /* CONFIG_PARAVIRT */
  
  /* Free all resources held by a thread. */
-Index: linux-4.9.11/arch/x86/kernel/ioport.c
+Index: linux-4.9.18/arch/x86/kernel/ioport.c
 ===================================================================
---- linux-4.9.11.orig/arch/x86/kernel/ioport.c
-+++ linux-4.9.11/arch/x86/kernel/ioport.c
+--- linux-4.9.18.orig/arch/x86/kernel/ioport.c
++++ linux-4.9.18/arch/x86/kernel/ioport.c
 @@ -17,13 +17,29 @@
  #include <linux/bitmap.h>
  #include <asm/syscalls.h>
@@ -174,10 +174,10 @@ Index: linux-4.9.11/arch/x86/kernel/ioport.c
  
  	return 0;
  }
-Index: linux-4.9.11/arch/x86/kernel/paravirt.c
+Index: linux-4.9.18/arch/x86/kernel/paravirt.c
 ===================================================================
---- linux-4.9.11.orig/arch/x86/kernel/paravirt.c
-+++ linux-4.9.11/arch/x86/kernel/paravirt.c
+--- linux-4.9.18.orig/arch/x86/kernel/paravirt.c
++++ linux-4.9.18/arch/x86/kernel/paravirt.c
 @@ -369,6 +369,7 @@ __visible struct pv_cpu_ops pv_cpu_ops =
  	.swapgs = native_swapgs,
  
@@ -186,10 +186,10 @@ Index: linux-4.9.11/arch/x86/kernel/paravirt.c
  	.io_delay = native_io_delay,
  
  	.start_context_switch = paravirt_nop,
-Index: linux-4.9.11/arch/x86/kernel/process.c
+Index: linux-4.9.18/arch/x86/kernel/process.c
 ===================================================================
---- linux-4.9.11.orig/arch/x86/kernel/process.c
-+++ linux-4.9.11/arch/x86/kernel/process.c
+--- linux-4.9.18.orig/arch/x86/kernel/process.c
++++ linux-4.9.18/arch/x86/kernel/process.c
 @@ -106,16 +106,12 @@ void exit_thread(struct task_struct *tsk
  	struct fpu *fpu = &t->fpu;
  
@@ -235,10 +235,10 @@ Index: linux-4.9.11/arch/x86/kernel/process.c
  	propagate_user_return_notify(prev_p, next_p);
  }
  
-Index: linux-4.9.11/arch/x86/xen/enlighten.c
+Index: linux-4.9.18/arch/x86/xen/enlighten.c
 ===================================================================
---- linux-4.9.11.orig/arch/x86/xen/enlighten.c
-+++ linux-4.9.11/arch/x86/xen/enlighten.c
+--- linux-4.9.18.orig/arch/x86/xen/enlighten.c
++++ linux-4.9.18/arch/x86/xen/enlighten.c
 @@ -976,6 +976,18 @@ void xen_set_iopl_mask(unsigned mask)
  	HYPERVISOR_physdev_op(PHYSDEVOP_set_iopl, &set_iopl);
  }

--- a/recipes-kernel/linux/4.9/patches/netback-skip-frontend-wait-during-shutdown.patch
+++ b/recipes-kernel/linux/4.9/patches/netback-skip-frontend-wait-during-shutdown.patch
@@ -36,10 +36,10 @@ Service VM PV backend.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/xen/xenbus/xenbus_probe_backend.c
+Index: linux-4.9.18/drivers/xen/xenbus/xenbus_probe_backend.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xenbus/xenbus_probe_backend.c
-+++ linux-4.9.11/drivers/xen/xenbus/xenbus_probe_backend.c
+--- linux-4.9.18.orig/drivers/xen/xenbus/xenbus_probe_backend.c
++++ linux-4.9.18/drivers/xen/xenbus/xenbus_probe_backend.c
 @@ -187,6 +187,19 @@ static void frontend_changed(struct xenb
  	xenbus_otherend_changed(watch, vec, len, 0);
  }
@@ -69,10 +69,10 @@ Index: linux-4.9.11/drivers/xen/xenbus/xenbus_probe_backend.c
  		.dev_groups	= xenbus_dev_groups,
  	},
  };
-Index: linux-4.9.11/drivers/xen/xenbus/xenbus_probe.h
+Index: linux-4.9.18/drivers/xen/xenbus/xenbus_probe.h
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xenbus/xenbus_probe.h
-+++ linux-4.9.11/drivers/xen/xenbus/xenbus_probe.h
+--- linux-4.9.18.orig/drivers/xen/xenbus/xenbus_probe.h
++++ linux-4.9.18/drivers/xen/xenbus/xenbus_probe.h
 @@ -85,4 +85,11 @@ extern int xenbus_read_otherend_details(
  
  void xenbus_ring_ops_init(void);

--- a/recipes-kernel/linux/4.9/patches/netback-vwif-support.patch
+++ b/recipes-kernel/linux/4.9/patches/netback-vwif-support.patch
@@ -1,7 +1,7 @@
-Index: linux-4.9.6/drivers/net/xen-netback/xenbus.c
+Index: linux-4.9.18/drivers/net/xen-netback/xenbus.c
 ===================================================================
---- linux-4.9.6.orig/drivers/net/xen-netback/xenbus.c
-+++ linux-4.9.6/drivers/net/xen-netback/xenbus.c
+--- linux-4.9.18.orig/drivers/net/xen-netback/xenbus.c
++++ linux-4.9.18/drivers/net/xen-netback/xenbus.c
 @@ -1196,6 +1196,7 @@ static int read_xenbus_vif_flags(struct
  
  static const struct xenbus_device_id netback_ids[] = {

--- a/recipes-kernel/linux/4.9/patches/netfront-support-backend-relocate.patch
+++ b/recipes-kernel/linux/4.9/patches/netfront-support-backend-relocate.patch
@@ -37,10 +37,10 @@ Service VM PV backend.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/net/xen-netfront.c
+Index: linux-4.9.18/drivers/net/xen-netfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/xen-netfront.c
-+++ linux-4.9.11/drivers/net/xen-netfront.c
+--- linux-4.9.18.orig/drivers/net/xen-netfront.c
++++ linux-4.9.18/drivers/net/xen-netfront.c
 @@ -2028,15 +2028,26 @@ static void netback_changed(struct xenbu
  	dev_dbg(&dev->dev, "%s\n", xenbus_strstate(backend_state));
  

--- a/recipes-kernel/linux/4.9/patches/pci-pt-flr.patch
+++ b/recipes-kernel/linux/4.9/patches/pci-pt-flr.patch
@@ -39,11 +39,11 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/pci/pci.c
+Index: linux-4.9.18/drivers/pci/pci.c
 ===================================================================
---- linux-4.9.11.orig/drivers/pci/pci.c
-+++ linux-4.9.11/drivers/pci/pci.c
-@@ -3997,6 +3997,10 @@ static int __pci_dev_reset(struct pci_de
+--- linux-4.9.18.orig/drivers/pci/pci.c
++++ linux-4.9.18/drivers/pci/pci.c
+@@ -3993,6 +3993,10 @@ static int __pci_dev_reset(struct pci_de
  
  	rc = pci_parent_bus_reset(dev, probe);
  done:
@@ -54,11 +54,11 @@ Index: linux-4.9.11/drivers/pci/pci.c
  	return rc;
  }
  
-Index: linux-4.9.11/drivers/pci/quirks.c
+Index: linux-4.9.18/drivers/pci/quirks.c
 ===================================================================
---- linux-4.9.11.orig/drivers/pci/quirks.c
-+++ linux-4.9.11/drivers/pci/quirks.c
-@@ -3645,10 +3645,15 @@ static int reset_ivb_igd(struct pci_dev
+--- linux-4.9.18.orig/drivers/pci/quirks.c
++++ linux-4.9.18/drivers/pci/quirks.c
+@@ -3646,10 +3646,15 @@ static int reset_ivb_igd(struct pci_dev
  	void __iomem *mmio_base;
  	unsigned long timeout;
  	u32 val;
@@ -74,7 +74,7 @@ Index: linux-4.9.11/drivers/pci/quirks.c
  	mmio_base = pci_iomap(dev, 0, 0);
  	if (!mmio_base)
  		return -ENOMEM;
-@@ -3679,7 +3684,10 @@ reset_complete:
+@@ -3680,7 +3685,10 @@ reset_complete:
  	iowrite32(0x00000002, mmio_base + NSDE_PWR_STATE);
  
  	pci_iounmap(dev, mmio_base);
@@ -86,10 +86,10 @@ Index: linux-4.9.11/drivers/pci/quirks.c
  }
  
  /*
-Index: linux-4.9.11/drivers/xen/xen-pciback/pci_stub.c
+Index: linux-4.9.18/drivers/xen/xen-pciback/pci_stub.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xen-pciback/pci_stub.c
-+++ linux-4.9.11/drivers/xen/xen-pciback/pci_stub.c
+--- linux-4.9.18.orig/drivers/xen/xen-pciback/pci_stub.c
++++ linux-4.9.18/drivers/xen/xen-pciback/pci_stub.c
 @@ -416,10 +416,13 @@ static int pcistub_init_device(struct pc
  	if (!dev_data->pci_saved_state)
  		dev_err(&dev->dev, "Could not store PCI conf saved state!\n");

--- a/recipes-kernel/linux/4.9/patches/pci-pt-move-unaligned-resources.patch
+++ b/recipes-kernel/linux/4.9/patches/pci-pt-move-unaligned-resources.patch
@@ -35,11 +35,11 @@ PCI pass-through, depending on the device.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/pci/pci.c
+Index: linux-4.9.18/drivers/pci/pci.c
 ===================================================================
---- linux-4.9.11.orig/drivers/pci/pci.c
-+++ linux-4.9.11/drivers/pci/pci.c
-@@ -4989,6 +4989,27 @@ EXPORT_SYMBOL_GPL(pci_ignore_hotplug);
+--- linux-4.9.18.orig/drivers/pci/pci.c
++++ linux-4.9.18/drivers/pci/pci.c
+@@ -4955,6 +4955,27 @@ EXPORT_SYMBOL_GPL(pci_ignore_hotplug);
  static char resource_alignment_param[RESOURCE_ALIGNMENT_PARAM_SIZE] = {0};
  static DEFINE_SPINLOCK(resource_alignment_lock);
  
@@ -67,7 +67,7 @@ Index: linux-4.9.11/drivers/pci/pci.c
  /**
   * pci_specified_resource_alignment - get resource alignment specified by user.
   * @dev: the PCI device to get
-@@ -5076,6 +5097,8 @@ static resource_size_t pci_specified_res
+@@ -5042,6 +5063,8 @@ static resource_size_t pci_specified_res
  		}
  		p++;
  	}

--- a/recipes-kernel/linux/4.9/patches/pciback-restrictive-attr.patch
+++ b/recipes-kernel/linux/4.9/patches/pciback-restrictive-attr.patch
@@ -1,7 +1,7 @@
-Index: linux-4.9.11/drivers/xen/xen-pciback/pci_stub.c
+Index: linux-4.9.18/drivers/xen/xen-pciback/pci_stub.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xen-pciback/pci_stub.c
-+++ linux-4.9.11/drivers/xen/xen-pciback/pci_stub.c
+--- linux-4.9.18.orig/drivers/xen/xen-pciback/pci_stub.c
++++ linux-4.9.18/drivers/xen/xen-pciback/pci_stub.c
 @@ -1372,15 +1372,14 @@ out:
  static DRIVER_ATTR(quirks, S_IRUSR | S_IWUSR, pcistub_quirk_show,
  		   pcistub_quirk_add);

--- a/recipes-kernel/linux/4.9/patches/privcmd-mmapnocache-ioctl.patch
+++ b/recipes-kernel/linux/4.9/patches/privcmd-mmapnocache-ioctl.patch
@@ -45,10 +45,10 @@ xc_map_foreign_batch_cacheattr() called in QEMU, Surfman, possibly elsewhere...
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/xen/privcmd.c
+Index: linux-4.9.18/drivers/xen/privcmd.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/privcmd.c
-+++ linux-4.9.11/drivers/xen/privcmd.c
+--- linux-4.9.18.orig/drivers/xen/privcmd.c
++++ linux-4.9.18/drivers/xen/privcmd.c
 @@ -548,6 +548,48 @@ out_unlock:
  	goto out;
  }
@@ -109,10 +109,10 @@ Index: linux-4.9.11/drivers/xen/privcmd.c
  	default:
  		ret = -EINVAL;
  		break;
-Index: linux-4.9.11/include/uapi/xen/privcmd.h
+Index: linux-4.9.18/include/uapi/xen/privcmd.h
 ===================================================================
---- linux-4.9.11.orig/include/uapi/xen/privcmd.h
-+++ linux-4.9.11/include/uapi/xen/privcmd.h
+--- linux-4.9.18.orig/include/uapi/xen/privcmd.h
++++ linux-4.9.18/include/uapi/xen/privcmd.h
 @@ -77,6 +77,19 @@ struct privcmd_mmapbatch_v2 {
  	int __user *err;  /* array of error codes */
  };

--- a/recipes-kernel/linux/4.9/patches/realmem-mmap.patch
+++ b/recipes-kernel/linux/4.9/patches/realmem-mmap.patch
@@ -34,10 +34,10 @@ INTERNAL DEPENDENCIES
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/char/mem.c
+Index: linux-4.9.18/drivers/char/mem.c
 ===================================================================
---- linux-4.9.11.orig/drivers/char/mem.c
-+++ linux-4.9.11/drivers/char/mem.c
+--- linux-4.9.18.orig/drivers/char/mem.c
++++ linux-4.9.18/drivers/char/mem.c
 @@ -332,9 +332,13 @@ static int mmap_mem(struct file *file, s
  						&vma->vm_page_prot))
  		return -EINVAL;

--- a/recipes-kernel/linux/4.9/patches/skb-forward-copy-bridge-param.patch
+++ b/recipes-kernel/linux/4.9/patches/skb-forward-copy-bridge-param.patch
@@ -33,10 +33,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/net/bridge/br_forward.c
+Index: linux-4.9.18/net/bridge/br_forward.c
 ===================================================================
---- linux-4.9.11.orig/net/bridge/br_forward.c
-+++ linux-4.9.11/net/bridge/br_forward.c
+--- linux-4.9.18.orig/net/bridge/br_forward.c
++++ linux-4.9.18/net/bridge/br_forward.c
 @@ -11,6 +11,7 @@
   *	2 of the License, or (at your option) any later version.
   */

--- a/recipes-kernel/linux/4.9/patches/thorough-reset-interface-to-pciback-s-sysfs.patch
+++ b/recipes-kernel/linux/4.9/patches/thorough-reset-interface-to-pciback-s-sysfs.patch
@@ -163,10 +163,10 @@ PATCHES
  drivers/xen/xen-pciback/pci_stub.c | 338 ++++++++++++++++++++++++++++++++++---
  1 file changed, 312 insertions(+), 26 deletions(-)
 
-Index: linux-4.9.11/drivers/xen/xen-pciback/pci_stub.c
+Index: linux-4.9.18/drivers/xen/xen-pciback/pci_stub.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xen-pciback/pci_stub.c
-+++ linux-4.9.11/drivers/xen/xen-pciback/pci_stub.c
+--- linux-4.9.18.orig/drivers/xen/xen-pciback/pci_stub.c
++++ linux-4.9.18/drivers/xen/xen-pciback/pci_stub.c
 @@ -102,10 +102,9 @@ static void pcistub_device_release(struc
  
  	xen_unregister_device_domain_owner(dev);

--- a/recipes-kernel/linux/4.9/patches/tpm-log-didvid.patch
+++ b/recipes-kernel/linux/4.9/patches/tpm-log-didvid.patch
@@ -33,10 +33,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/char/tpm/tpm_tis_core.c
+Index: linux-4.9.18/drivers/char/tpm/tpm_tis_core.c
 ===================================================================
---- linux-4.9.11.orig/drivers/char/tpm/tpm_tis_core.c
-+++ linux-4.9.11/drivers/char/tpm/tpm_tis_core.c
+--- linux-4.9.18.orig/drivers/char/tpm/tpm_tis_core.c
++++ linux-4.9.18/drivers/char/tpm/tpm_tis_core.c
 @@ -725,9 +725,9 @@ int tpm_tis_core_init(struct device *dev
  	if (rc < 0)
  		goto out_err;

--- a/recipes-kernel/linux/4.9/patches/tpm-tis-force-ioremap.patch
+++ b/recipes-kernel/linux/4.9/patches/tpm-tis-force-ioremap.patch
@@ -1,7 +1,7 @@
-Index: linux-4.9.11/drivers/char/tpm/tpm_tis.c
+Index: linux-4.9.18/drivers/char/tpm/tpm_tis.c
 ===================================================================
---- linux-4.9.11.orig/drivers/char/tpm/tpm_tis.c
-+++ linux-4.9.11/drivers/char/tpm/tpm_tis.c
+--- linux-4.9.18.orig/drivers/char/tpm/tpm_tis.c
++++ linux-4.9.18/drivers/char/tpm/tpm_tis.c
 @@ -150,8 +150,20 @@ static int tpm_tis_init(struct device *d
  		return -ENOMEM;
  

--- a/recipes-kernel/linux/4.9/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.9/patches/usbback-base.patch
@@ -36,10 +36,10 @@ Toolstack in general.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/usb/Kconfig
+Index: linux-4.9.18/drivers/usb/Kconfig
 ===================================================================
---- linux-4.9.11.orig/drivers/usb/Kconfig
-+++ linux-4.9.11/drivers/usb/Kconfig
+--- linux-4.9.18.orig/drivers/usb/Kconfig
++++ linux-4.9.18/drivers/usb/Kconfig
 @@ -93,6 +93,17 @@ source "drivers/usb/image/Kconfig"
  
  source "drivers/usb/usbip/Kconfig"
@@ -58,20 +58,20 @@ Index: linux-4.9.11/drivers/usb/Kconfig
  endif
  
  source "drivers/usb/musb/Kconfig"
-Index: linux-4.9.11/drivers/usb/Makefile
+Index: linux-4.9.18/drivers/usb/Makefile
 ===================================================================
---- linux-4.9.11.orig/drivers/usb/Makefile
-+++ linux-4.9.11/drivers/usb/Makefile
+--- linux-4.9.18.orig/drivers/usb/Makefile
++++ linux-4.9.18/drivers/usb/Makefile
 @@ -61,3 +61,5 @@ obj-$(CONFIG_USB_GADGET)	+= gadget/
  obj-$(CONFIG_USB_COMMON)	+= common/
  
  obj-$(CONFIG_USBIP_CORE)	+= usbip/
 +
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) += xen-usbback/
-Index: linux-4.9.11/drivers/usb/core/Makefile
+Index: linux-4.9.18/drivers/usb/core/Makefile
 ===================================================================
---- linux-4.9.11.orig/drivers/usb/core/Makefile
-+++ linux-4.9.11/drivers/usb/core/Makefile
+--- linux-4.9.18.orig/drivers/usb/core/Makefile
++++ linux-4.9.18/drivers/usb/core/Makefile
 @@ -6,6 +6,7 @@ usbcore-y := usb.o hub.o hcd.o urb.o mes
  usbcore-y += config.o file.o buffer.o sysfs.o endpoint.o
  usbcore-y += devio.o notify.o generic.o quirks.o devices.o
@@ -80,10 +80,10 @@ Index: linux-4.9.11/drivers/usb/core/Makefile
  
  usbcore-$(CONFIG_OF)		+= of.o
  usbcore-$(CONFIG_PCI)		+= hcd-pci.o
-Index: linux-4.9.11/drivers/usb/core/dusb.c
+Index: linux-4.9.18/drivers/usb/core/dusb.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/core/dusb.c
++++ linux-4.9.18/drivers/usb/core/dusb.c
 @@ -0,0 +1,169 @@
 +/*****************************************************************************/
 +
@@ -254,10 +254,10 @@ Index: linux-4.9.11/drivers/usb/core/dusb.c
 +}
 +EXPORT_SYMBOL(dusb_dev_controller_speed);
 +
-Index: linux-4.9.11/drivers/usb/core/hub.c
+Index: linux-4.9.18/drivers/usb/core/hub.c
 ===================================================================
---- linux-4.9.11.orig/drivers/usb/core/hub.c
-+++ linux-4.9.11/drivers/usb/core/hub.c
+--- linux-4.9.18.orig/drivers/usb/core/hub.c
++++ linux-4.9.18/drivers/usb/core/hub.c
 @@ -951,6 +951,15 @@ int usb_remove_device(struct usb_device
  	return 0;
  }
@@ -297,18 +297,18 @@ Index: linux-4.9.11/drivers/usb/core/hub.c
  
  			if (!rebind && cintf->dev.driver) {
  				drv = to_usb_driver(cintf->dev.driver);
-Index: linux-4.9.11/drivers/usb/xen-usbback/Makefile
+Index: linux-4.9.18/drivers/usb/xen-usbback/Makefile
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/Makefile
++++ linux-4.9.18/drivers/usb/xen-usbback/Makefile
 @@ -0,0 +1,3 @@
 +obj-$(CONFIG_XEN_USBDEV_BACKEND) := usbbk.o
 +
 +usbbk-y	:= usbback.o xenbus.o interface.o vusb.o buffers.o
-Index: linux-4.9.11/drivers/usb/xen-usbback/buffers.c
+Index: linux-4.9.18/drivers/usb/xen-usbback/buffers.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/buffers.c
++++ linux-4.9.18/drivers/usb/xen-usbback/buffers.c
 @@ -0,0 +1,422 @@
 +/******************************************************************************
 + * usbback/buffers.c
@@ -732,10 +732,10 @@ Index: linux-4.9.11/drivers/usb/xen-usbback/buffers.c
 +	}
 +}
 +
-Index: linux-4.9.11/drivers/usb/xen-usbback/common.h
+Index: linux-4.9.18/drivers/usb/xen-usbback/common.h
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/common.h
++++ linux-4.9.18/drivers/usb/xen-usbback/common.h
 @@ -0,0 +1,361 @@
 +/*
 + * Copyright (c) Citrix Systems Inc.
@@ -1098,10 +1098,10 @@ Index: linux-4.9.11/drivers/usb/xen-usbback/common.h
 +void dump(uint8_t *buffer, int len);
 +
 +#endif /* __USBIF__BACKEND__COMMON_H__ */
-Index: linux-4.9.11/drivers/usb/xen-usbback/interface.c
+Index: linux-4.9.18/drivers/usb/xen-usbback/interface.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/interface.c
++++ linux-4.9.18/drivers/usb/xen-usbback/interface.c
 @@ -0,0 +1,164 @@
 +/******************************************************************************
 + *
@@ -1267,10 +1267,10 @@ Index: linux-4.9.11/drivers/usb/xen-usbback/interface.c
 +	usbif_cachep = kmem_cache_create("usbif_cache", sizeof(usbif_t),
 +					 0, 0, NULL);
 +}
-Index: linux-4.9.11/drivers/usb/xen-usbback/usbback.c
+Index: linux-4.9.18/drivers/usb/xen-usbback/usbback.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/usbback.c
++++ linux-4.9.18/drivers/usb/xen-usbback/usbback.c
 @@ -0,0 +1,1269 @@
 +/******************************************************************************
 + *
@@ -2541,10 +2541,10 @@ Index: linux-4.9.11/drivers/usb/xen-usbback/usbback.c
 +module_init(usbif_init);
 +
 +MODULE_LICENSE("Dual BSD/GPL");
-Index: linux-4.9.11/drivers/usb/xen-usbback/vusb.c
+Index: linux-4.9.18/drivers/usb/xen-usbback/vusb.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/vusb.c
++++ linux-4.9.18/drivers/usb/xen-usbback/vusb.c
 @@ -0,0 +1,938 @@
 +/******************************************************************************
 + * usbback/vusb.c
@@ -3484,10 +3484,10 @@ Index: linux-4.9.11/drivers/usb/xen-usbback/vusb.c
 +	}
 +}
 +
-Index: linux-4.9.11/drivers/usb/xen-usbback/xenbus.c
+Index: linux-4.9.18/drivers/usb/xen-usbback/xenbus.c
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/drivers/usb/xen-usbback/xenbus.c
++++ linux-4.9.18/drivers/usb/xen-usbback/xenbus.c
 @@ -0,0 +1,582 @@
 +/*  Xenbus code for usbif backend
 +    Copyright (C) 2005 Rusty Russell <rusty@rustcorp.com.au>
@@ -4071,10 +4071,10 @@ Index: linux-4.9.11/drivers/usb/xen-usbback/xenbus.c
 +{
 +	return xenbus_register_backend(&usbback_driver);
 +}
-Index: linux-4.9.11/include/linux/dusb.h
+Index: linux-4.9.18/include/linux/dusb.h
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/include/linux/dusb.h
++++ linux-4.9.18/include/linux/dusb.h
 @@ -0,0 +1,44 @@
 +/*****************************************************************************/
 +
@@ -4120,10 +4120,10 @@ Index: linux-4.9.11/include/linux/dusb.h
 +extern void usb_device_reenumerate(struct usb_device *udev);
 +
 +#endif
-Index: linux-4.9.11/include/xen/interface/io/usbif.h
+Index: linux-4.9.18/include/xen/interface/io/usbif.h
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/include/xen/interface/io/usbif.h
++++ linux-4.9.18/include/xen/interface/io/usbif.h
 @@ -0,0 +1,196 @@
 +/******************************************************************************
 + * usbif.h
@@ -4321,10 +4321,10 @@ Index: linux-4.9.11/include/xen/interface/io/usbif.h
 + * indent-tabs-mode: nil
 + * End:
 + */
-Index: linux-4.9.11/include/xen/vusb.h
+Index: linux-4.9.18/include/xen/vusb.h
 ===================================================================
 --- /dev/null
-+++ linux-4.9.11/include/xen/vusb.h
++++ linux-4.9.18/include/xen/vusb.h
 @@ -0,0 +1,56 @@
 +#ifndef __XEN_VUSB_H__
 +#define __XEN_VUSB_H__
@@ -4382,10 +4382,10 @@ Index: linux-4.9.11/include/xen/vusb.h
 +}
 +
 +#endif /* __XEN_VUSB_H__ */
-Index: linux-4.9.11/drivers/scsi/sr.c
+Index: linux-4.9.18/drivers/scsi/sr.c
 ===================================================================
---- linux-4.9.11.orig/drivers/scsi/sr.c
-+++ linux-4.9.11/drivers/scsi/sr.c
+--- linux-4.9.18.orig/drivers/scsi/sr.c
++++ linux-4.9.18/drivers/scsi/sr.c
 @@ -267,6 +267,15 @@ static unsigned int sr_check_events(stru
  	if (!(clearing & DISK_EVENT_MEDIA_CHANGE))
  		return events;
@@ -4423,10 +4423,10 @@ Index: linux-4.9.11/drivers/scsi/sr.c
  
  	if (cd->device->changed) {
  		events |= DISK_EVENT_MEDIA_CHANGE;
-Index: linux-4.9.11/drivers/usb/host/xhci-pci.c
+Index: linux-4.9.18/drivers/usb/host/xhci-pci.c
 ===================================================================
---- linux-4.9.11.orig/drivers/usb/host/xhci-pci.c
-+++ linux-4.9.11/drivers/usb/host/xhci-pci.c
+--- linux-4.9.18.orig/drivers/usb/host/xhci-pci.c
++++ linux-4.9.18/drivers/usb/host/xhci-pci.c
 @@ -202,6 +202,11 @@ static void xhci_pci_quirks(struct devic
  	if (xhci->quirks & XHCI_RESET_ON_RESUME)
  		xhci_dbg_trace(xhci, trace_xhci_dbg_quirks,

--- a/recipes-kernel/linux/4.9/patches/xenbus-move-otherend-watches-on-relocate.patch
+++ b/recipes-kernel/linux/4.9/patches/xenbus-move-otherend-watches-on-relocate.patch
@@ -35,10 +35,10 @@ Required for service VM network disagregation.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/xen/xenbus/xenbus_probe.c
+Index: linux-4.9.18/drivers/xen/xenbus/xenbus_probe.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xenbus/xenbus_probe.c
-+++ linux-4.9.11/drivers/xen/xenbus/xenbus_probe.c
+--- linux-4.9.18.orig/drivers/xen/xenbus/xenbus_probe.c
++++ linux-4.9.18/drivers/xen/xenbus/xenbus_probe.c
 @@ -545,12 +545,36 @@ static int strsep_len(const char *str, c
  	return (len == 0) ? i : -ERANGE;
  }

--- a/recipes-kernel/linux/4.9/patches/xenkbd-tablet-resolution.patch
+++ b/recipes-kernel/linux/4.9/patches/xenkbd-tablet-resolution.patch
@@ -31,10 +31,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/input/misc/xen-kbdfront.c
+Index: linux-4.9.18/drivers/input/misc/xen-kbdfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/input/misc/xen-kbdfront.c
-+++ linux-4.9.11/drivers/input/misc/xen-kbdfront.c
+--- linux-4.9.18.orig/drivers/input/misc/xen-kbdfront.c
++++ linux-4.9.18/drivers/input/misc/xen-kbdfront.c
 @@ -174,8 +174,8 @@ static int xenkbd_probe(struct xenbus_de
  
  	if (abs) {
@@ -46,10 +46,10 @@ Index: linux-4.9.11/drivers/input/misc/xen-kbdfront.c
  	} else {
  		input_set_capability(ptr, EV_REL, REL_X);
  		input_set_capability(ptr, EV_REL, REL_Y);
-Index: linux-4.9.11/include/xen/interface/io/fbif.h
+Index: linux-4.9.18/include/xen/interface/io/fbif.h
 ===================================================================
---- linux-4.9.11.orig/include/xen/interface/io/fbif.h
-+++ linux-4.9.11/include/xen/interface/io/fbif.h
+--- linux-4.9.18.orig/include/xen/interface/io/fbif.h
++++ linux-4.9.18/include/xen/interface/io/fbif.h
 @@ -137,6 +137,8 @@ struct xenfb_page {
  #ifdef __KERNEL__
  #define XENFB_WIDTH 800

--- a/recipes-kernel/linux/4.9/patches/xenstore-no-read-vs-write-atomicity.patch
+++ b/recipes-kernel/linux/4.9/patches/xenstore-no-read-vs-write-atomicity.patch
@@ -39,10 +39,10 @@ None.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/xen/xenbus/xenbus_dev_frontend.c
+Index: linux-4.9.18/drivers/xen/xenbus/xenbus_dev_frontend.c
 ===================================================================
---- linux-4.9.11.orig/drivers/xen/xenbus/xenbus_dev_frontend.c
-+++ linux-4.9.11/drivers/xen/xenbus/xenbus_dev_frontend.c
+--- linux-4.9.18.orig/drivers/xen/xenbus/xenbus_dev_frontend.c
++++ linux-4.9.18/drivers/xen/xenbus/xenbus_dev_frontend.c
 @@ -552,6 +552,14 @@ static int xenbus_file_open(struct inode
  
  	filp->private_data = u;
@@ -58,10 +58,10 @@ Index: linux-4.9.11/drivers/xen/xenbus/xenbus_dev_frontend.c
  	return 0;
  }
  
-Index: linux-4.9.11/include/linux/fs.h
+Index: linux-4.9.18/include/linux/fs.h
 ===================================================================
---- linux-4.9.11.orig/include/linux/fs.h
-+++ linux-4.9.11/include/linux/fs.h
+--- linux-4.9.18.orig/include/linux/fs.h
++++ linux-4.9.18/include/linux/fs.h
 @@ -922,6 +922,11 @@ struct file_handle {
  	unsigned char f_handle[0];
  };

--- a/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-add-RING_COPY_RESPONSE.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-add-RING_COPY_RESPONSE.patch
@@ -27,10 +27,10 @@ omitting the copy.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/include/xen/interface/io/ring.h
+Index: linux-4.9.18/include/xen/interface/io/ring.h
 ===================================================================
---- linux-4.9.11.orig/include/xen/interface/io/ring.h
-+++ linux-4.9.11/include/xen/interface/io/ring.h
+--- linux-4.9.18.orig/include/xen/interface/io/ring.h
++++ linux-4.9.18/include/xen/interface/io/ring.h
 @@ -198,6 +198,20 @@ struct __name##_back_ring {						\
  #define RING_GET_RESPONSE(_r, _idx)					\
      (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].rsp))

--- a/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-blkfront-make-local-copy-of-response-before-usin.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-blkfront-make-local-copy-of-response-before-usin.patch
@@ -18,10 +18,10 @@ then access it.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/block/xen-blkfront.c
+Index: linux-4.9.18/drivers/block/xen-blkfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/block/xen-blkfront.c
-+++ linux-4.9.11/drivers/block/xen-blkfront.c
+--- linux-4.9.18.orig/drivers/block/xen-blkfront.c
++++ linux-4.9.18/drivers/block/xen-blkfront.c
 @@ -1538,7 +1538,7 @@ static bool blkif_completion(unsigned lo
  static irqreturn_t blkif_interrupt(int irq, void *dev_id)
  {

--- a/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-blkfront-prepare-request-locally-only-then-put-i.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-blkfront-prepare-request-locally-only-then-put-i.patch
@@ -19,10 +19,10 @@ one just filled.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/block/xen-blkfront.c
+Index: linux-4.9.18/drivers/block/xen-blkfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/block/xen-blkfront.c
-+++ linux-4.9.11/drivers/block/xen-blkfront.c
+--- linux-4.9.18.orig/drivers/block/xen-blkfront.c
++++ linux-4.9.18/drivers/block/xen-blkfront.c
 @@ -688,7 +688,8 @@ static void blkif_setup_extra_req(struct
  static int blkif_queue_rw_req(struct request *req, struct blkfront_ring_info *rinfo)
  {

--- a/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch
@@ -17,10 +17,10 @@ before using it as an array index.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/net/xen-netfront.c
+Index: linux-4.9.18/drivers/net/xen-netfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/xen-netfront.c
-+++ linux-4.9.11/drivers/net/xen-netfront.c
+--- linux-4.9.18.orig/drivers/net/xen-netfront.c
++++ linux-4.9.18/drivers/net/xen-netfront.c
 @@ -380,6 +380,7 @@ static void xennet_tx_buf_gc(struct netf
  				continue;
  

--- a/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch
@@ -18,10 +18,10 @@ use issue.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/net/xen-netfront.c
+Index: linux-4.9.18/drivers/net/xen-netfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/xen-netfront.c
-+++ linux-4.9.11/drivers/net/xen-netfront.c
+--- linux-4.9.18.orig/drivers/net/xen-netfront.c
++++ linux-4.9.18/drivers/net/xen-netfront.c
 @@ -373,13 +373,13 @@ static void xennet_tx_buf_gc(struct netf
  		rmb(); /* Ensure we see responses up to 'rp'. */
  

--- a/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch
@@ -19,10 +19,10 @@ written there, instead of reading it back from the shared page.
 ################################################################################
 PATCHES 
 ################################################################################
-Index: linux-4.9.11/drivers/net/xen-netfront.c
+Index: linux-4.9.18/drivers/net/xen-netfront.c
 ===================================================================
---- linux-4.9.11.orig/drivers/net/xen-netfront.c
-+++ linux-4.9.11/drivers/net/xen-netfront.c
+--- linux-4.9.18.orig/drivers/net/xen-netfront.c
++++ linux-4.9.18/drivers/net/xen-netfront.c
 @@ -445,7 +445,7 @@ static void xennet_tx_setup_grant(unsign
  	tx->flags = 0;
  


### PR DESCRIPTION
Point of interest:
- (c74fd80f2f41) xen: do not re-use pirq number cached in pci device msi msg data.