### PR TITLE
OXT-1056: Package both C and OCaml xenstored. Default to C.

### DIFF
--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -53,6 +53,13 @@ PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
 PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"
 PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 
+# Allow build of multiple packages containing xenstore daemons
+MULTI_PROVIDER_WHITELIST += "xen-xenstored"
+# Select a preferred XenStored daemon implementation.
+# C xenstored is provided by the xen.bb recipe, so "xen"
+# OCaml xenstored is provided by the xen-libxl.bb recipe, so "xen-libxl"
+PREFERRED_PROVIDER_xen-xenstored = "xen"
+
 PREFERRED_VERSION_rsyslog = "7%"
 
 # Set our root home

--- a/recipes-core/images/xenclient-dom0-image.bb
+++ b/recipes-core/images/xenclient-dom0-image.bb
@@ -12,7 +12,8 @@ IMAGE_FSTYPES = "xc.ext3.gz"
 # Nor a collection of questionable CA certificates
 BAD_RECOMMENDATIONS += "xserver-xorg avahi-daemon avahi-autoipd ca-certificates"
 # The above seems to be broken and we *really* don't want avahi!
-PACKAGE_REMOVE = "avahi-daemon avahi-autoipd"
+# Also remove the unwanted version of xenstored
+PACKAGE_REMOVE = "avahi-daemon avahi-autoipd xen-xenstored-ocaml"
 
 ANGSTROM_EXTRA_INSTALL += " \
 			  " 
@@ -121,7 +122,13 @@ remove_initscripts() {
     fi
 }
 
-ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; remove_initscripts; process_tmp_stubdomain_items; "
+# After ensuring that the correct number of xenstored daemon(s) are installed,
+# enforce that the init script is active:
+activate_xenstored_initscript() {
+    update-rc.d -r ${IMAGE_ROOTFS} xenstored defaults 05
+}
+
+ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; remove_initscripts; activate_xenstored_initscript; process_tmp_stubdomain_items; "
 
 inherit openxt-selinux-image
 #inherit validate-package-versions

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -45,6 +45,7 @@ IMAGE_INSTALL = "\
     v4v-module \
     xen-libxenstore \
     xen-xenstore \
+    xen-ocaml-libs \
     wget \
     ethtool \
     carrier-detect \

--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -23,6 +23,7 @@ RDEPENDS_${PN} = " \
     xen-libxenlight \
     xen-libxenstat \
     xen-libxlutil \
+    xen-ocaml-libs \
     xen-xenstat \
     xen-xenstored \
     xen-xl \

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -1,7 +1,9 @@
 require recipes-extended/xen/xen.inc
 require xen-common.inc
 
-DESCRIPTION = "Xen hypervisor libxl and xenstore components"
+inherit findlib
+
+DESCRIPTION = "Xen hypervisor libxl, ocaml and xenstore components"
 
 # In OpenXT, multiple recipes are used to build Xen and its components:
 # a 32-bit build of tools ; a 64-bit hypervisor ; a separate blktap
@@ -49,7 +51,6 @@ SRC_URI_append = " \
     "
 
 PACKAGES = " \
-    ${PN}-dbg \
     xen-xl \
     xen-libxl-dev \
     xen-libxlutil \
@@ -58,12 +59,22 @@ PACKAGES = " \
     xen-libxenlight-dev \
     xen-libxl-staticdev \
     xen-xenstored \
+    xen-ocaml-libs-dev \
+    xen-ocaml-libs-dbg \
+    xen-ocaml-libs-staticdev \
+    xen-ocaml-libs \
+    ${PN}-dbg \
     "
 
 FILES_${PN}-staticdev = " \
     ${libdir}/libxlutil.a \
     ${libdir}/libxenlight.a \
     "
+
+FILES_xen-ocaml-libs-dev = "${ocamllibdir}/*/*.so"
+FILES_xen-ocaml-libs-dbg = "${ocamllibdir}/*/.debug/*"
+FILES_xen-ocaml-libs-staticdev = "${ocamllibdir}/*/*.a"
+FILES_xen-ocaml-libs = "${ocamllibdir}/*"
 
 EXTRA_OEMAKE += "CROSS_SYS_ROOT=${STAGING_DIR_HOST} CROSS_COMPILE=${HOST_PREFIX}"
 EXTRA_OEMAKE += "CONFIG_IOEMU=n"
