### PR TITLE
STABLE-6: OXT-1094: xen: Backport XSA-{207,212,213,214,215}

### DIFF
--- a/recipes-extended/xen/files/gcc6-compilation.patch
+++ b/recipes-extended/xen/files/gcc6-compilation.patch
@@ -1,0 +1,49 @@
+Index: xen-4.3.4/xen/arch/x86/cpu/mcheck/non-fatal.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/cpu/mcheck/non-fatal.c
++++ xen-4.3.4/xen/arch/x86/cpu/mcheck/non-fatal.c
+@@ -94,8 +94,8 @@ static int __init init_nonfatal_mce_chec
+ 	if (mce_disabled || !mce_available(c))
+ 		return -ENODEV;
+ 
+-    if ( __get_cpu_var(poll_bankmask) == NULL )
+-        return -EINVAL;
++	if ( __get_cpu_var(poll_bankmask) == NULL )
++		return -EINVAL;
+ 
+ 	/*
+ 	 * Check for non-fatal errors every MCE_RATE s
+Index: xen-4.3.4/xen/drivers/passthrough/amd/iommu_intr.c
+===================================================================
+--- xen-4.3.4.orig/xen/drivers/passthrough/amd/iommu_intr.c
++++ xen-4.3.4/xen/drivers/passthrough/amd/iommu_intr.c
+@@ -449,7 +449,7 @@ void* __init amd_iommu_alloc_intremap_ta
+ 
+ int __init amd_setup_hpet_msi(struct msi_desc *msi_desc)
+ {
+-    if ( (!msi_desc->hpet_id != hpet_sbdf.id) ||
++    if ( (msi_desc->hpet_id != hpet_sbdf.id) ||
+          (hpet_sbdf.iommu == NULL) )
+     {
+         AMD_IOMMU_DEBUG("Fail to setup HPET MSI remapping\n");
+Index: xen-4.3.4/xen/crypto/rijndael.c
+===================================================================
+--- xen-4.3.4.orig/xen/crypto/rijndael.c
++++ xen-4.3.4/xen/crypto/rijndael.c
+@@ -380,6 +380,7 @@ static const u32 Te4[256] = {
+     0x41414141U, 0x99999999U, 0x2d2d2d2dU, 0x0f0f0f0fU,
+     0xb0b0b0b0U, 0x54545454U, 0xbbbbbbbbU, 0x16161616U,
+ };
++#ifdef NEED_RIJNDAEL_DECRYPT
+ static const u32 Td0[256] = {
+     0x51f4a750U, 0x7e416553U, 0x1a17a4c3U, 0x3a275e96U,
+     0x3bab6bcbU, 0x1f9d45f1U, 0xacfa58abU, 0x4be30393U,
+@@ -710,6 +711,8 @@ static const u32 Td4[256] = {
+     0xe1e1e1e1U, 0x69696969U, 0x14141414U, 0x63636363U,
+     0x55555555U, 0x21212121U, 0x0c0c0c0cU, 0x7d7d7d7dU,
+ };
++#endif /* NEED_RIJNDAEL_DECRYPT */
++
+ static const u32 rcon[] = {
+ 	0x01000000, 0x02000000, 0x04000000, 0x08000000,
+ 	0x10000000, 0x20000000, 0x40000000, 0x80000000,

--- a/recipes-extended/xen/files/iommu-make-page-table-deallocation-preemptible.patch
+++ b/recipes-extended/xen/files/iommu-make-page-table-deallocation-preemptible.patch
@@ -1,0 +1,236 @@
+From cedfdd43a9798e535a05690bb6f01394490d26bb Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Tue, 7 Jan 2014 16:01:14 +0100
+Subject: [PATCH] IOMMU: make page table deallocation preemptible
+
+This too can take an arbitrary amount of time.
+
+In fact, the bulk of the work is being moved to a tasklet, as handling
+the necessary preemption logic in line seems close to impossible given
+that the teardown may also be invoked on error paths.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Acked-by: Xiantao Zhang <xiantao.zhang@intel.com>
+---
+ xen/drivers/passthrough/amd/pci_amd_iommu.c | 15 +++++++--
+ xen/drivers/passthrough/iommu.c             | 51 ++++++++++++++++++++---------
+ xen/drivers/passthrough/vtd/iommu.c         | 18 ++++++++--
+ xen/include/xen/iommu.h                     |  5 +++
+ 4 files changed, 68 insertions(+), 21 deletions(-)
+
+Index: xen-4.3.4/xen/drivers/passthrough/amd/pci_amd_iommu.c
+===================================================================
+--- xen-4.3.4.orig/xen/drivers/passthrough/amd/pci_amd_iommu.c
++++ xen-4.3.4/xen/drivers/passthrough/amd/pci_amd_iommu.c
+@@ -447,11 +447,21 @@ static int amd_iommu_assign_device(struc
+     return reassign_device(dom0, d, devfn, pdev);
+ }
+ 
+-static void deallocate_next_page_table(struct page_info* pg, int level)
++static void deallocate_next_page_table(struct page_info *pg, int level)
++{
++    PFN_ORDER(pg) = level;
++    spin_lock(&iommu_pt_cleanup_lock);
++    page_list_add_tail(pg, &iommu_pt_cleanup_list);
++    spin_unlock(&iommu_pt_cleanup_lock);
++}
++
++static void deallocate_page_table(struct page_info *pg)
+ {
+     void *table_vaddr, *pde;
+     u64 next_table_maddr;
+-    int index, next_level;
++    unsigned int index, level = PFN_ORDER(pg), next_level;
++
++    PFN_ORDER(pg) = 0;
+ 
+     if ( level <= 1 )
+     {
+@@ -641,6 +651,7 @@ const struct iommu_ops amd_iommu_ops = {
+     .teardown = amd_iommu_domain_destroy,
+     .map_page = amd_iommu_map_page,
+     .unmap_page = amd_iommu_unmap_page,
++    .free_page_table = deallocate_page_table,
+     .reassign_device = reassign_device,
+     .get_device_group_id = amd_iommu_group_id,
+     .update_ire_from_apic = amd_iommu_ioapic_update_ire,
+Index: xen-4.3.4/xen/drivers/passthrough/iommu.c
+===================================================================
+--- xen-4.3.4.orig/xen/drivers/passthrough/iommu.c
++++ xen-4.3.4/xen/drivers/passthrough/iommu.c
+@@ -58,6 +58,10 @@ bool_t __read_mostly amd_iommu_perdev_in
+ 
+ DEFINE_PER_CPU(bool_t, iommu_dont_flush_iotlb);
+ 
++DEFINE_SPINLOCK(iommu_pt_cleanup_lock);
++PAGE_LIST_HEAD(iommu_pt_cleanup_list);
++static struct tasklet iommu_pt_cleanup_tasklet;
++
+ static struct keyhandler iommu_p2m_table = {
+     .diagnostic = 0,
+     .u.fn = iommu_dump_p2m_table,
+@@ -235,6 +239,15 @@ int iommu_remove_device(struct pci_dev *
+     return hd->platform_ops->remove_device(pdev->devfn, pdev);
+ }
+ 
++static void iommu_teardown(struct domain *d)
++{
++    const struct hvm_iommu *hd = domain_hvm_iommu(d);
++
++    d->need_iommu = 0;
++    hd->platform_ops->teardown(d);
++    tasklet_schedule(&iommu_pt_cleanup_tasklet);
++}
++
+ /*
+  * If the device isn't owned by dom0, it means it already
+  * has been assigned to other domain, or it doesn't exist.
+@@ -309,10 +322,7 @@ static int assign_device(struct domain *
+ 
+  done:
+     if ( !has_arch_pdevs(d) && need_iommu(d) )
+-    {
+-        d->need_iommu = 0;
+-        hd->platform_ops->teardown(d);
+-    }
++        iommu_teardown(d);
+     spin_unlock(&pcidevs_lock);
+ 
+     return rc;
+@@ -377,10 +387,7 @@ static int iommu_populate_page_table(str
+     if ( !rc )
+         iommu_iotlb_flush_all(d);
+     else if ( rc != -ERESTART )
+-    {
+-        d->need_iommu = 0;
+-        hd->platform_ops->teardown(d);
+-    }
++        iommu_teardown(d);
+ 
+     return rc;
+ }
+@@ -396,10 +403,7 @@ void iommu_domain_destroy(struct domain
+         return;
+ 
+     if ( need_iommu(d) )
+-    {
+-        d->need_iommu = 0;
+-        hd->platform_ops->teardown(d);
+-    }
++        iommu_teardown(d);
+ 
+     list_for_each_safe ( ioport_list, tmp, &hd->g2m_ioport_list )
+     {
+@@ -430,6 +434,23 @@ int iommu_unmap_page(struct domain *d, u
+     return hd->platform_ops->unmap_page(d, gfn);
+ }
+ 
++static void iommu_free_pagetables(unsigned long unused)
++{
++    do {
++        struct page_info *pg;
++
++        spin_lock(&iommu_pt_cleanup_lock);
++        pg = page_list_remove_head(&iommu_pt_cleanup_list);
++        spin_unlock(&iommu_pt_cleanup_lock);
++        if ( !pg )
++            return;
++        iommu_get_ops()->free_page_table(pg);
++    } while ( !softirq_pending(smp_processor_id()) );
++
++    tasklet_schedule_on_cpu(&iommu_pt_cleanup_tasklet,
++                            cpumask_cycle(smp_processor_id(), &cpu_online_map));
++}
++
+ void iommu_iotlb_flush(struct domain *d, unsigned long gfn, unsigned int page_count)
+ {
+     struct hvm_iommu *hd = domain_hvm_iommu(d);
+@@ -492,10 +513,7 @@ int deassign_device(struct domain *d, u1
+     pdev->fault.count = 0;
+ 
+     if ( !has_arch_pdevs(d) && need_iommu(d) )
+-    {
+-        d->need_iommu = 0;
+-        hd->platform_ops->teardown(d);
+-    }
++        iommu_teardown(d);
+ 
+     return ret;
+ }
+@@ -534,6 +552,7 @@ int __init iommu_setup(void)
+                iommu_passthrough ? "Passthrough" :
+                iommu_dom0_strict ? "Strict" : "Relaxed");
+         printk("Interrupt remapping %sabled\n", iommu_intremap ? "en" : "dis");
++        tasklet_init(&iommu_pt_cleanup_tasklet, iommu_free_pagetables, 0);
+     }
+ 
+     return rc;
+Index: xen-4.3.4/xen/drivers/passthrough/vtd/iommu.c
+===================================================================
+--- xen-4.3.4.orig/xen/drivers/passthrough/vtd/iommu.c
++++ xen-4.3.4/xen/drivers/passthrough/vtd/iommu.c
+@@ -650,13 +650,24 @@ static void dma_pte_clear_one(struct dom
+ 
+ static void iommu_free_pagetable(u64 pt_maddr, int level)
+ {
+-    int i;
+-    struct dma_pte *pt_vaddr, *pte;
+-    int next_level = level - 1;
++    struct page_info *pg = maddr_to_page(pt_maddr);
+ 
+     if ( pt_maddr == 0 )
+         return;
+ 
++    PFN_ORDER(pg) = level;
++    spin_lock(&iommu_pt_cleanup_lock);
++    page_list_add_tail(pg, &iommu_pt_cleanup_list);
++    spin_unlock(&iommu_pt_cleanup_lock);
++}
++
++static void iommu_free_page_table(struct page_info *pg)
++{
++    unsigned int i, next_level = PFN_ORDER(pg) - 1;
++    u64 pt_maddr = page_to_maddr(pg);
++    struct dma_pte *pt_vaddr, *pte;
++
++    PFN_ORDER(pg) = 0;
+     pt_vaddr = (struct dma_pte *)map_vtd_domain_page(pt_maddr);
+ 
+     for ( i = 0; i < PTE_NUM; i++ )
+@@ -2539,6 +2550,7 @@ const struct iommu_ops intel_iommu_ops =
+     .teardown = iommu_domain_teardown,
+     .map_page = intel_iommu_map_page,
+     .unmap_page = intel_iommu_unmap_page,
++    .free_page_table = iommu_free_page_table,
+     .reassign_device = reassign_device_ownership,
+     .get_device_group_id = intel_iommu_group_id,
+     .update_ire_from_apic = io_apic_write_remap_rte,
+Index: xen-4.3.4/xen/include/xen/iommu.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/xen/iommu.h
++++ xen-4.3.4/xen/include/xen/iommu.h
+@@ -88,6 +88,7 @@ bool_t pt_irq_need_timer(uint32_t flags)
+ 
+ struct msi_desc;
+ struct msi_msg;
++struct page_info;
+ 
+ struct iommu_ops {
+     int (*init)(struct domain *d);
+@@ -100,6 +101,7 @@ struct iommu_ops {
+     int (*map_page)(struct domain *d, unsigned long gfn, unsigned long mfn,
+                     unsigned int flags);
+     int (*unmap_page)(struct domain *d, unsigned long gfn);
++    void (*free_page_table)(struct page_info *);
+     int (*reassign_device)(struct domain *s, struct domain *t,
+ 			   u8 devfn, struct pci_dev *);
+     int (*get_device_group_id)(u16 seg, u8 bus, u8 devfn);
+@@ -152,4 +154,7 @@ int adjust_vtd_irq_affinities(void);
+  */
+ DECLARE_PER_CPU(bool_t, iommu_dont_flush_iotlb);
+ 
++extern struct spinlock iommu_pt_cleanup_lock;
++extern struct page_list_head iommu_pt_cleanup_list;
++
+ #endif /* _IOMMU_H_ */

--- a/recipes-extended/xen/files/iommu-make-page-table-population-preemptible.patch
+++ b/recipes-extended/xen/files/iommu-make-page-table-population-preemptible.patch
@@ -1,0 +1,210 @@
+From 3e06b9890c0a691388ace5a6636728998b237b90 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Tue, 7 Jan 2014 14:21:48 +0100
+Subject: [PATCH] IOMMU: make page table population preemptible
+
+Since this can take an arbitrary amount of time, the rooting domctl as
+well as all involved code must become aware of this requiring a
+continuation.
+
+The subject domain's rel_mem_list is being (ab)used for this, in a way
+similar to and compatible with broken page offlining.
+
+Further, operations get slightly re-ordered in assign_device(): IOMMU
+page tables now get set up _before_ the first device gets assigned, at
+once closing a small timing window in which the guest may already see
+the device but wouldn't be able to access it.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Tim Deegan <tim@xen.org>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Acked-by: Xiantao Zhang <xiantao.zhang@intel.com>
+---
+ xen/arch/x86/domain.c           |  6 ++++
+ xen/arch/x86/mm/p2m-pod.c       |  3 +-
+ xen/drivers/passthrough/iommu.c | 74 +++++++++++++++++++++++++++++++++++------
+ xen/include/xen/sched.h         |  4 +--
+ 4 files changed, 73 insertions(+), 14 deletions(-)
+
+Index: xen-4.3.4/xen/arch/x86/domain.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/domain.c
++++ xen-4.3.4/xen/arch/x86/domain.c
+@@ -1937,6 +1937,12 @@ int domain_relinquish_resources(struct d
+         }
+ 
+         d->arch.relmem = RELMEM_xen;
++
++        spin_lock(&d->page_alloc_lock);
++        page_list_splice(&d->arch.relmem_list, &d->page_list);
++        INIT_PAGE_LIST_HEAD(&d->arch.relmem_list);
++        spin_unlock(&d->page_alloc_lock);
++
+         /* Fallthrough. Relinquish every page of memory. */
+     case RELMEM_xen:
+         ret = relinquish_memory(d, &d->xenpage_list, ~0UL);
+Index: xen-4.3.4/xen/arch/x86/mm/p2m-pod.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/mm/p2m-pod.c
++++ xen-4.3.4/xen/arch/x86/mm/p2m-pod.c
+@@ -461,7 +461,8 @@ p2m_pod_offline_or_broken_hit(struct pag
+ 
+ pod_hit:
+     lock_page_alloc(p2m);
+-    page_list_add_tail(p, &d->arch.relmem_list);
++    /* Insertion must be at list head (see iommu_populate_page_table()). */
++    page_list_add(p, &d->arch.relmem_list);
+     unlock_page_alloc(p2m);
+     pod_unlock(p2m);
+     return 1;
+Index: xen-4.3.4/xen/drivers/passthrough/iommu.c
+===================================================================
+--- xen-4.3.4.orig/xen/drivers/passthrough/iommu.c
++++ xen-4.3.4/xen/drivers/passthrough/iommu.c
+@@ -18,6 +18,7 @@
+ #include <asm/hvm/iommu.h>
+ #include <xen/paging.h>
+ #include <xen/guest_access.h>
++#include <xen/event.h>
+ #include <xen/softirq.h>
+ #include <xen/keyhandler.h>
+ #include <xsm/xsm.h>
+@@ -265,7 +266,23 @@ static int assign_device(struct domain *
+              d->mem_event->paging.ring_page)) )
+         return -EXDEV;
+ 
+-    spin_lock(&pcidevs_lock);
++    if ( !spin_trylock(&pcidevs_lock) )
++        return -ERESTART;
++
++    if ( need_iommu(d) <= 0 )
++    {
++        if ( !iommu_use_hap_pt(d) )
++        {
++            rc = iommu_populate_page_table(d);
++            if ( rc )
++            {
++                spin_unlock(&pcidevs_lock);
++                return rc;
++            }
++        }
++        d->need_iommu = 1;
++    }
++
+     pdev = pci_get_pdev_by_domain(dom0, seg, bus, devfn);
+     if ( !pdev )
+     {
+@@ -290,15 +307,14 @@ static int assign_device(struct domain *
+                    rc);
+     }
+ 
+-    if ( has_arch_pdevs(d) && !need_iommu(d) )
++ done:
++    if ( !has_arch_pdevs(d) && need_iommu(d) )
+     {
+-        d->need_iommu = 1;
+-        if ( !iommu_use_hap_pt(d) )
+-            rc = iommu_populate_page_table(d);
+-        goto done;
++        d->need_iommu = 0;
++        hd->platform_ops->teardown(d);
+     }
+-done:
+     spin_unlock(&pcidevs_lock);
++
+     return rc;
+ }
+ 
+@@ -306,12 +322,17 @@ static int iommu_populate_page_table(str
+ {
+     struct hvm_iommu *hd = domain_hvm_iommu(d);
+     struct page_info *page;
+-    int rc = 0;
++    int rc = 0, n = 0;
++
++    d->need_iommu = -1;
+ 
+     this_cpu(iommu_dont_flush_iotlb) = 1;
+     spin_lock(&d->page_alloc_lock);
+ 
+-    page_list_for_each ( page, &d->page_list )
++    if ( unlikely(d->is_dying) )
++        rc = -ESRCH;
++
++    while ( !rc && (page = page_list_remove_head(&d->page_list)) )
+     {
+         if ( is_hvm_domain(d) ||
+             (page->u.inuse.type_info & PGT_type_mask) == PGT_writable_page )
+@@ -321,7 +342,32 @@ static int iommu_populate_page_table(str
+                 d, mfn_to_gmfn(d, page_to_mfn(page)), page_to_mfn(page),
+                 IOMMUF_readable|IOMMUF_writable);
+             if ( rc )
++            {
++                page_list_add(page, &d->page_list);
+                 break;
++            }
++        }
++        page_list_add_tail(page, &d->arch.relmem_list);
++        if ( !(++n & 0xff) && !page_list_empty(&d->page_list) &&
++             hypercall_preempt_check() )
++            rc = -ERESTART;
++    }
++
++    if ( !rc )
++    {
++        /*
++         * The expectation here is that generally there are many normal pages
++         * on relmem_list (the ones we put there) and only few being in an
++         * offline/broken state. The latter ones are always at the head of the
++         * list. Hence we first move the whole list, and then move back the
++         * first few entries.
++         */
++        page_list_move(&d->page_list, &d->arch.relmem_list);
++        while ( (page = page_list_first(&d->page_list)) != NULL &&
++                (page->count_info & (PGC_state|PGC_broken)) )
++        {
++            page_list_del(page, &d->page_list);
++            page_list_add_tail(page, &d->arch.relmem_list);
+         }
+     }
+ 
+@@ -330,8 +376,11 @@ static int iommu_populate_page_table(str
+ 
+     if ( !rc )
+         iommu_iotlb_flush_all(d);
+-    else
++    else if ( rc != -ERESTART )
++    {
++        d->need_iommu = 0;
+         hd->platform_ops->teardown(d);
++    }
+ 
+     return rc;
+ }
+@@ -682,7 +731,10 @@ int iommu_do_domctl(
+ 
+         ret = device_assigned(seg, bus, devfn) ?:
+               assign_device(d, seg, bus, devfn);
+-        if ( ret )
++        if ( ret == -ERESTART )
++            ret = hypercall_create_continuation(__HYPERVISOR_domctl,
++                                                "h", u_domctl);
++        else if ( ret )
+             printk(XENLOG_G_ERR "XEN_DOMCTL_assign_device: "
+                    "assign %04x:%02x:%02x.%u to dom%d failed (%d)\n",
+                    seg, bus, PCI_SLOT(devfn), PCI_FUNC(devfn),
+Index: xen-4.3.4/xen/include/xen/sched.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/xen/sched.h
++++ xen-4.3.4/xen/include/xen/sched.h
+@@ -292,8 +292,8 @@ struct domain
+     /* Is this an HVM guest? */
+     bool_t           is_hvm;
+ #ifdef HAS_PASSTHROUGH
+-    /* Does this guest need iommu mappings? */
+-    bool_t           need_iommu;
++    /* Does this guest need iommu mappings (-1 meaning "being set up")? */
++    s8               need_iommu;
+ #endif
+     /* is node-affinity automatically computed? */
+     bool_t           auto_node_affinity;

--- a/recipes-extended/xen/files/xen-arm-fully-implement-multicall-interface.patch
+++ b/recipes-extended/xen/files/xen-arm-fully-implement-multicall-interface.patch
@@ -1,0 +1,187 @@
+From f0dbdc628a0ecdc44d6afab28a9d5a52c996eec5 Mon Sep 17 00:00:00 2001
+From: Ian Campbell <ian.campbell@citrix.com>
+Date: Thu, 17 Apr 2014 13:57:24 +0100
+Subject: [PATCH] xen: arm: fully implement multicall interface.
+
+I'm not sure what I was smoking at the time of 5d74ad1a082e "xen: arm:
+implement do_multicall_call for both 32 and 64-bit" but it is obviously
+insufficient since it doesn't actually wire up the hypercall.
+
+Before doing so we need to make the usual adjustments for ARM and turn the
+unsigned longs into xen_ulong_t. There is no difference in the resulting
+structure for x86.
+
+There are knock on changes to the trace interface, but again they are nops on
+x86.
+
+For 32-bit ARM guests we require that the arguments which they pass to a
+hypercall via a multicall do not use the upper bits of xen_ulong_t and kill
+them if they violate this. This should ensure that no ABI surprises can be
+silently lurking when running on a 32-bit hypervisor waiting to pounce when the
+same kernel is run on a 64-bit hypervisor. Killing the guest is harsh but it
+will be far easier to relax the restriction if it turns out to cause problems
+than to tighten it up if we were lax to begin with.
+
+In the interests of clarity and always using explicitly sized types change the
+unsigned int in the hypercall arguments to a uint32_t. There is no actual
+change here on any platform.
+
+We should consider backporting this to 4.4.1 in case a guest decides they want
+to use a multicall in common code e.g. I suggested such a thing while
+reviewing a netback change recently.
+
+Signed-off-by: Ian Campbell <ian.campbell@citrix.com>
+Cc: keir@xen.org
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: George Dunlap <george.dunlap@eu.citrix.com>
+Acked-by: Julien Grall <julien.grall@linaro.org>
+---
+ xen/arch/arm/traps.c          | 28 ++++++++++++++++++++++++++--
+ xen/common/compat/multicall.c |  2 +-
+ xen/common/multicall.c        |  4 ++--
+ xen/common/trace.c            |  2 +-
+ xen/include/public/xen.h      | 10 ++++++----
+ xen/include/xen/trace.h       |  2 +-
+ 6 files changed, 37 insertions(+), 11 deletions(-)
+
+Index: xen-4.3.4/xen/arch/arm/traps.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/arm/traps.c
++++ xen-4.3.4/xen/arch/arm/traps.c
+@@ -17,6 +17,7 @@
+  */
+ 
+ #include <xen/config.h>
++#include <xen/stdbool.h>
+ #include <xen/init.h>
+ #include <xen/string.h>
+ #include <xen/version.h>
+@@ -689,6 +690,7 @@ static arm_hypercall_t arm_hypercall_tab
+     HYPERCALL(sysctl, 2),
+     HYPERCALL(hvm_op, 2),
+     HYPERCALL(grant_table_op, 3),
++    HYPERCALL(multicall, 2),
+     HYPERCALL_ARM(vcpu_op, 3),
+ };
+ 
+@@ -809,6 +811,24 @@ static void do_trap_hypercall(struct cpu
+ #endif
+ }
+ 
++static bool_t check_multicall_32bit_clean(struct multicall_entry *multi)
++{
++    int i;
++
++    for ( i = 0; i < arm_hypercall_table[multi->op].nr_args; i++ )
++    {
++        if ( unlikely(multi->args[i] & 0xffffffff00000000ULL) )
++        {
++            printk("%pv: multicall argument %d is not 32-bit clean %"PRIx64"\n",
++                   current, i, multi->args[i]);
++            domain_crash(current->domain);
++            return false;
++        }
++    }
++
++    return true;
++}
++
+ void do_multicall_call(struct multicall_entry *multi)
+ {
+     arm_hypercall_fn_t call = NULL;
+@@ -826,9 +846,13 @@ void do_multicall_call(struct multicall_
+         return;
+     }
+ 
++    if ( is_32bit_domain(current->domain) &&
++         !check_multicall_32bit_clean(multi) )
++        return;
++
+     multi->result = call(multi->args[0], multi->args[1],
+-                        multi->args[2], multi->args[3],
+-                        multi->args[4]);
++                         multi->args[2], multi->args[3],
++                         multi->args[4]);
+ }
+ 
+ static void do_cp15_32(struct cpu_user_regs *regs,
+Index: xen-4.3.4/xen/common/compat/multicall.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/compat/multicall.c
++++ xen-4.3.4/xen/common/compat/multicall.c
+@@ -29,7 +29,7 @@ DEFINE_XEN_GUEST_HANDLE(multicall_entry_
+ 
+ static void __trace_multicall_call(multicall_entry_t *call)
+ {
+-    unsigned long args[6];
++    xen_ulong_t args[6];
+     int i;
+ 
+     for ( i = 0; i < ARRAY_SIZE(args); i++ )
+Index: xen-4.3.4/xen/common/multicall.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/multicall.c
++++ xen-4.3.4/xen/common/multicall.c
+@@ -35,10 +35,10 @@ static void trace_multicall_call(multica
+ 
+ ret_t
+ do_multicall(
+-    XEN_GUEST_HANDLE_PARAM(multicall_entry_t) call_list, unsigned int nr_calls)
++    XEN_GUEST_HANDLE_PARAM(multicall_entry_t) call_list, uint32_t nr_calls)
+ {
+     struct mc_state *mcs = &current->mc_state;
+-    unsigned int     i;
++    uint32_t         i;
+     int              rc = 0;
+ 
+     if ( unlikely(__test_and_set_bit(_MCSF_in_multicall, &mcs->flags)) )
+Index: xen-4.3.4/xen/common/trace.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/trace.c
++++ xen-4.3.4/xen/common/trace.c
+@@ -817,7 +817,7 @@ unlock:
+ }
+ 
+ void __trace_hypercall(uint32_t event, unsigned long op,
+-                       const unsigned long *args)
++                       const xen_ulong_t *args)
+ {
+     struct {
+         uint32_t op;
+Index: xen-4.3.4/xen/include/public/xen.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/public/xen.h
++++ xen-4.3.4/xen/include/public/xen.h
+@@ -541,13 +541,15 @@ DEFINE_XEN_GUEST_HANDLE(mmu_update_t);
+ /*
+  * ` enum neg_errnoval
+  * ` HYPERVISOR_multicall(multicall_entry_t call_list[],
+- * `                      unsigned int nr_calls);
++ * `                      uint32_t nr_calls);
+  *
+- * NB. The fields are natural register size for this architecture.
++ * NB. The fields are logically the natural register size for this
++ * architecture. In cases where xen_ulong_t is larger than this then
++ * any unused bits in the upper portion must be zero.
+  */
+ struct multicall_entry {
+-    unsigned long op, result;
+-    unsigned long args[6];
++    xen_ulong_t op, result;
++    xen_ulong_t args[6];
+ };
+ typedef struct multicall_entry multicall_entry_t;
+ DEFINE_XEN_GUEST_HANDLE(multicall_entry_t);
+Index: xen-4.3.4/xen/include/xen/trace.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/xen/trace.h
++++ xen-4.3.4/xen/include/xen/trace.h
+@@ -45,7 +45,7 @@ static inline void trace_var(u32 event,
+ }
+ 
+ void __trace_hypercall(uint32_t event, unsigned long op,
+-                       const unsigned long *args);
++                       const xen_ulong_t *args);
+ 
+ /* Convenience macros for calling the trace function. */
+ #define TRACE_0D(_e)                            \

--- a/recipes-extended/xen/files/xsa-207-memory-leak-when-destroying-guest-without-PT-devices.patch
+++ b/recipes-extended/xen/files/xsa-207-memory-leak-when-destroying-guest-without-PT-devices.patch
@@ -1,0 +1,51 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-207 http://xenbits.xen.org/xsa/advisory-207.html
+memory leak when destroying guest without PT devices
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+From: Oleksandr Tyshchenko <olekstysh@gmail.com>
+Subject: IOMMU: always call teardown callback
+
+There is a possible scenario when (d)->need_iommu remains unset
+during guest domain execution. For example, when no devices
+were assigned to it. Taking into account that teardown callback
+is not called when (d)->need_iommu is unset we might have unreleased
+resourses after destroying domain.
+
+So, always call teardown callback to roll back actions
+that were performed in init callback.
+
+This is XSA-207.
+
+Signed-off-by: Oleksandr Tyshchenko <olekstysh@gmail.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Tested-by: Jan Beulich <jbeulich@suse.com>
+Tested-by: Julien Grall <julien.grall@arm.com>
+
+################################################################################
+REQUIRES
+################################################################################
+iommu-make-page-table-population-preemptible.patch
+iommu-make-page-table-deallocation-preemptible.patch
+
+################################################################################
+PATCHES
+################################################################################
+Index: xen-4.3.4/xen/drivers/passthrough/iommu.c
+===================================================================
+--- xen-4.3.4.orig/xen/drivers/passthrough/iommu.c
++++ xen-4.3.4/xen/drivers/passthrough/iommu.c
+@@ -402,8 +402,7 @@ void iommu_domain_destroy(struct domain
+     if ( !iommu_enabled || !hd->platform_ops )
+         return;
+ 
+-    if ( need_iommu(d) )
+-        iommu_teardown(d);
++    iommu_teardown(d);
+ 
+     list_for_each_safe ( ioport_list, tmp, &hd->g2m_ioport_list )
+     {

--- a/recipes-extended/xen/files/xsa-212-x86-broken-check-in-memory_exchange.patch
+++ b/recipes-extended/xen/files/xsa-212-x86-broken-check-in-memory_exchange.patch
@@ -1,0 +1,106 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-212 http://xenbits.xen.org/xsa/advisory-212.html
+x86: broken check in memory_exchange() permits PV guest breakout
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-212.html
+Patch: xsa212.patch
+
+memory: properly check guest memory ranges in XENMEM_exchange handling
+
+The use of guest_handle_okay() here (as introduced by the XSA-29 fix)
+is insufficient here, guest_handle_subrange_okay() needs to be used
+instead.
+
+Note that the uses are okay in
+- XENMEM_add_to_physmap_batch handling due to the size field being only
+  16 bits wide,
+- livepatch_list() due to the limit of 1024 enforced on the
+  number-of-entries input (leaving aside the fact that this can be
+  called by a privileged domain only anyway),
+- compat mode handling due to counts there being limited to 32 bits,
+- everywhere else due to guest arrays being accessed sequentially from
+  index zero.
+
+This is XSA-212.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+################################################################################
+PATCHES
+################################################################################
+Index: xen-4.3.4/xen/common/memory.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/memory.c
++++ xen-4.3.4/xen/common/memory.c
+@@ -469,8 +469,8 @@ static long memory_exchange(XEN_GUEST_HA
+         goto fail_early;
+     }
+ 
+-    if ( !guest_handle_okay(exch.in.extent_start, exch.in.nr_extents) ||
+-         !guest_handle_okay(exch.out.extent_start, exch.out.nr_extents) )
++    if ( !guest_handle_subrange_okay(exch.in.extent_start, exch.nr_exchanged,
++                                     exch.in.nr_extents - 1) )
+     {
+         rc = -EFAULT;
+         goto fail_early;
+@@ -490,11 +490,27 @@ static long memory_exchange(XEN_GUEST_HA
+     {
+         in_chunk_order  = exch.out.extent_order - exch.in.extent_order;
+         out_chunk_order = 0;
++
++        if ( !guest_handle_subrange_okay(exch.out.extent_start,
++                                         exch.nr_exchanged >> in_chunk_order,
++                                         exch.out.nr_extents - 1) )
++        {
++            rc = -EFAULT;
++            goto fail_early;
++        }
+     }
+     else
+     {
+         in_chunk_order  = 0;
+         out_chunk_order = exch.in.extent_order - exch.out.extent_order;
++
++        if ( !guest_handle_subrange_okay(exch.out.extent_start,
++                                         exch.nr_exchanged << out_chunk_order,
++                                         exch.out.nr_extents - 1) )
++        {
++            rc = -EFAULT;
++            goto fail_early;
++        }
+     }
+ 
+     d = rcu_lock_domain_by_any_id(exch.in.domid);
+Index: xen-4.3.4/xen/include/asm-x86/x86_64/uaccess.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/asm-x86/x86_64/uaccess.h
++++ xen-4.3.4/xen/include/asm-x86/x86_64/uaccess.h
+@@ -29,8 +29,9 @@ extern void *xlat_malloc(unsigned long *
+ /*
+  * Valid if in +ve half of 48-bit address space, or above Xen-reserved area.
+  * This is also valid for range checks (addr, addr+size). As long as the
+- * start address is outside the Xen-reserved area then we will access a
+- * non-canonical address (and thus fault) before ever reaching VIRT_START.
++ * start address is outside the Xen-reserved area, sequential accesses
++ * (starting at addr) will hit a non-canonical address (and thus fault)
++ * before ever reaching VIRT_START.
+  */
+ #define __addr_ok(addr) \
+     (((unsigned long)(addr) < (1UL<<47)) || \
+@@ -40,7 +41,8 @@ extern void *xlat_malloc(unsigned long *
+     (__addr_ok(addr) || is_compat_arg_xlat_range(addr, size))
+ 
+ #define array_access_ok(addr, count, size) \
+-    (access_ok(addr, (count)*(size)))
++    (likely(((count) ?: 0UL) < (~0UL / (size))) && \
++     access_ok(addr, (count) * (size)))
+ 
+ #define __compat_addr_ok(d, addr) \
+     ((unsigned long)(addr) < HYPERVISOR_COMPAT_VIRT_START(d))

--- a/recipes-extended/xen/files/xsa-213-x86-64bit-PV-guest-breakout-via-pagetable-use-after-mode-change.patch
+++ b/recipes-extended/xen/files/xsa-213-x86-64bit-PV-guest-breakout-via-pagetable-use-after-mode-change.patch
@@ -1,0 +1,201 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-213 http://xenbits.xen.org/xsa/advisory-213.html
+x86: 64bit PV guest breakout via pagetable use-after-mode-change
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-213.html
+Patch: xsa213-4.6.patch
+
+From: Jan Beulich <jbeulich@suse.com>
+Subject: multicall: deal with early exit conditions
+
+In particular changes to guest privilege level require the multicall
+sequence to be aborted, as hypercalls are permitted from kernel mode
+only. While likely not very useful in a multicall, also properly handle
+the return value in the HYPERVISOR_iret case (which should be the guest
+specified value).
+
+This is XSA-213.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Acked-by: Julien Grall <julien.grall@arm.com>
+
+################################################################################
+REQUIRES
+################################################################################
+xen-arm-fully-implement-multicall-interface.patch
+
+################################################################################
+PATCHES
+################################################################################
+Index: xen-4.3.4/xen/arch/arm/traps.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/arm/traps.c
++++ xen-4.3.4/xen/arch/arm/traps.c
+@@ -829,30 +829,33 @@ static bool_t check_multicall_32bit_clea
+     return true;
+ }
+ 
+-void do_multicall_call(struct multicall_entry *multi)
++enum mc_disposition do_multicall_call(struct multicall_entry *multi)
+ {
+     arm_hypercall_fn_t call = NULL;
+ 
+     if ( multi->op >= ARRAY_SIZE(arm_hypercall_table) )
+     {
+         multi->result = -ENOSYS;
+-        return;
++        return mc_continue;
+     }
+ 
+     call = arm_hypercall_table[multi->op].fn;
+     if ( call == NULL )
+     {
+         multi->result = -ENOSYS;
+-        return;
++        return mc_continue;
+     }
+ 
+     if ( is_32bit_domain(current->domain) &&
+          !check_multicall_32bit_clean(multi) )
+-        return;
++        return mc_continue;
+ 
+     multi->result = call(multi->args[0], multi->args[1],
+                          multi->args[2], multi->args[3],
+                          multi->args[4]);
++
++    return likely(!psr_mode_is_user(guest_cpu_user_regs()))
++           ? mc_continue : mc_preempt;
+ }
+ 
+ static void do_cp15_32(struct cpu_user_regs *regs,
+Index: xen-4.3.4/xen/common/multicall.c
+===================================================================
+--- xen-4.3.4.orig/xen/common/multicall.c
++++ xen-4.3.4/xen/common/multicall.c
+@@ -40,6 +40,7 @@ do_multicall(
+     struct mc_state *mcs = &current->mc_state;
+     uint32_t         i;
+     int              rc = 0;
++    enum mc_disposition disp = mc_continue;
+ 
+     if ( unlikely(__test_and_set_bit(_MCSF_in_multicall, &mcs->flags)) )
+     {
+@@ -50,7 +51,7 @@ do_multicall(
+     if ( unlikely(!guest_handle_okay(call_list, nr_calls)) )
+         rc = -EFAULT;
+ 
+-    for ( i = 0; !rc && i < nr_calls; i++ )
++    for ( i = 0; !rc && disp == mc_continue && i < nr_calls; i++ )
+     {
+         if ( i && hypercall_preempt_check() )
+             goto preempted;
+@@ -63,7 +64,7 @@ do_multicall(
+ 
+         trace_multicall_call(&mcs->call);
+ 
+-        do_multicall_call(&mcs->call);
++        disp = do_multicall_call(&mcs->call);
+ 
+ #ifndef NDEBUG
+         {
+@@ -77,7 +78,14 @@ do_multicall(
+         }
+ #endif
+ 
+-        if ( unlikely(__copy_field_to_guest(call_list, &mcs->call, result)) )
++        if ( unlikely(disp == mc_exit) )
++        {
++            if ( __copy_field_to_guest(call_list, &mcs->call, result) )
++                /* nothing, best effort only */;
++            rc = mcs->call.result;
++        }
++        else if ( unlikely(__copy_field_to_guest(call_list, &mcs->call,
++                                                 result)) )
+             rc = -EFAULT;
+         else if ( test_bit(_MCSF_call_preempted, &mcs->flags) )
+         {
+@@ -93,6 +101,9 @@ do_multicall(
+             guest_handle_add_offset(call_list, 1);
+     }
+ 
++    if ( unlikely(disp == mc_preempt) && i < nr_calls )
++        goto preempted;
++
+     perfc_incr(calls_to_multicall);
+     perfc_add(calls_from_multicall, i);
+     mcs->flags = 0;
+Index: xen-4.3.4/xen/include/asm-arm/multicall.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/asm-arm/multicall.h
++++ xen-4.3.4/xen/include/asm-arm/multicall.h
+@@ -1,7 +1,11 @@
+ #ifndef __ASM_ARM_MULTICALL_H__
+ #define __ASM_ARM_MULTICALL_H__
+ 
+-extern void do_multicall_call(struct multicall_entry *call);
++extern enum mc_disposition {
++    mc_continue,
++    mc_exit,
++    mc_preempt,
++} do_multicall_call(struct multicall_entry *call);
+ 
+ #endif /* __ASM_ARM_MULTICALL_H__ */
+ /*
+Index: xen-4.3.4/xen/include/asm-x86/multicall.h
+===================================================================
+--- xen-4.3.4.orig/xen/include/asm-x86/multicall.h
++++ xen-4.3.4/xen/include/asm-x86/multicall.h
+@@ -7,8 +7,21 @@
+ 
+ #include <xen/errno.h>
+ 
++enum mc_disposition {
++    mc_continue,
++    mc_exit,
++    mc_preempt,
++};
++
++#define multicall_ret(call)                                  \
++    (unlikely((call)->op == __HYPERVISOR_iret)               \
++     ? mc_exit                                               \
++       : likely(guest_kernel_mode(current,                   \
++                                  guest_cpu_user_regs()))    \
++         ? mc_continue : mc_preempt)
++
+ #define do_multicall_call(_call)                             \
+-    do {                                                     \
++    ({                                                       \
+         __asm__ __volatile__ (                               \
+             "    movq  %c1(%0),%%rax; "                      \
+             "    leaq  hypercall_table(%%rip),%%rdi; "       \
+@@ -36,9 +49,11 @@
+               /* all the caller-saves registers */           \
+             : "rax", "rcx", "rdx", "rsi", "rdi",             \
+               "r8",  "r9",  "r10", "r11" );                  \
+-    } while ( 0 )
++        multicall_ret(_call);                                \
++    })
+ 
+ #define compat_multicall_call(_call)                         \
++    ({                                                       \
+         __asm__ __volatile__ (                               \
+             "    movl  %c1(%0),%%eax; "                      \
+             "    leaq  compat_hypercall_table(%%rip),%%rdi; "\
+@@ -65,6 +80,8 @@
+               "i" (offsetof(__typeof__(*_call), result))     \
+               /* all the caller-saves registers */           \
+             : "rax", "rcx", "rdx", "rsi", "rdi",             \
+-              "r8",  "r9",  "r10", "r11" )                   \
++              "r8",  "r9",  "r10", "r11" );                  \
++        multicall_ret(_call);                                \
++    })
+ 
+ #endif /* __ASM_X86_MULTICALL_H__ */

--- a/recipes-extended/xen/files/xsa-214-grant-transfer-allows-pv-guest-to-elevate-privileges.patch
+++ b/recipes-extended/xen/files/xsa-214-grant-transfer-allows-pv-guest-to-elevate-privileges.patch
@@ -1,0 +1,55 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-214 http://xenbits.xen.org/xsa/advisory-214.html
+grant transfer allows PV guest to elevate privileges
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Source: http://xenbits.xen.org/xsa/advisory-214.html
+Patch: xsa214.patch
+
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86: discard type information when stealing pages
+
+While a page having just a single general reference left necessarily
+has a zero type reference count too, its type may still be valid (and
+in validated state; at present this is only possible and relevant for
+PGT_seg_desc_page, as page tables have their type forcibly zapped when
+their type reference count drops to zero, and
+PGT_{writable,shared}_page pages don't require any validation). In
+such a case when the page is being re-used with the same type again,
+validation is being skipped. As validation criteria differ between
+32- and 64-bit guests, pages to be transferred between guests need to
+have their validation indicator zapped (and with it we zap all other
+type information at once).
+
+This is XSA-214.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+Index: xen-4.3.4/xen/arch/x86/mm.c
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/mm.c
++++ xen-4.3.4/xen/arch/x86/mm.c
+@@ -4254,6 +4254,17 @@ int steal_page(
+         y = cmpxchg(&page->count_info, x, x & ~PGC_count_mask);
+     } while ( y != x );
+ 
++    /*
++     * With the sole reference dropped temporarily, no-one can update type
++     * information. Type count also needs to be zero in this case, but e.g.
++     * PGT_seg_desc_page may still have PGT_validated set, which we need to
++     * clear before transferring ownership (as validation criteria vary
++     * depending on domain type).
++     */
++    BUG_ON(page->u.inuse.type_info & (PGT_count_mask | PGT_locked |
++                                      PGT_pinned));
++    page->u.inuse.type_info = 0;
++
+     /* Swizzle the owner then reinstate the PGC_allocated reference. */
+     page_set_owner(page, NULL);
+     y = page->count_info;

--- a/recipes-extended/xen/files/xsa-215-possible-memory-corruption-via-failsafe-callback.patch
+++ b/recipes-extended/xen/files/xsa-215-possible-memory-corruption-via-failsafe-callback.patch
@@ -1,0 +1,51 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+XSA-215 http://xenbits.xen.org/xsa/advisory-215.html
+possible memory corruption via failsafe callback
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86: correct create_bounce_frame
+
+We may push up to 96 bytes on the guest (kernel) stack, so we should
+also cover as much in the early range check. Note that this is the
+simplest possible patch, which has the theoretical potential of
+breaking a guest: We only really push 96 bytes when invoking the
+failsafe callback, ordinary exceptions only have 56 or 64 bytes pushed
+(without / with error code respectively). There is, however, no PV OS
+known to place a kernel stack there.
+
+This is XSA-215.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+################################################################################
+PATCHES
+################################################################################
+Index: xen-4.3.4/xen/arch/x86/x86_64/entry.S
+===================================================================
+--- xen-4.3.4.orig/xen/arch/x86/x86_64/entry.S
++++ xen-4.3.4/xen/arch/x86/x86_64/entry.S
+@@ -348,7 +348,7 @@ int80_slow_path:
+         jmp   handle_exception_saved
+ 
+ /* CREATE A BASIC EXCEPTION FRAME ON GUEST OS STACK:                     */
+-/*   { RCX, R11, [DS-GS,] [CR2,] [ERRCODE,] RIP, CS, RFLAGS, RSP, SS }   */
++/*   { RCX, R11, [DS-GS,] [ERRCODE,] RIP, CS, RFLAGS, RSP, SS }          */
+ /* %rdx: trap_bounce, %rbx: struct vcpu                                  */
+ /* On return only %rbx and %rdx are guaranteed non-clobbered.            */
+ create_bounce_frame:
+@@ -368,7 +368,7 @@ create_bounce_frame:
+ 2:      andq  $~0xf,%rsi                # Stack frames are 16-byte aligned.
+         movq  $HYPERVISOR_VIRT_START,%rax
+         cmpq  %rax,%rsi
+-        movq  $HYPERVISOR_VIRT_END+60,%rax
++        movq  $HYPERVISOR_VIRT_END+12*8,%rax
+         sbb   %ecx,%ecx                 # In +ve address space? Then okay.
+         cmpq  %rax,%rsi
+         adc   %ecx,%ecx                 # Above Xen private area? Then okay.

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -135,6 +135,15 @@ SRC_URI = "${XEN_SRC_URI};name=source \
     file://xsa-200-x86-cmpxchg8b-emulation-fails-to-ignore-operand-size-override.patch \
     file://xsa-202-x86-pv-guests-may-be-able-to-mask-interrupts.patch \
     file://xsa-204-x86-mishandling-of-syscall-singlestep-during-emulation.patch \
+    file://gcc6-compilation.patch \
+    file://iommu-make-page-table-population-preemptible.patch \
+    file://iommu-make-page-table-deallocation-preemptible.patch \
+    file://xsa-207-memory-leak-when-destroying-guest-without-PT-devices.patch \
+    file://xsa-212-x86-broken-check-in-memory_exchange.patch \
+    file://xen-arm-fully-implement-multicall-interface.patch \
+    file://xsa-213-x86-64bit-PV-guest-breakout-via-pagetable-use-after-mode-change.patch \
+    file://xsa-214-grant-transfer-allows-pv-guest-to-elevate-privileges.patch \
+    file://xsa-215-possible-memory-corruption-via-failsafe-callback.patch \
 "
 
 SRC_URI[source.md5sum] := "${XEN_SRC_MD5SUM}"


### PR DESCRIPTION
Since Xen 4.3.4 is EOL, also add required commits to keep the XSA
patches sane.