### PR TITLE
OXT-1081: logrotate: replace fedorahosted.org SRC_URI with github.com

### DIFF
--- a/recipes-extended/logrotate/logrotate/act-as-mv-when-rotate.patch
+++ b/recipes-extended/logrotate/logrotate/act-as-mv-when-rotate.patch
@@ -1,0 +1,147 @@
+From 68f29ab490cf987aa34b5f4caf1784b58a021308 Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Tue, 17 Feb 2015 21:08:07 -0800
+Subject: [PATCH] Act as the "mv" command when rotate log
+
+Act as the "mv" command when rotate log, first rename, if failed, then
+read and write.
+
+Upstream-Status: Pending
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ logrotate.c |   71 +++++++++++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 59 insertions(+), 12 deletions(-)
+
+diff --git a/logrotate.c b/logrotate.c
+index d3deb6a..cf8bf2c 100644
+--- a/logrotate.c
++++ b/logrotate.c
+@@ -1157,6 +1157,53 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
+     return 0;
+ }
+ 
++/* Act as the "mv" command, if rename failed, then read the old file and
++ * write to new file. The function which invokes the mvFile will use
++ * the strerror(errorno) to handle the error message, so we don't have
++ * to print the error message here */
++
++int mvFile (char *oldName, char *newName, struct logInfo *log, acl_type acl)
++{
++    struct stat sbprev;
++    int fd_old, fd_new, n;
++    char buf[BUFSIZ];
++
++    /* Do the rename first */
++    if (!rename(oldName, newName))
++        return 0;
++
++    /* If the errno is EXDEV, then read old file, write newfile and
++     * remove the oldfile */
++    if (errno == EXDEV) {
++        /* Open the old file to read */
++        if ((fd_old = open(oldName, O_RDONLY)) < 0)
++            return 1;
++
++        /* Create the file to write, keep the same attribute as the old file */
++        if (stat(oldName, &sbprev))
++            return 1;
++        else {
++            if ((fd_new = createOutputFile(newName,
++                O_WRONLY | O_CREAT | O_TRUNC, &sbprev, acl, 0)) < 0 )
++                return 1;
++        }
++
++        /* Read and write */
++        while ((n = read(fd_old, buf, BUFSIZ)) > 0)
++            if (write(fd_new, buf, n) != n)
++                return 1;
++
++        if ((close(fd_old) < 0) ||
++            removeLogFile(oldName, log) ||
++            (close(fd_new) < 0))
++            return 1;
++
++        return 0;
++    }
++
++    return 1;
++}
++
+ int prerotateSingleLog(struct logInfo *log, int logNum, struct logState *state,
+ 		       struct logNames *rotNames)
+ {
+@@ -1523,15 +1570,15 @@ int prerotateSingleLog(struct logInfo *log, int logNum, struct logState *state,
+ 		}
+ 
+ 	    message(MESS_DEBUG,
+-		    "renaming %s to %s (rotatecount %d, logstart %d, i %d), \n",
++		    "moving %s to %s (rotatecount %d, logstart %d, i %d), \n",
+ 		    oldName, newName, rotateCount, logStart, i);
+ 
+-	    if (!debug && rename(oldName, newName)) {
++	    if (!debug && mvFile(oldName, newName, log, prev_acl)) {
+ 		if (errno == ENOENT) {
+ 		    message(MESS_DEBUG, "old log %s does not exist\n",
+ 			    oldName);
+ 		} else {
+-		    message(MESS_ERROR, "error renaming %s to %s: %s\n",
++		    message(MESS_ERROR, "error moving %s to %s: %s\n",
+ 			    oldName, newName, strerror(errno));
+ 		    hasErrors = 1;
+ 		}
+@@ -1669,21 +1716,21 @@ int rotateSingleLog(struct logInfo *log, int logNum, struct logState *state,
+ 				return 1;
+ 			}
+ 
+-			message(MESS_DEBUG, "renaming %s to %s\n", log->files[logNum],
++			message(MESS_DEBUG, "moving %s to %s\n", log->files[logNum],
+ 				tmpFilename);
+-			if (!debug && !hasErrors && rename(log->files[logNum], tmpFilename)) {
+-			message(MESS_ERROR, "failed to rename %s to %s: %s\n",
++			if (!debug && !hasErrors && mvFile(log->files[logNum], rotNames->finalName, log, prev_acl)) {
++			message(MESS_ERROR, "failed to move %s to %s: %s\n",
+ 				log->files[logNum], tmpFilename,
+ 				strerror(errno));
+ 				hasErrors = 1;
+ 			}
+ 		}
+ 		else {
+-			message(MESS_DEBUG, "renaming %s to %s\n", log->files[logNum],
++			message(MESS_DEBUG, "moving %s to %s\n", log->files[logNum],
+ 				rotNames->finalName);
+ 			if (!debug && !hasErrors &&
+-			rename(log->files[logNum], rotNames->finalName)) {
+-				message(MESS_ERROR, "failed to rename %s to %s: %s\n",
++			mvFile(log->files[logNum], rotNames->finalName, log, prev_acl)) {
++				message(MESS_ERROR, "failed to move %s to %s: %s\n",
+ 					log->files[logNum], tmpFilename,
+ 					strerror(errno));
+ 					hasErrors = 1;
+@@ -2063,7 +2110,7 @@ int rotateLogSet(struct logInfo *log, int force)
+     return hasErrors;
+ }
+ 
+-static int writeState(char *stateFilename)
++static int writeState(struct logInfo *log, char *stateFilename)
+ {
+ 	struct logState *p;
+ 	FILE *f;
+@@ -2227,7 +2274,7 @@ static int writeState(char *stateFilename)
+ 		fclose(f);
+ 
+ 	if (error == 0) {
+-		if (rename(tmpFilename, stateFilename)) {
++		if (mvFile(tmpFilename, stateFilename, log, prev_acl)) {
+ 			unlink(tmpFilename);
+ 			error = 1;
+ 			message(MESS_ERROR, "error renaming temp state file %s\n",
+@@ -2525,7 +2572,7 @@ int main(int argc, const char **argv)
+ 		rc |= rotateLogSet(log, force);
+ 
+ 	if (!debug)
+-		rc |= writeState(stateFile);
++		rc |= writeState(log, stateFile);
+ 
+ 	return (rc != 0);
+ }

--- a/recipes-extended/logrotate/logrotate/disable-check-different-filesystems.patch
+++ b/recipes-extended/logrotate/logrotate/disable-check-different-filesystems.patch
@@ -1,0 +1,32 @@
+Disable the check for different filesystems
+
+The logrotate supports rotate log across different filesystems now, so
+disable the check for different filesystems.
+
+Upstream-Status: Pending
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ config.c |    9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/config.c b/config.c
+index dbbf563..64e66f6 100644
+--- a/config.c
++++ b/config.c
+@@ -1493,15 +1493,6 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
+ 							goto error;
+ 						}
+ 					}
+-
+-					if (sb.st_dev != sb2.st_dev
+-						&& !(newlog->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY | LOG_FLAG_TMPFILENAME))) {
+-						message(MESS_ERROR,
+-							"%s:%d olddir %s and log file %s "
+-							"are on different devices\n", configFile,
+-							lineNum, newlog->oldDir, newlog->files[i]);
+-						goto error;
+-					}
+ 				}
+ 			}
+ 

--- a/recipes-extended/logrotate/logrotate/update-the-manual.patch
+++ b/recipes-extended/logrotate/logrotate/update-the-manual.patch
@@ -1,0 +1,38 @@
+From e0b0fe30e9c49234994a20a86aacfaf80e690087 Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Tue, 17 Feb 2015 21:14:37 -0800
+Subject: [PATCH] Update the manual
+
+Update the manual for rotating on different filesystems.
+
+Upstream-Status: Pending
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ logrotate.8 |   10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/logrotate.8 b/logrotate.8
+index e4e5f48..84407d0 100644
+--- a/logrotate.8
++++ b/logrotate.8
+@@ -405,12 +405,10 @@ Do not rotate the log if it is empty (this overrides the \fBifempty\fR option).
+ 
+ .TP
+ \fBolddir \fIdirectory\fR
+-Logs are moved into \fIdirectory\fR for rotation. The \fIdirectory\fR must be
+-on the same physical device as the log file being rotated, unless \fBcopy\fR,
+-\fBcopytruncate\fR or \fBrenamecopy\fR option is used. The \fIdirectory\fR
+-is assumed to be relative to the directory holding the log file
+-unless an absolute path name is specified. When this option is used all
+-old versions of the log end up in \fIdirectory\fR.  This option may be
++Logs are moved into \fIdirectory\fR for rotation. The \fIdirectory\fR
++is assumed to be relative to the directory holding the log file unless
++an absolute path name is specified. When this option is used all old
++versions of the log end up in \fIdirectory\fR. This option may be
+ overridden by the \fBnoolddir\fR option.
+ 
+ .TP
+-- 
+1.7.9.5
+

--- a/recipes-extended/logrotate/logrotate_3.9.1.bb
+++ b/recipes-extended/logrotate/logrotate_3.9.1.bb
@@ -1,0 +1,71 @@
+SUMMARY = "Rotates, compresses, removes and mails system log files"
+SECTION = "console/utils"
+HOMEPAGE = "https://github.com/logrotate/logrotate/issues"
+LICENSE = "GPLv2"
+
+# TODO: logrotate 3.8.8 adds autotools/automake support, update recipe to use it.
+# TODO: Document coreutils dependency. Why not RDEPENDS? Why not busybox?
+
+DEPENDS="coreutils popt"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=18810669f13b87348459e611d31ab760"
+# When updating logrotate to latest upstream, SRC_URI should point to
+# a proper release tarball from https://github.com/logrotate/logrotate/releases
+# and we have to take the snapshot for now because there is no such
+# tarball available for 3.9.1.
+
+S = "${WORKDIR}/${BPN}-r3-9-1"
+
+UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"
+
+SRC_URI = "https://github.com/${BPN}/${BPN}/archive/r3-9-1.tar.gz \
+           file://act-as-mv-when-rotate.patch \
+           file://update-the-manual.patch \
+           file://disable-check-different-filesystems.patch \
+            "
+
+SRC_URI[md5sum] = "8572b7c2cf9ade09a8a8e10098500fb3"
+SRC_URI[sha256sum] = "5bf8e478c428e7744fefa465118f8296e7e771c981fb6dffb7527856a0ea3617"
+
+PACKAGECONFIG ?= "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'acl', 'acl', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'selinux', 'selinux', '', d)} \
+"
+
+PACKAGECONFIG[acl] = ",,acl"
+PACKAGECONFIG[selinux] = ",,libselinux"
+
+CONFFILES_${PN} += "${localstatedir}/lib/logrotate.status \
+                    ${sysconfdir}/logrotate.conf"
+
+# If RPM_OPT_FLAGS is unset, it adds -g itself rather than obeying our
+# optimization variables, so use it rather than EXTRA_CFLAGS.
+EXTRA_OEMAKE = "\
+    LFS= \
+    OS_NAME='${OS_NAME}' \
+    'CC=${CC}' \
+    'RPM_OPT_FLAGS=${CFLAGS}' \
+    'EXTRA_LDFLAGS=${LDFLAGS}' \
+    ${@bb.utils.contains('PACKAGECONFIG', 'acl', 'WITH_ACL=yes', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'selinux', 'WITH_SELINUX=yes', '', d)} \
+"
+
+# OS_NAME in the makefile defaults to `uname -s`. The behavior for
+# freebsd/netbsd is questionable, so leave it as Linux, which only sets
+# INSTALL=install and BASEDIR=/usr.
+OS_NAME = "Linux"
+
+do_compile_prepend() {
+    # Make sure the recompile is OK
+    rm -f ${B}/.depend
+}
+
+do_install(){
+    oe_runmake install DESTDIR=${D} PREFIX=${D} MANDIR=${mandir}
+    mkdir -p ${D}${sysconfdir}/logrotate.d
+    mkdir -p ${D}${sysconfdir}/cron.daily
+    mkdir -p ${D}${localstatedir}/lib
+    install -p -m 644 examples/logrotate-default ${D}${sysconfdir}/logrotate.conf
+    install -p -m 755 examples/logrotate.cron ${D}${sysconfdir}/cron.daily/logrotate
+    touch ${D}${localstatedir}/lib/logrotate.status
+}


### PR DESCRIPTION
From: Choong YinThong
Date: Sun, 9 Apr 2017 16:33:18 -0700
Subject: [PATCH] logrotate: replace fedorahosted.org SRC_URI with github.com
 source

fedorahosted.org was retired on March 1st, 2017. This is to
update the SRC_URI to point to github.com.
Update the ${PN} to ${BPN} in order to pass the autobuilder
mulitlib enable configuration.

[YOCTO #11226]
OXT-1081