@@ -116,7 +127,8 @@ do_install() {
     install -m 0755 ${WORKDIR}/xen-init-dom0.initscript \
                     ${D}${sysconfdir}/init.d/xen-init-dom0
 
-    oe_runmake DESTDIR=${D} -C tools/ocaml/xenstored install
+    oe_runmake DESTDIR=${D} -C tools/ocaml install
+
     mv ${D}/usr/sbin/oxenstored ${D}/${sbindir}/xenstored
     install -m 0755 ${WORKDIR}/xenstored.initscript \
                     ${D}${sysconfdir}/init.d/xenstored

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -23,17 +23,25 @@ python () {
                 'libxlutil',
                 'libxlutil-dev',
                 'libxenlight',
-                'libxenlight-dev',
-                'xenstored'
+                'libxenlight-dev'
                 ]:
         d.renameVar("FILES_xen-libxl-" + PKG, "FILES_xen-" + PKG)
 
     # After renaming a variable, it is simpler to append to it here:
     d.appendVar("FILES_xen-xl", " /etc/init.d/xen-init-dom0")
-    # OpenXT uses init scripts rather than systemd.
-    d.appendVar("FILES_xen-xenstored", " /etc/init.d/xenstored")
-    d.appendVar("FILES_xen-xenstored", " /etc/xen/oxenstored.conf")
 }
+
+# OpenXT packages both the C and OCaml versions of XenStored.
+# This recipe packages the OCaml daemon; xen.bb packages the C one.
+FILES_xen-xenstored-ocaml = " \
+    ${sbindir}/xenstored.xen-xenstored-ocaml \
+    ${localstatedir}/lib/xenstored \
+    ${sysconfdir}/init.d/xenstored.xen-xenstored-ocaml \
+    ${sysconfdir}/xen/oxenstored.conf \
+    "
+
+PROVIDES =+ "xen-xenstored xen-xenstored-ocaml"
+RPROVIDES_xen-xenstored-ocaml = "xen-xenstored xen-xenstored-ocaml"
 
 DEPENDS += " \
     util-linux \
@@ -58,7 +66,7 @@ PACKAGES = " \
     xen-libxenlight \
     xen-libxenlight-dev \
     xen-libxl-staticdev \
-    xen-xenstored \
+    xen-xenstored-ocaml \
     xen-ocaml-libs-dev \
     xen-ocaml-libs-dbg \
     xen-ocaml-libs-staticdev \
@@ -91,11 +99,21 @@ FULL_OPTIMIZATION = "-pipe ${DEBUG_FLAGS}"
 TARGET_CC_ARCH += "${LDFLAGS}"
 CC_FOR_OCAML="i686-oe-linux-gcc"
 
-INITSCRIPT_PACKAGES = "xen-xl xen-xenstored"
+INITSCRIPT_PACKAGES = "xen-xl xen-xenstored-ocaml"
 INITSCRIPT_NAME_xen-xl = "xen-init-dom0"
 INITSCRIPT_PARAMS_xen-xl = "defaults 21"
