### PR TITLE
OXT-826 : XSM: Add distinct device use permissions with and without IOMMU

### DIFF
--- a/recipes-extended/xen/files/xsm-for-vtd.patch
+++ b/recipes-extended/xen/files/xsm-for-vtd.patch
@@ -217,7 +217,7 @@ diff --git a/xen/xsm/flask/policy/access_vectors b/xen/xsm/flask/policy/access_v
 index b06cf16..92f4a0f 100644
 --- a/xen/xsm/flask/policy/access_vectors
 +++ b/xen/xsm/flask/policy/access_vectors
-@@ -430,6 +430,12 @@ class resource
+@@ -430,6 +430,11 @@ class resource
  #  target = resource's security label
  # also checked when using some core Xen devices (target xen_t)
      use
@@ -225,12 +225,11 @@ index b06cf16..92f4a0f 100644
 +# checked when adding a resource to a domain:
 +#  source = domain which will have access to the resource
 +#  target = resource's security label
-+# also checked when using some core Xen devices (target xen_t)
 +    use_with_iommu
  # PHYSDEVOP_map_pirq and ioapic writes for dom0, when acting on real IRQs
  #  For GSI interrupts, the IRQ's label is indexed by the IRQ number
  #  For MSI interrupts, the label of the PCI device is used
-@@ -462,6 +468,15 @@ class resource
+@@ -462,6 +467,15 @@ class resource
      setup
  }
  

