### PR TITLE
  STABLE-7: Support swapping isos in virtual cd drive

### DIFF
--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -1,0 +1,352 @@
+commit d04740f8f1dfc5c2149863aa3f896ac4664b5c88
+Author: Chris Rogers <rogersc@ainfosec.com>
+Date:   Tue Apr 18 14:43:21 2017 -0400
+
+    implement iso hotswap
+
+Index: xen-4.6.4/tools/libxl/libxl.c
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl.c
++++ xen-4.6.4/tools/libxl/libxl.c
+@@ -2940,6 +2940,126 @@ int libxl_device_disk_getinfo(libxl_ctx
+     return rc;
+ }
+ 
++int libxl_cdrom_change(libxl_ctx *ctx, uint32_t domid, char *iso, libxl_device_disk *olddisk, char *vdev,
++                       const libxl_asyncop_how *ao_how)
++{
++    AO_CREATE(ctx, domid, ao_how);
++    int rc = -1;
++    libxl__device device;
++    libxl_device_disk disk_empty;
++    xs_transaction_t t = XBT_NULL;
++    char *devpath = NULL;
++    char *be_path = NULL;
++    char *fe_path = NULL;
++    char *tmp = NULL;
++    char *be_state = NULL;
++    char *fe_state = NULL;
++    uint32_t stubdomid = libxl_get_stubdom_id(ctx, domid);
++    libxl__domain_userdata_lock *lock = NULL;
++
++    memset(&device, 0, sizeof(libxl__device));
++    memset(&disk_empty, 0, sizeof(libxl_device_disk));
++
++    struct xs_permissions roperm[2];
++    roperm[0].id = 0;
++    roperm[0].perms = XS_PERM_NONE;
++    roperm[1].id = stubdomid;
++    roperm[1].perms = XS_PERM_READ;
++
++    /* get our empty disk setup */
++    libxl_device_disk_init(&disk_empty);
++    disk_empty.format = LIBXL_DISK_FORMAT_EMPTY;
++    disk_empty.vdev = libxl__strdup(NOGC, olddisk->vdev);
++    disk_empty.pdev_path = libxl__strdup(NOGC, "");
++    disk_empty.is_cdrom = 1;
++    libxl__device_disk_setdefault(gc, &disk_empty);
++
++    lock = libxl__lock_domain_userdata(gc, domid);
++    if (!lock) {
++        rc = ERROR_LOCK_FAIL;
++        goto out;
++    }
++
++    /* tap iso, if it's already tapped it will return the existing tap */
++    devpath = libxl__blktap_devpath(gc, iso, LIBXL_DISK_FORMAT_EMPTY, "/config/platform-crypto-keys");
++
++    rc = libxl__device_from_disk(gc, stubdomid, olddisk, &device);
++    if (rc){
++        fprintf(stderr, "can't create device from disk\n");
++        goto out;
++    }
++    /* insert empty cdrom */
++    libxl__qmp_insert_cdrom(gc, domid, &disk_empty);
++
++    be_path = libxl__device_backend_path(gc, &device);
++    fe_path = libxl__device_frontend_path(gc, &device);
++
++    /* disconnect iso for now */
++    do {
++        t = xs_transaction_start(ctx->xsh);
++        tmp = libxl__xs_read(gc, t, libxl__sprintf(gc, "%s/tapdisk-params", be_path));
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/online", be_path), "%s", "0");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/state", be_path), "%s", "5");
++    } while (xs_transaction_end(ctx->xsh, t, false) == false && errno == EAGAIN);
++
++    /* make sure we're disconnected */
++    while(1) {
++        be_state = libxl__xs_read(gc, XBT_NULL, libxl__sprintf(gc, "%s/state", be_path));
++        fe_state = libxl__xs_read(gc, XBT_NULL, libxl__sprintf(gc, "%s/state", fe_path));
++        if(!strcmp(be_state, "6") && !strcmp(fe_state, "6"))
++            break;
++        sleep(1);
++    }
++
++    /* Destroy old xenbus */
++    do {
++        t = xs_transaction_start(ctx->xsh);
++        libxl__xs_rm_checked(gc, t, be_path);
++        libxl__xs_rm_checked(gc, t, fe_path);
++    } while (xs_transaction_end(ctx->xsh, t, false) == false && errno == EAGAIN);
++
++    /* cleanup old tap if it's not shared with anyone else */
++    if(!tapdev_is_shared(gc, tmp))
++        libxl__device_destroy_tapdisk(gc, tmp, stubdomid);
++
++    /*write new device */
++    do {
++        t = xs_transaction_start(ctx->xsh);
++        libxl__xs_mkdir(gc, t, be_path, roperm, ARRAY_SIZE(roperm));
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/params", be_path), "%s", devpath);
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/type", be_path), "%s", "phy");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/physical-device", be_path), "fe:%d", libxl__get_tap_minor(gc, LIBXL_DISK_FORMAT_EMPTY, iso));
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/frontend", be_path), "%s", fe_path);
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/device-type", be_path), "%s", "cdrom");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/online", be_path), "%s", "1");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/state", be_path), "%s", "1");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/removable", be_path), "%s", "1");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/mode", be_path), "%s", "1");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/frontend-id", be_path), "%u", stubdomid);
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/dev", be_path), "%s", "hdc");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/tapdisk-params", be_path), "%s", libxl__sprintf(gc, "aio:%s", iso));
++
++        roperm[0].id = stubdomid;
++        roperm[1].id = 0;
++        libxl__xs_mkdir(gc, t, fe_path, roperm, ARRAY_SIZE(roperm));
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/state", fe_path), "%s", "1");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/backend-id", fe_path), "%s", "0");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/backend", fe_path), "%s", be_path);
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/virtual-device", fe_path), "%s", vdev);
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/device-type", fe_path), "%s", "cdrom");
++        libxl__xs_write(gc, t, libxl__sprintf(gc, "%s/backend-uuid", fe_path), "%s", "00000000-0000-0000-0000-000000000000");
++     } while (xs_transaction_end(ctx->xsh, t, false) == false && errno == EAGAIN);
++
++    /* tell qemu to remount /dev/xvdc */
++    libxl__qmp_change_cdrom(gc, domid, olddisk);
++
++    libxl__ao_complete(egc, ao, 0);
++out:
++    if (lock) libxl__unlock_domain_userdata(lock);
++    if (rc) return AO_CREATE_FAIL(rc);
++    return AO_INPROGRESS;
++}
++
+ int libxl_cdrom_insert(libxl_ctx *ctx, uint32_t domid, libxl_device_disk *disk,
+                        const libxl_asyncop_how *ao_how)
+ {
+Index: xen-4.6.4/tools/libxl/libxl.h
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl.h
++++ xen-4.6.4/tools/libxl/libxl.h
+@@ -1392,6 +1392,9 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+                        const libxl_asyncop_how *ao_how)
+                        LIBXL_EXTERNAL_CALLERS_ONLY;
+ 
++int libxl_cdrom_change(libxl_ctx *ctx, uint32_t domid, char * iso, libxl_device_disk *disk, char *vdev,
++                       const libxl_asyncop_how *ao_how)
++                       LIBXL_EXTERNAL_CALLERS_ONLY;
+ /* Network Interfaces */
+ int libxl_device_nic_add(libxl_ctx *ctx, uint32_t domid, libxl_device_nic *nic,
+                          const libxl_asyncop_how *ao_how)
+Index: xen-4.6.4/tools/libxl/libxl_blktap2.c
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl_blktap2.c
++++ xen-4.6.4/tools/libxl/libxl_blktap2.c
+@@ -23,6 +23,18 @@ int libxl__blktap_enabled(libxl__gc *gc)
+     return !tap_ctl_check(&msg);
+ }
+ 
++int libxl__get_tap_minor(libxl__gc *gc, libxl_disk_format format, const char *disk)
++{
++    const char *type = NULL;
++    tap_list_t tap;
++
++    memset(&tap, 0, sizeof(tap_list_t));
++
++    type = libxl__device_disk_string_of_format(format);
++    tap_ctl_find(type, disk, &tap);
++    return tap.minor;
++}
++
+ char *libxl__blktap_devpath(libxl__gc *gc,
+                             const char *disk,
+                             libxl_disk_format format,
+@@ -56,7 +68,7 @@ char *libxl__blktap_devpath(libxl__gc *g
+     return NULL;
+ }
+ 
+-static bool tapdev_is_shared(libxl__gc *gc, const char *params)
++bool tapdev_is_shared(libxl__gc *gc, const char *params)
+ {
+     char **domids, **vbds;
+     char *tp;
+Index: xen-4.6.4/tools/libxl/libxl_internal.h
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl_internal.h
++++ xen-4.6.4/tools/libxl/libxl_internal.h
+@@ -1696,6 +1696,9 @@ _hidden char *libxl__blktap_devpath(libx
+                                     libxl_disk_format format,
+                                     char *keydir);
+ 
++_hidden int libxl__get_tap_minor(libxl__gc *gc, libxl_disk_format format, const char *disk);
++_hidden bool tapdev_is_shared(libxl__gc *gc, const char *params);
++
+ /* libxl__device_destroy_tapdisk:
+  *   Destroys any tapdisk process associated with the backend represented
+  *   by be_path.
+@@ -1762,6 +1765,7 @@ _hidden int libxl__qmp_save(libxl__gc *g
+ /* Set dirty bitmap logging status */
+ _hidden int libxl__qmp_set_global_dirty_log(libxl__gc *gc, int domid, bool enable);
+ _hidden int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid, const libxl_device_disk *disk);
++_hidden int libxl__qmp_change_cdrom(libxl__gc *gc, int domid, const libxl_device_disk *disk);
+ /* Add a virtual CPU */
+ _hidden int libxl__qmp_cpu_add(libxl__gc *gc, int domid, int index);
+ /* close and free the QMP handler */
+Index: xen-4.6.4/tools/libxl/libxl_qmp.c
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl_qmp.c
++++ xen-4.6.4/tools/libxl/libxl_qmp.c
+@@ -948,6 +948,17 @@ int libxl__qmp_set_global_dirty_log(libx
+                            NULL, NULL);
+ }
+ 
++int libxl__qmp_change_cdrom(libxl__gc *gc, int domid,
++							const libxl_device_disk *disk)
++{
++    libxl__json_object *args = NULL;
++    int dev_number = libxl__device_disk_dev_number(disk->vdev, NULL, NULL);
++
++    QMP_PARAMETERS_SPRINTF(&args, "device", "ide-%i", dev_number);
++    qmp_parameters_add_string(gc, &args, "target", "/dev/xvdc");
++    return qmp_run_command(gc, domid, "change", args, NULL, NULL);
++}
++
+ int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid,
+                             const libxl_device_disk *disk)
+ {
+Index: xen-4.6.4/tools/libxl/libxl_utils.c
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl_utils.c
++++ xen-4.6.4/tools/libxl/libxl_utils.c
+@@ -1384,6 +1384,12 @@ int libxl__random_bytes(libxl__gc *gc, u
+     return ret;
+ }
+ 
++int libxl_util_xs_read(libxl_ctx *ctx, char *path, char **out)
++{
++    *out = xs_read(ctx->xsh, XBT_NULL, path, NULL);
++    return 0;
++}
++
+ /*
+  * Local variables:
+  * mode: C
+Index: xen-4.6.4/tools/libxl/libxl_utils.h
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/libxl_utils.h
++++ xen-4.6.4/tools/libxl/libxl_utils.h
+@@ -165,6 +165,8 @@ int libxl_cpumap_to_nodemap(libxl_ctx *c
+                             const libxl_bitmap *cpumap,
+                             libxl_bitmap *nodemap);
+ 
++int libxl_util_xs_read(libxl_ctx *ctx, char *path, char **out);
++
+  static inline uint32_t libxl__sizekb_to_mb(uint32_t s) {
+     return (s + 1023) / 1024;
+ }
+Index: xen-4.6.4/tools/libxl/xl_cmdimpl.c
+===================================================================
+--- xen-4.6.4.orig/tools/libxl/xl_cmdimpl.c
++++ xen-4.6.4/tools/libxl/xl_cmdimpl.c
+@@ -3346,31 +3346,76 @@ static int cd_insert(uint32_t domid, con
+     XLU_Config *config = 0;
+     struct stat b;
+     int rc = 0;
++    uint32_t stubdomid = 0;
++    int i, nb, devid = -1;
++    libxl_device_disk *disks = NULL;
++    libxl_device_disk olddisk;
++    libxl_diskinfo diskinfo;
++    char *dev = NULL;
++    char *strdevid = NULL;
++    char *xspath = NULL;
++
++    memset(&diskinfo, 0, sizeof(libxl_diskinfo));
++    memset(&olddisk, 0, sizeof(libxl_device_disk));
+ 
+     xasprintf(&buf, "vdev=%s,access=r,devtype=cdrom,target=%s",
+               virtdev, phys ? phys : "");
+ 
+     parse_disk_config(&config, buf, &disk);
+ 
+-    /* ATM the existence of the backing file is not checked for qdisk
+-     * in libxl_cdrom_insert() because RAW is used for remote
+-     * protocols as well as plain files.  This will ideally be changed
+-     * for 4.4, but this work-around fixes the problem of "cd-insert"
+-     * returning success for non-existent files. */
+-    if (disk.format != LIBXL_DISK_FORMAT_EMPTY
+-        && stat(disk.pdev_path, &b)) {
+-        fprintf(stderr, "Cannot stat file: %s\n",
+-                disk.pdev_path);
+-        rc = 1;
+-        goto out;
+-    }
++    stubdomid = libxl_get_stubdom_id(ctx, domid);
+ 
+-    if (libxl_cdrom_insert(ctx, domid, &disk, NULL))
+-        rc=1;
++    /* If stubdom, protocol changes slightly. Retap new iso in dom0,
++     * send qmp message to stubdom to change cdrom medium using blkfront
++     * target */
++    if(stubdomid > 0) {
++        disks = libxl_device_disk_list(ctx, domid, &nb);
++        if (disks) {
++            for (i=0; i<nb; i++) {
++                if (!libxl_device_disk_getinfo(ctx, domid, &disks[i], &diskinfo)) {
++                    xasprintf(&xspath, "%s/dev", diskinfo.backend);
++                    if(!xspath)
++                        goto out;
++                    libxl_util_xs_read(ctx, xspath, &dev);
++                    if(!dev)
++                        goto out;
++                    if(!strcmp(dev, "hdc"))
++                        devid = diskinfo.devid;
++                    libxl_diskinfo_dispose(&diskinfo);
++                }
++                libxl_device_disk_dispose(&disks[i]);
++            }
++            free(disks);
++        }
++        xasprintf(&strdevid, "%d", devid);
++   
++        libxl_vdev_to_device_disk(ctx, domid, strdevid, &olddisk);
++
++        libxl_cdrom_change(ctx, domid, phys, &olddisk, strdevid, NULL);
++
++    } else {
++        /* ATM the existence of the backing file is not checked for qdisk
++         * in libxl_cdrom_insert() because RAW is used for remote
++         * protocols as well as plain files.  This will ideally be changed
++         * for 4.4, but this work-around fixes the problem of "cd-insert"
++         * returning success for non-existent files. */
++        if (disk.format != LIBXL_DISK_FORMAT_EMPTY
++            && stat(disk.pdev_path, &b)) {
++            fprintf(stderr, "Cannot stat file: %s\n",
++                    disk.pdev_path);
++            rc = 1;
++            goto out;
++        }
+ 
++        if (libxl_cdrom_insert(ctx, domid, &disk, NULL))
++            rc=1;
++    }
+ out:
+     libxl_device_disk_dispose(&disk);
+     free(buf);
++    if(dev) free(dev);
++    if(strdevid) free(strdevid);
++    if(xspath) free(xspath);
+ 
+     return rc;
+ }

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -77,6 +77,7 @@ SRC_URI_append = " \
     file://libxl-pci-passthrough-fixes.patch \
     file://libxl-vwif-support.patch \
     file://libxl-atapi-pt.patch \
+    file://libxl-iso-hotswap.patch \
     file://xsa-191-x86-null-segments-not-always-treated-as-unusable.patch \
     file://xsa-192-x86-task-switch-to-vm86-mode-mis-handled.patch \
     file://xsa-193-x86-segment-base-write-emulation-lacking-canonical-address-checks.patch \

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/set-blockdev-ro.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/set-blockdev-ro.patch
@@ -1,0 +1,10 @@
+--- a/blockdev.c	2017-04-18 16:17:35.682420814 -0400
++++ b/blockdev.c	2017-04-18 16:17:24.974289324 -0400
+@@ -2582,6 +2582,7 @@
+ 
+     switch (read_only) {
+     case BLOCKDEV_CHANGE_READ_ONLY_MODE_RETAIN:
++        bdrv_flags &= ~BDRV_O_RDWR;
+         break;
+ 
+     case BLOCKDEV_CHANGE_READ_ONLY_MODE_READ_ONLY:

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -39,6 +39,7 @@ SRC_URI += "file://compile-time-stubdom-flag.patch \
             file://use-relative-xenstore-nodes.patch \
             file://exit-mainloop-on-reset.patch \
             file://write-acpi-state-to-xenstore.patch \
+            file://set-blockdev-ro.patch \
             file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
             "
 


### PR DESCRIPTION
  while guest is on. Make sure we set readonly flags for blockdev
  in qemu when set to 'preserved'. Attempting to open xvdc fails
  because open flags have writable set.

  OXT-1068

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>