-INITSCRIPT_NAME_xen-xenstored = "xenstored"
-INITSCRIPT_PARAMS_xen-xenstored = "defaults 05"
+INITSCRIPT_NAME_xen-xenstored-ocaml = "xenstored"
+INITSCRIPT_PARAMS_xen-xenstored-ocaml = "defaults 05"
+
+pkg_postinst_xen-xenstored-ocaml () {
+    update-alternatives --install ${sbindir}/xenstored xenstored xenstored.xen-xenstored-ocaml 100
+    update-alternatives --install ${sysconfdir}/init.d/xenstored xenstored-initscript xenstored.xen-xenstored-ocaml 100
+}
+
+pkg_prerm_xen-xenstored-ocaml () {
+    update-alternatives --remove xenstored xenstored.xen-xenstored-ocaml
+    update-alternatives --remove xenstored-initscript xenstored.xen-xenstored-ocaml
+}
 
 do_configure_prepend() {
 	#remove optimizations in the config files
@@ -129,9 +147,9 @@ do_install() {
 
     oe_runmake DESTDIR=${D} -C tools/ocaml install
 
-    mv ${D}/usr/sbin/oxenstored ${D}/${sbindir}/xenstored
+    mv ${D}/usr/sbin/oxenstored ${D}/${sbindir}/xenstored.xen-xenstored-ocaml
     install -m 0755 ${WORKDIR}/xenstored.initscript \
-                    ${D}${sysconfdir}/init.d/xenstored
+                    ${D}${sysconfdir}/init.d/xenstored.xen-xenstored-ocaml
     rm ${D}${sysconfdir}/xen/oxenstored.conf
     install -m 0644 ${WORKDIR}/oxenstored.conf \
                     ${D}${sysconfdir}/xen/oxenstored.conf

--- a/recipes-openxt/xenclient/uid_git.bb
+++ b/recipes-openxt/xenclient/uid_git.bb
@@ -2,7 +2,7 @@ inherit findlib
 DESCRIPTION = "UID - User Interface Daemon"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
-DEPENDS = "ocaml-cross ocaml-dbus xenclient-toolstack"
+DEPENDS = "ocaml-cross ocaml-dbus xen-libxl xenclient-toolstack"
 
 # Ocaml stuff is built with the native compiler with "-m32".
 

--- a/recipes-openxt/xenclient/xenclient-toolstack_git.bb
+++ b/recipes-openxt/xenclient/xenclient-toolstack_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "XenClient toolstack"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=321bf41f280cf805086dd5a720b37785"
-DEPENDS += "ocaml-cross ocaml-dbus ocaml-camomile xen xz"
+DEPENDS += "ocaml-cross ocaml-dbus ocaml-camomile xen xen-libxl xz"
 RDEPENDS_${PN} = "xen-xenstore xen-xenstored"
 RDEPENDS_${PN}_xenclient-ndvm += " db-tools"
 
@@ -46,11 +46,16 @@ S = "${WORKDIR}/git"
 do_compile() {
         make V=1 XEN_DIST_ROOT="${STAGING_DIR}"
 }
-OCAML_INSTALL_LIBS  = "libs/uuid libs/stdext libs/mmap \
-                      libs/json libs/jsonrpc libs/http \
-                      libs/log libs/xc libs/eventchn \
-                      libs/xb libs/xs \
-		      libs/common"
+
+OCAML_INSTALL_LIBS = " \
+    libs/uuid \
+    libs/stdext \
+    libs/json \
+    libs/jsonrpc \
+    libs/http \
+    libs/log \
+    libs/common \
+    "
 
 do_configure_xenclient-nilfvm() {
         :

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
@@ -2,10 +2,11 @@ Index: refpolicy/policy/modules/contrib/xen.fc
 ===================================================================
 --- refpolicy.orig/policy/modules/contrib/xen.fc
 +++ refpolicy/policy/modules/contrib/xen.fc
-@@ -8,9 +8,12 @@
+@@ -8,10 +8,16 @@
  
  /usr/sbin/blktapctrl	--	gen_context(system_u:object_r:blktap_exec_t,s0)
  /usr/sbin/evtchnd	--	gen_context(system_u:object_r:evtchnd_exec_t,s0)
++/etc/xen/xenstored.conf   --      gen_context(system_u:object_r:xenstored_etc_t,s0)
 +/etc/xen/oxenstored.conf   --      gen_context(system_u:object_r:xenstored_etc_t,s0)
  /usr/sbin/tapdisk	--	gen_context(system_u:object_r:blktap_exec_t,s0)
  /usr/sbin/xenconsoled	--	gen_context(system_u:object_r:xenconsoled_exec_t,s0)
@@ -13,9 +14,12 @@ Index: refpolicy/policy/modules/contrib/xen.fc
 +/usr/bin/xenmgr         --      gen_context(system_u:object_r:xend_exec_t,s0)
 +/usr/bin/xenstored      --      gen_context(system_u:object_r:xenstored_exec_t,s0)
  /usr/sbin/xenstored	--	gen_context(system_u:object_r:xenstored_exec_t,s0)
++/usr/sbin/xenstored.xen-xenstored-c	--	gen_context(system_u:object_r:xenstored_exec_t,s0)
++/usr/sbin/xenstored.xen-xenstored-ocaml	--	gen_context(system_u:object_r:xenstored_exec_t,s0)
  /usr/sbin/xl	--	gen_context(system_u:object_r:xm_exec_t,s0)
  /usr/sbin/xm	--	gen_context(system_u:object_r:xm_exec_t,s0)
-@@ -19,12 +22,15 @@
+ 
+@@ -19,12 +25,15 @@
  /var/lib/xen/images(/.*)?	gen_context(system_u:object_r:xen_image_t,s0)
  /var/lib/xend(/.*)?	gen_context(system_u:object_r:xend_var_lib_t,s0)
  /var/lib/xenstored(/.*)?	gen_context(system_u:object_r:xenstored_var_lib_t,s0)
@@ -31,7 +35,7 @@ Index: refpolicy/policy/modules/contrib/xen.fc
  
  /var/run/evtchnd	-s	gen_context(system_u:object_r:evtchnd_var_run_t,s0)
  /var/run/evtchnd\.pid	--	gen_context(system_u:object_r:evtchnd_var_run_t,s0)
-@@ -36,3 +42,6 @@
+@@ -36,3 +45,6 @@
  /var/run/xenstored(/.*)?	gen_context(system_u:object_r:xenstored_var_run_t,s0)
  
  /xen(/.*)?	gen_context(system_u:object_r:xen_image_t,s0)


### PR DESCRIPTION
This PR for OXT-1056 builds upon the related PR #604 for OXT-1067 (to unfork the OCaml libraries), so  includes those commits. This PR is fine to go in and the other just be retired.

There's a minor interaction between the OE standard behaviour for update-rc.d and update-alternatives that becomes evident when packaging alternative versions of the same init script, so there's a workaround for that in this PR, in the xenclient-dom0-image.bb section. OE also needed more convincing than would be expected to only install a single xenstored package, so that's enforced in the same file.

The results are correct: C daemon installed and working; OCaml daemon packaged but not installed.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>