### PR TITLE
STABLE-7: [libxl] Fix segfault caused by strstr on domain

### DIFF
--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -73,17 +73,18 @@ Index: xen-4.6.4/tools/libxl/libxl.c
  
      tmp = READ_LIBXLDEV(gc, "handle");
      if (tmp)
-@@ -3563,6 +3581,9 @@ static int libxl__device_nic_from_xensto
-                                 GCSPRINTF("%s/backend", libxl_path), &tmp);
-     if (rc) goto out;
- 
+@@ -3568,6 +3586,10 @@ static int libxl__device_nic_from_xensto
+         rc = ERROR_FAIL;
+         goto out;
+     }
++
 +    if (strstr(tmp, "vwif"))
 +        libxl_defbool_set(&nic->wireless, true);
 +
-     if (!tmp) {
-         LOG(ERROR, "nic %s does not exist (no backend path)", libxl_path);
-         rc = ERROR_FAIL;
-@@ -3607,6 +3628,7 @@ int libxl_devid_to_device_nic(libxl_ctx
+     rc = libxl__backendpath_parse_domid(gc, tmp, &nic->backend_domid);
+     if (rc) goto out;
+ 
+@@ -3607,6 +3629,7 @@ int libxl_devid_to_device_nic(libxl_ctx
      GC_INIT(ctx);
      char *libxl_dom_path, *libxl_path;
      int rc = ERROR_FAIL;
@@ -91,7 +92,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
  
      libxl_device_nic_init(nic);
      libxl_dom_path = libxl__xs_libxl_path(gc, domid);
-@@ -3614,6 +3636,9 @@ int libxl_devid_to_device_nic(libxl_ctx
+@@ -3614,6 +3637,9 @@ int libxl_devid_to_device_nic(libxl_ctx
          goto out;
  
      libxl_path = GCSPRINTF("%s/device/vif/%d", libxl_dom_path, devid);
@@ -101,7 +102,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
  
      rc = libxl__device_nic_from_xenstore(gc, libxl_path, nic);
      if (rc) goto out;
-@@ -3627,13 +3652,14 @@ out:
+@@ -3627,13 +3653,14 @@ out:
  static int libxl__append_nic_list(libxl__gc *gc,
                                             uint32_t domid,
                                             libxl_device_nic **nics,
@@ -118,7 +119,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
  
      libxl_dir_path = GCSPRINTF("%s/device/vif",
                                 libxl__xs_libxl_path(gc, domid));
-@@ -3654,9 +3680,14 @@ static int libxl__append_nic_list(libxl_
+@@ -3654,9 +3681,14 @@ static int libxl__append_nic_list(libxl_
          }
          *nnics += n;
      }
@@ -134,7 +135,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
      return rc;
  }
  
-@@ -3668,7 +3699,7 @@ libxl_device_nic *libxl_device_nic_list(
+@@ -3668,7 +3700,7 @@ libxl_device_nic *libxl_device_nic_list(
  
      *num = 0;
  
@@ -143,7 +144,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
      if (rc) goto out_err;
  
      GC_FREE;
-@@ -3695,9 +3726,15 @@ int libxl_device_nic_getinfo(libxl_ctx *
+@@ -3695,9 +3727,15 @@ int libxl_device_nic_getinfo(libxl_ctx *
      dompath = libxl__xs_get_dompath(gc, domid);
      nicinfo->devid = nic->devid;
  
@@ -162,7 +163,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
      nicinfo->backend = xs_read(ctx->xsh, XBT_NULL,
                                  GCSPRINTF("%s/backend", libxl_path), NULL);
      if (!nicinfo->backend) {
-@@ -4490,9 +4527,11 @@ static int add_device(libxl__egc *egc, l
+@@ -4490,9 +4528,11 @@ static int add_device(libxl__egc *egc, l
  
      switch(dev->backend_kind) {
      case LIBXL__DEVICE_KIND_VBD:
@@ -176,7 +177,7 @@ Index: xen-4.6.4/tools/libxl/libxl.c
  
          GCNEW(aodev);
          libxl__prepare_ao_device(ao, aodev);
-@@ -4533,9 +4572,11 @@ static int remove_device(libxl__egc *egc
+@@ -4533,9 +4573,11 @@ static int remove_device(libxl__egc *egc
  
      switch(ddev->dev->backend_kind) {
      case LIBXL__DEVICE_KIND_VBD:


### PR DESCRIPTION
  shutdown. Just check and make sure tmp != NULL before calling
  strstr.

  OXT-1086

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>