### PR TITLE
STABLE-7: OXT-826 : XSM: Add distinct device use permissions with and without IOMMU

### DIFF
--- a/recipes-extended/xen/files/xsm-for-vtd.patch
+++ b/recipes-extended/xen/files/xsm-for-vtd.patch
@@ -1,0 +1,240 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Enable XSM control over device passthrough with separate policy controls for:
+* when an IOMMU is available and capable of isolation using interrupt remapping
+* when only a less capable IOMMU is available
+* when no IOMMU is available
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+
+################################################################################
+CHANGELOG
+################################################################################
+
+################################################################################
+REMOVAL
+################################################################################
+Via upstreaming.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Yes.
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+OpenXT's XSM policy in xsm-policy.git
+
+################################################################################
+PATCHES
+################################################################################
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 59905e2..16eddea 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -20,6 +20,7 @@
+ #include <xen/errno.h>
+ #include <xen/guest_access.h>
+ #include <xen/xenoprof.h>
++#include <xen/iommu.h>
+ #ifdef HAS_PCI
+ #include <asm/msi.h>
+ #endif
+@@ -866,11 +867,31 @@ static int flask_map_domain_msi (struct domain *d, int irq, void *data,
+ #endif
+ }
+ 
++static u32 flask_iommu_resource_use_perm(void)
++{
++    /* Obtain the permission level required for allowing a domain
++     * to use an assigned device.
++     *
++     * An active IOMMU with interrupt remapping capability is essential
++     * for ensuring strict isolation of devices, so provide a distinct
++     * permission for that case and also enable optional support for
++     * less capable hardware (no IOMMU or IOMMU missing intremap capability)
++     * via other separate permissions.
++     */
++    u32 perm = RESOURCE__USE_NOIOMMU;
++
++    if (iommu_enabled)
++        perm = ( iommu_intremap ? RESOURCE__USE_IOMMU :
++                                  RESOURCE__USE_IOMMU_NOINTREMAP );
++    return perm;
++}
++
+ static int flask_map_domain_irq (struct domain *d, int irq, void *data)
+ {
+     u32 sid, dsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     if ( irq >= nr_static_irqs && data ) {
+         rc = flask_map_domain_msi(d, irq, data, &sid, &ad);
+@@ -887,7 +908,7 @@ static int flask_map_domain_irq (struct domain *d, int irq, void *data)
+     if ( rc )
+         return rc;
+ 
+-    rc = avc_has_perm(dsid, sid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    rc = avc_has_perm(dsid, sid, SECCLASS_RESOURCE, dperm, &ad);
+     return rc;
+ }
+ 
+@@ -936,6 +957,7 @@ static int flask_bind_pt_irq (struct domain *d, struct xen_domctl_bind_pt_irq *b
+     int rc = -EPERM;
+     int irq;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     rc = current_has_perm(d, SECCLASS_RESOURCE, RESOURCE__ADD);
+     if ( rc )
+@@ -952,7 +974,7 @@ static int flask_bind_pt_irq (struct domain *d, struct xen_domctl_bind_pt_irq *b
+         return rc;
+ 
+     dsid = domain_sid(d);
+-    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+ static int flask_unbind_pt_irq (struct domain *d, struct xen_domctl_bind_pt_irq *bind)
+@@ -970,6 +992,7 @@ struct iomem_has_perm_data {
+     u32 ssid;
+     u32 dsid;
+     u32 perm;
++    u32 use_perm;
+ };
+ 
+ static int _iomem_has_perm(void *v, u32 sid, unsigned long start, unsigned long end)
+@@ -987,7 +1010,7 @@ static int _iomem_has_perm(void *v, u32 sid, unsigned long start, unsigned long
+     if ( rc )
+         return rc;
+ 
+-    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, data->use_perm, &ad);
+ }
+ 
+ static int flask_iomem_permission(struct domain *d, uint64_t start, uint64_t end, uint8_t access)
+@@ -1007,6 +1030,7 @@ static int flask_iomem_permission(struct domain *d, uint64_t start, uint64_t end
+ 
+     data.ssid = domain_sid(current->domain);
+     data.dsid = domain_sid(d);
++    data.use_perm = flask_iommu_resource_use_perm();
+ 
+     return security_iterate_iomem_sids(start, end, _iomem_has_perm, &data);
+ }
+@@ -1021,7 +1045,7 @@ static int flask_pci_config_permission(struct domain *d, uint32_t machine_bdf, u
+     u32 dsid, rsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
+-    u32 perm = RESOURCE__USE;
++    u32 perm;
+ 
+     rc = security_device_sid(machine_bdf, &rsid);
+     if ( rc )
+@@ -1030,6 +1054,8 @@ static int flask_pci_config_permission(struct domain *d, uint32_t machine_bdf, u
+     /* Writes to the BARs count as setup */
+     if ( access && (end >= 0x10 && start < 0x28) )
+         perm = RESOURCE__SETUP;
++    else
++        perm = flask_iommu_resource_use_perm();
+ 
+     AVC_AUDIT_DATA_INIT(&ad, DEV);
+     ad.device = (unsigned long) machine_bdf;
+@@ -1243,6 +1269,7 @@ static int flask_assign_device(struct domain *d, uint32_t machine_bdf)
+     u32 dsid, rsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     rc = current_has_perm(d, SECCLASS_RESOURCE, RESOURCE__ADD);
+     if ( rc )
+@@ -1259,7 +1286,7 @@ static int flask_assign_device(struct domain *d, uint32_t machine_bdf)
+         return rc;
+ 
+     dsid = domain_sid(d);
+-    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+ static int flask_deassign_device(struct domain *d, uint32_t machine_bdf)
+@@ -1298,6 +1325,7 @@ static int flask_assign_dtdevice(struct domain *d, const char *dtpath)
+     u32 dsid, rsid;
+     int rc = -EPERM;
+     struct avc_audit_data ad;
++    u32 dperm = flask_iommu_resource_use_perm();
+ 
+     rc = current_has_perm(d, SECCLASS_RESOURCE, RESOURCE__ADD);
+     if ( rc )
+@@ -1314,7 +1342,7 @@ static int flask_assign_dtdevice(struct domain *d, const char *dtpath)
+         return rc;
+ 
+     dsid = domain_sid(d);
+-    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+ static int flask_deassign_dtdevice(struct domain *d, const char *dtpath)
+@@ -1373,6 +1401,7 @@ struct ioport_has_perm_data {
+     u32 ssid;
+     u32 dsid;
+     u32 perm;
++    u32 use_perm;
+ };
+ 
+ static int _ioport_has_perm(void *v, u32 sid, unsigned long start, unsigned long end)
+@@ -1390,7 +1419,7 @@ static int _ioport_has_perm(void *v, u32 sid, unsigned long start, unsigned long
+     if ( rc )
+         return rc;
+ 
+-    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, RESOURCE__USE, &ad);
++    return avc_has_perm(data->dsid, sid, SECCLASS_RESOURCE, data->use_perm, &ad);
+ }
+ 
+ static int flask_ioport_permission(struct domain *d, uint32_t start, uint32_t end, uint8_t access)
+@@ -1411,6 +1440,7 @@ static int flask_ioport_permission(struct domain *d, uint32_t start, uint32_t en
+ 
+     data.ssid = domain_sid(current->domain);
+     data.dsid = domain_sid(d);
++    data.use_perm = flask_iommu_resource_use_perm();
+ 
+     return security_iterate_ioport_sids(start, end, _ioport_has_perm, &data);
+ }
+diff --git a/xen/xsm/flask/policy/access_vectors b/xen/xsm/flask/policy/access_vectors
+index b06cf16..4710f91 100644
+--- a/xen/xsm/flask/policy/access_vectors
++++ b/xen/xsm/flask/policy/access_vectors
+@@ -425,11 +425,27 @@ class resource
+ #  source = domain making the hypercall
+ #  target = domain which will no longer have access to the resource
+     remove
++# checked when using some core Xen devices (target xen_t)
++#  source = domain which will have access to the resource
++#  target = xen_t
++    use
+ # checked when adding a resource to a domain:
+ #  source = domain which will have access to the resource
+ #  target = resource's security label
+-# also checked when using some core Xen devices (target xen_t)
+-    use
++# Requires an active IOMMU capable of interrupt remapping in order to
++# enforce isolation.
++    use_iommu
++# checked when adding a resource to a domain when an IOMMU is available
++# but it is not capable of interrupt mapping:
++#  source = domain which will have access to the resource
++#  target = resource's security label
++# Enable this to allow some less secure systems to still work.
++    use_iommu_nointremap
++# checked when adding a resource to a domain when no IOMMU present:
++#  source = domain which will have access to the resource
++#  target = resource's security label
++# Enable this to allow some less secure systems to still work.
++    use_noiommu
+ # PHYSDEVOP_map_pirq and ioapic writes for dom0, when acting on real IRQs
+ #  For GSI interrupts, the IRQ's label is indexed by the IRQ number
+ #  For MSI interrupts, the label of the PCI device is used

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -49,6 +49,7 @@ SRC_URI_append = " \
     file://openxt-xen-xsmv4vuse.patch \
     file://xenstat-disable-tmem-use.patch;patch=1 \
     file://acpi-slic-support.patch \
+    file://xsm-for-vtd.patch \
     file://libxl-do-not-destroy-in-use-tapdevs.patch \
     file://libxl-syslog.patch \
     file://libxl-RFC-4of7-Add-stubdomain-version-tools-domain-build-info.patch \


### PR DESCRIPTION

Enable policy to express control over device access:
 * Allow only when an IOMMU is active, or not.
 * Option to require an IOMMU capable of interrupt remapping.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>