### PR TITLE
OXT-978: libv4v: Produce PIC static libraries.

### DIFF
--- a/recipes-openxt/libv4v/libv4v_git.bb
+++ b/recipes-openxt/libv4v/libv4v_git.bb
@@ -13,6 +13,8 @@ S = "${WORKDIR}/git/libv4v"
 
 inherit autotools-brokensep pkgconfig lib_package xenclient
 
+EXTRA_OECONF += "--with-pic"
+
 do_install_append(){
     install -d ${D}/etc
     install -d ${D}/etc/udev


### PR DESCRIPTION
Some dynamic libraries will link against the static libv4v*.a. By
default, libtool will generate PIC dynamic libraries and non-PIC static
libraries.

libvhd.so (through libicbinn) links against libv4v.a, and the SELinux
does not allow execmod. In the end, tapdisk will fail to create
service-vm tapdisk from vhds with avc:
avc:  denied  { execmod } for  pid=1071 comm="tapdisk2" path="/usr/lib/libvhd.so.1.0.0" dev="dm-3" ino=6354 scontext=system_u:system_r:tapdisk_t:s0-s0:c0.c1023 tcontext=system_u:object_r:lib_t:s0 tclass=file permissive=0

OXT-978