### PR TITLE
OXT-1067: Unfork OCaml libraries

### DIFF
--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -45,6 +45,7 @@ IMAGE_INSTALL = "\
     v4v-module \
     xen-libxenstore \
     xen-xenstore \
+    xen-ocaml-libs \
     wget \
     ethtool \
     carrier-detect \

--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -23,6 +23,7 @@ RDEPENDS_${PN} = " \
     xen-libxenlight \
     xen-libxenstat \
     xen-libxlutil \
+    xen-ocaml-libs \
     xen-xenstat \
     xen-xenstored \
     xen-xl \

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -1,7 +1,9 @@
 require recipes-extended/xen/xen.inc
 require xen-common.inc
 
-DESCRIPTION = "Xen hypervisor libxl and xenstore components"
+inherit findlib
+
+DESCRIPTION = "Xen hypervisor libxl, ocaml and xenstore components"
 
 # In OpenXT, multiple recipes are used to build Xen and its components:
 # a 32-bit build of tools ; a 64-bit hypervisor ; a separate blktap
@@ -49,7 +51,6 @@ SRC_URI_append = " \
     "
 
 PACKAGES = " \
-    ${PN}-dbg \
     xen-xl \
     xen-libxl-dev \
     xen-libxlutil \
@@ -58,12 +59,22 @@ PACKAGES = " \
     xen-libxenlight-dev \
     xen-libxl-staticdev \
     xen-xenstored \
+    xen-ocaml-libs-dev \
+    xen-ocaml-libs-dbg \
+    xen-ocaml-libs-staticdev \
+    xen-ocaml-libs \
+    ${PN}-dbg \
     "
 
 FILES_${PN}-staticdev = " \
     ${libdir}/libxlutil.a \
     ${libdir}/libxenlight.a \
     "
+
+FILES_xen-ocaml-libs-dev = "${ocamllibdir}/*/*.so"
+FILES_xen-ocaml-libs-dbg = "${ocamllibdir}/*/.debug/*"
+FILES_xen-ocaml-libs-staticdev = "${ocamllibdir}/*/*.a"
+FILES_xen-ocaml-libs = "${ocamllibdir}/*"
 
 EXTRA_OEMAKE += "CROSS_SYS_ROOT=${STAGING_DIR_HOST} CROSS_COMPILE=${HOST_PREFIX}"
 EXTRA_OEMAKE += "CONFIG_IOEMU=n"
@@ -116,7 +127,8 @@ do_install() {
     install -m 0755 ${WORKDIR}/xen-init-dom0.initscript \
                     ${D}${sysconfdir}/init.d/xen-init-dom0
 
-    oe_runmake DESTDIR=${D} -C tools/ocaml/xenstored install
+    oe_runmake DESTDIR=${D} -C tools/ocaml install
+
     mv ${D}/usr/sbin/oxenstored ${D}/${sbindir}/xenstored
     install -m 0755 ${WORKDIR}/xenstored.initscript \
                     ${D}${sysconfdir}/init.d/xenstored

--- a/recipes-openxt/xenclient/uid_git.bb
+++ b/recipes-openxt/xenclient/uid_git.bb
@@ -2,7 +2,7 @@ inherit findlib
 DESCRIPTION = "UID - User Interface Daemon"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
-DEPENDS = "ocaml-cross ocaml-dbus xenclient-toolstack"
+DEPENDS = "ocaml-cross ocaml-dbus xen-libxl xenclient-toolstack"
 
 # Ocaml stuff is built with the native compiler with "-m32".
 

--- a/recipes-openxt/xenclient/xenclient-toolstack_git.bb
+++ b/recipes-openxt/xenclient/xenclient-toolstack_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "XenClient toolstack"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=321bf41f280cf805086dd5a720b37785"
-DEPENDS += "ocaml-cross ocaml-dbus ocaml-camomile xen xz"
+DEPENDS += " ocaml-cross ocaml-dbus ocaml-camomile xen xen-libxl xz "
 RDEPENDS_${PN} = "xen-xenstore xen-xenstored"
 RDEPENDS_${PN}_xenclient-ndvm += " db-tools"
 
@@ -46,11 +46,16 @@ S = "${WORKDIR}/git"
 do_compile() {
         make V=1 XEN_DIST_ROOT="${STAGING_DIR}"
 }
-OCAML_INSTALL_LIBS  = "libs/uuid libs/stdext libs/mmap \
-                      libs/json libs/jsonrpc libs/http \
-                      libs/log libs/xc libs/eventchn \
-                      libs/xb libs/xs \
-		      libs/common"
+
+OCAML_INSTALL_LIBS = " \
+    libs/uuid \
+    libs/stdext \
+    libs/json \
+    libs/jsonrpc \
+    libs/http \
+    libs/log \
+    libs/common \
+    "
 
 do_configure_xenclient-nilfvm() {
         :


### PR DESCRIPTION
PRs in: xenclient-oe, toolstack, uid and manager repositories.

Precursor work to a packaging update to xenstored.
Retiring this fork will reduce the work required for the next Xen uprev.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>