### PR TITLE
keymanagement: handle non-ml upgrade from legacy

### DIFF
--- a/recipes-openxt/openxt/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt/openxt-keymanagement/key-functions
@@ -494,6 +494,10 @@ platform_unlock() {
     local name="${2}"
 
     get-config-key | cryptsetup -q -d - -S ${PSLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        # fall back and see if platform key will open on any slot
+        get-config-key | cryptsetup -q -d - luksOpen "${part}" "${name}" >/dev/null 2>&1
+    fi
 
     return $?
 }


### PR DESCRIPTION
Under legacy key management different LUKS slots where used for key storage.
Since we are not remapping LUKS slots when upgrading from a system using the
legacy slots, make the new key managent attempt a general unlock if the unlock
using the expected slot fails.

OXT-1054

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>