### PR TITLE
Allow writable CDs and fix guest crash on write.

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/atapi-pass-through.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/atapi-pass-through.patch
@@ -1722,7 +1722,17 @@ Index: qemu-2.6.2/blockdev.c
      int cyls, heads, secs, translation;
      int max_devs, bus_id, unit_id, index;
      const char *devaddr;
-@@ -985,6 +991,13 @@ DriveInfo *drive_new(QemuOpts *all_opts,
+@@ -949,7 +955,9 @@ DriveInfo *drive_new(QemuOpts *all_opts,
+             media = MEDIA_DISK;
+         } else if (!strcmp(value, "cdrom")) {
+             media = MEDIA_CDROM;
++#ifndef CONFIG_ATAPI_PT
+             read_only = true;
++#endif
+         } else {
+             error_report("'%s' invalid media", value);
+             goto fail;
+@@ -985,6 +993,13 @@ DriveInfo *drive_new(QemuOpts *all_opts,
          type = block_default_type;
      }
  
@@ -1736,7 +1746,7 @@ Index: qemu-2.6.2/blockdev.c
      /* Geometry */
      cyls  = qemu_opt_get_number(legacy_opts, "cyls", 0);
      heads = qemu_opt_get_number(legacy_opts, "heads", 0);
-@@ -1172,11 +1185,19 @@ DriveInfo *drive_new(QemuOpts *all_opts,
+@@ -1172,11 +1187,19 @@ DriveInfo *drive_new(QemuOpts *all_opts,
      blk_set_legacy_dinfo(blk, dinfo);
  
      switch(type) {
@@ -1784,7 +1794,7 @@ Index: qemu-2.6.2/configure
    --disable-archipelago) archipelago="no"
    ;;
    --enable-archipelago) archipelago="yes"
-@@ -4903,6 +4913,8 @@ echo "Archipelago support $archipelago"
+@@ -4904,6 +4914,8 @@ echo "Archipelago support $archipelago"
  echo "gcov              $gcov_tool"
  echo "gcov enabled      $gcov"
  echo "OpenXT stubdomain support $stubdom"
@@ -1793,7 +1803,7 @@ Index: qemu-2.6.2/configure
  echo "TPM support       $tpm"
  echo "libssh2 support   $libssh2"
  echo "TPM passthrough   $tpm_passthrough"
-@@ -5450,6 +5462,14 @@ if test "$stubdom" = "yes" ; then
+@@ -5454,6 +5466,14 @@ if test "$stubdom" = "yes" ; then
    echo "CONFIG_STUBDOM=y" >> $config_host_mak
  fi
  
@@ -3266,9 +3276,9 @@ Index: qemu-2.6.2/hw/ide/atapi_pt.c
 +{
 +    s->io_buffer_index = 0;
 +    if (s->atapi_dma) {
++        s->io_buffer_index = 0;
 +        s->io_buffer_size = s->atapipts->dout_xfer_len;
-+        s->bus->dma->ops->start_dma(s->bus->dma, s,
-+                                    atapi_pt_dout_fetch_dma_done);
++        ide_start_dma(s, atapi_pt_dout_fetch_dma_done);
 +    } else {        /* PIO */
 +        s->packet_transfer_size = s->atapipts->dout_xfer_len;
 +        s->io_buffer_size = 0;

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/xenstore-based-ISO-media-change-detection-for-both-s.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/xenstore-based-ISO-media-change-detection-for-both-s.patch
@@ -86,7 +86,7 @@ Index: qemu-2.6.2/blockdev.c
  
  static QTAILQ_HEAD(, BlockDriverState) monitor_bdrv_states =
      QTAILQ_HEAD_INITIALIZER(monitor_bdrv_states);
-@@ -1203,6 +1204,16 @@ DriveInfo *drive_new(QemuOpts *all_opts,
+@@ -1205,6 +1206,16 @@ DriveInfo *drive_new(QemuOpts *all_opts,
          break;
      }
  


### PR DESCRIPTION
This fixes CD writing to what it is in stable-6 currently. Some things fail
like formatting the CD or dragging files/burning. Other things work like
right clicking an ISO and burning it to a CD. A separate ticket will be
opened to track those failures but this fixes the RO problem and the crash.

OXT-931

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>