### PR TITLE
OXT-1016: Only build the Xen recipes once per build

### DIFF
--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -93,3 +93,19 @@ PACKAGECONFIG =+ "xsm"
 PACKAGECONFIG =+ "hvm"
 
 S = "${WORKDIR}/xen-${PV}"
+
+#--
+# Modifications to the meta-virtualiation configuration (ref: OXT-1016)
+
+# iproute2 on OpenXT is currently a MACHINE-specific recipe
+# which causes all recipes that DEPEND upon it to be rebuilt for each MACHINE.
+# Drop that apparently-unnecessary dependency here to avoid that.
+
+DEPENDS_remove = "iproute2"
+
+# The stubs and deploy tasks are detected as MACHINE-specific due to the
+# variables that they use. Those tasks are not required here so drop them.
+
+deltask stubs
+deltask deploy
+#--

--- a/recipes-openxt/libv4v/libv4v_git.bb
+++ b/recipes-openxt/libv4v/libv4v_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "XenClient V4V library and interposer"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=321bf41f280cf805086dd5a720b37785"
-DEPENDS = "xen v4v-module"
+DEPENDS = "xen v4v-module-headers"
 
 PV = "git${SRCPV}"
 

--- a/recipes-openxt/xenclient/v4v-module-headers_git.bb
+++ b/recipes-openxt/xenclient/v4v-module-headers_git.bb
@@ -1,0 +1,35 @@
+DESCRIPTION = "v4v kernel module headers"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://v4v.h;beginline=6;endline=32;md5=8054a75b345d2cd08e16f9dd0ad9283b"
+
+PV = "git${SRCPV}"
+
+DEPENDS = ""
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "git://${OPENXT_GIT_MIRROR}/v4v.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+
+S = "${WORKDIR}/git/v4v"
+
+INHIBIT_DEFAULT_DEPS = "1"
+EXCLUDE_FROM_SHLIBS = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_PACKAGE_STRIP = "1"
+
+do_configure() {
+}
+
+do_compile() {
+}
+
+do_install() {
+    install -m 0755 -d ${D}/usr/include/linux
+    install -m 0755 -d ${STAGING_KERNEL_DIR}/include/xen
+    install -m 0755 -d ${STAGING_KERNEL_DIR}/include/linux
+    install -m 644 include/xen/v4v.h ${STAGING_KERNEL_DIR}/include/xen/v4v.h
+    install -m 644 linux/v4v_dev.h ${D}/usr/include/linux/v4v_dev.h
+    install -m 644 linux/v4v_dev.h ${STAGING_KERNEL_DIR}/include/linux/v4v_dev.h
+}
+
+STAGING_KERNEL_DIR[vardepsexclude] = "MACHINE"
+do_install[vardepsexclude] = "MACHINE"

--- a/recipes-openxt/xenclient/v4v-module_git.bb
+++ b/recipes-openxt/xenclient/v4v-module_git.bb
@@ -14,6 +14,7 @@ DEB_DESC_EXT="This package provides the XenClient v4v kernel module."
 DEB_SECTION="misc"
 DEB_PKG_MAINTAINER = "Citrix Systems <customerservice@citrix.com>"
 
+DEPENDS_append += " v4v-module-headers"
 DEPENDS_append_xenclient-nilfvm += " ${@deb_bootstrap_deps(d)} "
 
 inherit ${@"xenclient-simple-deb"if(d.getVar("MACHINE",1)=="xenclient-nilfvm")else("null")}
@@ -27,22 +28,10 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/v4v.git;protocol=${OPENXT_GIT_PROTOCOL};br
 
 S = "${WORKDIR}/git/v4v"
 
-do_install_headers() {
-        #install -m 0755 -d ${D}/usr/include/xen
-        install -m 0755 -d ${D}/usr/include/linux
-        install -m 0755 -d ${STAGING_KERNEL_DIR}/include/xen
-        install -m 0755 -d ${STAGING_KERNEL_DIR}/include/linux
-	#install -m 644 include/xen/v4v.h ${D}/usr/include/xen/v4v.h
-	install -m 644 include/xen/v4v.h ${STAGING_KERNEL_DIR}/include/xen/v4v.h
-	install -m 644 linux/v4v_dev.h ${D}/usr/include/linux/v4v_dev.h
-	install -m 644 linux/v4v_dev.h ${STAGING_KERNEL_DIR}/include/linux/v4v_dev.h
-}
 do_install_append_xenclient-nilfvm() {
 	## to generate deb package
 	sed -i "s|@KERNEL_VERSION@|${KERNEL_VERSION}|g" "${WORKDIR}/DEBIAN_postinst"
 	do_simple_deb_package
 }
-
-addtask install_headers after do_install before do_package do_populate_sysroot
 
 MAKE_TARGETS += "modules"


### PR DESCRIPTION
Remove the MACHINE-specific dependencies affecting the Xen recipes so that they no longer have to be recompiled per MACHINE.

PRs for: xenclient-oe, openxt and meta-openxt-ocaml-platform.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>