--- a/recipes-extended/xen/files/xsm-for-vtd.patch
+++ b/recipes-extended/xen/files/xsm-for-vtd.patch
@@ -1,0 +1,259 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Enable XSM control over device passthrough with separate policy controls for:
+* with and without an IOMMU available
+* an IOMMU with more capable isolation, in this case via interrupt remapping
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+
+################################################################################
+CHANGELOG
+################################################################################
+
+################################################################################
+REMOVAL
+################################################################################
+Via upstreaming.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Yes.
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+OpenXT's XSM policy in xsm-policy.git
+
+################################################################################
+PATCHES
+################################################################################
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 59905e2..bac29ad 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -20,6 +20,7 @@
+ #include <xen/errno.h>
+ #include <xen/guest_access.h>
+ #include <xen/xenoprof.h>
++#include <xen/iommu.h>
+ #ifdef HAS_PCI
+ #include <asm/msi.h>
+ #endif
+@@ -866,11 +867,41 @@ static int flask_map_domain_msi (struct domain *d, int irq, void *data,
+ #endif
+ }
+ 
++static u32 flask_iommu_resource_use_perm(void)
++{
++    /* This function defines the permission level required for allowing
++     * domains to use assigned devices.
++     *
++     * Interrupt remapping is an essential property for ensuring strict
++     * isolation of devices.
++     *
++     * If strict isolation is not available then check the platform permission
++     * to see whether the policy allows use of a less capable IOMMU.
++     */
++    struct av_decision avd;
++    u32 csid = domain_sid(current->domain);
++
++    /* Use the noaudit method for checking this permission because
++     * we're identifying which _other_ permission to check for.
++     * Failure here is sometimes expected and always acceptable so
++     * it is important not to log it to protect the logs.
++     */
++    if (iommu_enabled && (iommu_intremap ||
++                          !avc_has_perm_noaudit(csid, SECINITSID_XEN,
++                                                SECCLASS_IOMMU,
++                                                IOMMU__USE_INSECURE, &avd)))
++        return RESOURCE__USE_WITH_IOMMU;
++
++    /* Otherwise return the general USE permission */
++    return RESOURCE__USE;
++}
++
+ static int flask_map_domain_irq (struct domain *d, int irq, void *data)
+ {
+     u32 sid, dsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     if ( irq >= nr_static_irqs && data ) {
+         rc = flask_map_domain_msi(d, irq, data, &sid, &ad);
+@@ -887,7 +918,7 @@ static int flask_map_domain_irq (struct domain *d, int irq, void *data)
+     if ( rc )
+         return rc;
+ 
+-    rc = avc_has_perm(dsid, sid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    rc = avc_has_perm(dsid, sid, SECCLASS_RESOURCE, dperm, &ad);
+     return rc;
+ }
+ 
+@@ -936,6 +967,7 @@ static int flask_bind_pt_irq (struct domain *d, struct xen_domctl_bind_pt_irq *b
+     int rc = -EPERM;
+     int irq;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     rc = current_has_perm(d, SECCLASS_RESOURCE, RESOURCE__ADD);
+     if ( rc )
+@@ -952,7 +984,7 @@ static int flask_bind_pt_irq (struct domain *d, struct xen_domctl_bind_pt_irq *b
+         return rc;
+ 
+     dsid = domain_sid(d);
+-    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+ static int flask_unbind_pt_irq (struct domain *d, struct xen_domctl_bind_pt_irq *bind)
+@@ -970,6 +1002,7 @@ struct iomem_has_perm_data {
+     u32 ssid;
+     u32 dsid;
+     u32 perm;
++    u32 use_perm;
+ };
+ 
+ static int _iomem_has_perm(void *v, u32 sid, unsigned long start, unsigned long end)
+@@ -987,7 +1020,7 @@ static int _iomem_has_perm(void *v, u32 sid, unsigned long start, unsigned long
+     if ( rc )
+         return rc;
+ 
+-    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, data->use_perm, &ad);
+ }
+ 
+ static int flask_iomem_permission(struct domain *d, uint64_t start, uint64_t end, uint8_t access)
+@@ -1007,6 +1040,7 @@ static int flask_iomem_permission(struct domain *d, uint64_t start, uint64_t end
+ 
+     data.ssid = domain_sid(current->domain);
+     data.dsid = domain_sid(d);
++    data.use_perm = flask_iommu_resource_use_perm();
+ 
+     return security_iterate_iomem_sids(start, end, _iomem_has_perm, &data);
+ }
+@@ -1021,7 +1055,7 @@ static int flask_pci_config_permission(struct domain *d, uint32_t machine_bdf, u
+     u32 dsid, rsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
+-    u32 perm = RESOURCE__USE;
++    u32 perm;
+ 
+     rc = security_device_sid(machine_bdf, &rsid);
+     if ( rc )
+@@ -1030,6 +1064,8 @@ static int flask_pci_config_permission(struct domain *d, uint32_t machine_bdf, u
+     /* Writes to the BARs count as setup */
+     if ( access && (end >= 0x10 && start < 0x28) )
+         perm = RESOURCE__SETUP;
++    else
++        perm = flask_iommu_resource_use_perm();
+ 
+     AVC_AUDIT_DATA_INIT(&ad, DEV);
+     ad.device = (unsigned long) machine_bdf;
+@@ -1243,6 +1279,7 @@ static int flask_assign_device(struct domain *d, uint32_t machine_bdf)
+     u32 dsid, rsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     rc = current_has_perm(d, SECCLASS_RESOURCE, RESOURCE__ADD);
+     if ( rc )
+@@ -1259,7 +1296,7 @@ static int flask_assign_device(struct domain *d, uint32_t machine_bdf)
+         return rc;
+ 
+     dsid = domain_sid(d);
+-    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+ static int flask_deassign_device(struct domain *d, uint32_t machine_bdf)
+@@ -1298,6 +1335,7 @@ static int flask_assign_dtdevice(struct domain *d, const char *dtpath)
+     u32 dsid, rsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     rc = current_has_perm(d, SECCLASS_RESOURCE, RESOURCE__ADD);
+     if ( rc )
+@@ -1314,7 +1352,7 @@ static int flask_assign_dtdevice(struct domain *d, const char *dtpath)
+         return rc;
+ 
+     dsid = domain_sid(d);
+-    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+ static int flask_deassign_dtdevice(struct domain *d, const char *dtpath)
+@@ -1373,6 +1411,7 @@ struct ioport_has_perm_data {
+     u32 ssid;
+     u32 dsid;
+     u32 perm;
++    u32 use_perm;
+ };
+ 
+ static int _ioport_has_perm(void *v, u32 sid, unsigned long start, unsigned long end)
+@@ -1390,7 +1429,7 @@ static int _ioport_has_perm(void *v, u32 sid, unsigned long start, unsigned long
+     if ( rc )
+         return rc;
+ 
+-    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, data->use_perm, &ad);
+ }
+ 
+ static int flask_ioport_permission(struct domain *d, uint32_t start, uint32_t end, uint8_t access)
+@@ -1411,6 +1450,7 @@ static int flask_ioport_permission(struct domain *d, uint32_t start, uint32_t en
+ 
+     data.ssid = domain_sid(current->domain);
+     data.dsid = domain_sid(d);
++    data.use_perm = flask_iommu_resource_use_perm();
+ 
+     return security_iterate_ioport_sids(start, end, _ioport_has_perm, &data);
+ }
+diff --git a/xen/xsm/flask/policy/access_vectors b/xen/xsm/flask/policy/access_vectors
+index b06cf16..92f4a0f 100644
+--- a/xen/xsm/flask/policy/access_vectors
++++ b/xen/xsm/flask/policy/access_vectors
+@@ -430,6 +430,12 @@ class resource
+ #  target = resource's security label
+ # also checked when using some core Xen devices (target xen_t)
+     use
++# IOMMU required before a resource will be added to a domain:
++# checked when adding a resource to a domain:
++#  source = domain which will have access to the resource
++#  target = resource's security label
++# also checked when using some core Xen devices (target xen_t)
++    use_with_iommu
+ # PHYSDEVOP_map_pirq and ioapic writes for dom0, when acting on real IRQs
+ #  For GSI interrupts, the IRQ's label is indexed by the IRQ number
+ #  For MSI interrupts, the label of the PCI device is used
+@@ -462,6 +468,15 @@ class resource
+     setup
+ }
+ 
++# Class IOMMU governs whether a weak IOMMU is tolerable
++class iommu
++{
++# Allow use of an insecure IOMMU to grant resouces to domains that
++# require an IOMMU.
++# Provided to allow an administrator to consent and enable older hardware.
++    use_insecure
++}
++
+ # Class security describes the FLASK security server itself; these operations
+ # are accessed using the xsm_op hypercall.  The source is the domain invoking
+ # the hypercall, and the target is security_t.
+diff --git a/xen/xsm/flask/policy/security_classes b/xen/xsm/flask/policy/security_classes
+index 03dedf8..7a82118 100644
+--- a/xen/xsm/flask/policy/security_classes
++++ b/xen/xsm/flask/policy/security_classes
+@@ -19,5 +19,6 @@ class event
+ class grant
+ class security
+ class v4v
++class iommu
+ 
+ # FLASK

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -49,6 +49,7 @@ SRC_URI_append = " \
     file://openxt-xen-xsmv4vuse.patch \
     file://xenstat-disable-tmem-use.patch;patch=1 \
     file://acpi-slic-support.patch \
+    file://xsm-for-vtd.patch \
     file://libxl-do-not-destroy-in-use-tapdevs.patch \
     file://libxl-syslog.patch \
     file://libxl-RFC-4of7-Add-stubdomain-version-tools-domain-build-info.patch \


### PR DESCRIPTION
[ PR for initial @dpsmith review ]

Enable policy to express control over device access:
 * Enable policy to optionally express that device access is only allowed when an IOMMU is active.
 * Enable policy to require an IOMMU capable of interrupt remapping before granting device access that depends on an IOMMU.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>