### PR TITLE
OXT-1084: tcsd: Disable ipv6

### DIFF
--- a/recipes-openxt/trousers/files/trousers-tcsd-conf.patch
+++ b/recipes-openxt/trousers/files/trousers-tcsd-conf.patch
@@ -1,5 +1,7 @@
---- a/dist/tcsd.conf.in
-+++ b/dist/tcsd.conf.in
+Index: trousers-0.3.14/dist/tcsd.conf.in
+===================================================================
+--- trousers-0.3.14.orig/dist/tcsd.conf.in
++++ trousers-0.3.14/dist/tcsd.conf.in
 @@ -26,7 +26,7 @@
  # Values: Any absolute directory path
  # Description: Path where the tcsd creates its persistent storage file.
@@ -9,3 +11,10 @@
  #
  
  # Option: firmware_log_file
+@@ -187,5 +187,4 @@
+ # its TCP port. Value of 1 disables IPv6 support, so clients cannot reach
+ # TCSD using that protocol.
+ #
+-#  disable_ipv6 = 0
+-#
++disable_ipv6 = 1


### PR DESCRIPTION
Dom0 does not have ipv6 support and the SELinux policy does not give
tcsd the permission to try and load the module, which it will try to do.

OXT-1084