### PR TITLE
STABLE-7: [xl] On reboot, have xl reparse the config

### DIFF
--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -386,7 +386,27 @@ Index: xen-4.6.4/tools/libxl/xl_cmdimpl.c
          }
      }
  
-@@ -3018,8 +2998,6 @@ start:
+@@ -2704,8 +2684,10 @@ static uint32_t create_domain(struct dom
+     int restore_fd_to_close = -1;
+     const libxl_asyncprogress_how *autoconnect_console_how;
+     struct save_file_header hdr;
++    int restoring;
+ 
+-    int restoring = (restore_file || (migrate_fd >= 0));
++start:
++    restoring = (restore_file || (migrate_fd >= 0));
+ 
+     libxl_domain_config_init(&d_config);
+ 
+@@ -2875,7 +2857,6 @@ static uint32_t create_domain(struct dom
+     if (dom_info->dryrun)
+         goto out;
+ 
+-start:
+     assert(domid == INVALID_DOMID);
+ 
+     rc = acquire_lock();
+@@ -3018,8 +2999,6 @@ start:
                   */
                  dom_info->console_autoconnect = 0;
  
@@ -395,7 +415,7 @@ Index: xen-4.6.4/tools/libxl/xl_cmdimpl.c
                  if (common_domname
                      && strcmp(d_config.c_info.name, common_domname)) {
                      d_config.c_info.name = strdup(common_domname);
-@@ -3698,13 +3676,17 @@ static void unpause_domain(uint32_t domi
+@@ -3698,13 +3677,17 @@ static void unpause_domain(uint32_t domi
  static void destroy_domain(uint32_t domid, int force)
  {
      int rc;


### PR DESCRIPTION
  Move the jump label for the domain reboot case to also include
  the config parse code, since xenmgr just writes a new config
  to the same filename.  This fixes the bug where config value
  changes such as changing the memory amount aren't taking effect
  on reboot

  OXT-1090

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>