### PR TITLE
OXT-1104: SELinux policy: remove storage permissions from xenstored

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
@@ -470,14 +470,9 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  files_read_etc_files(xenstored_t)
  files_read_usr_files(xenstored_t)
-@@ -454,7 +562,12 @@ files_read_usr_files(xenstored_t)
- fs_search_xenfs(xenstored_t)
+@@ -454,6 +562,7 @@ files_read_usr_files(xenstored_t)
  fs_manage_xenfs_files(xenstored_t)
  
-+storage_raw_read_fixed_disk(xenstored_t)
-+storage_raw_write_fixed_disk(xenstored_t)
-+storage_raw_read_removable_device(xenstored_t)
-+
  term_use_generic_ptys(xenstored_t)
 +term_use_console(xenconsoled_t)
  


### PR DESCRIPTION
Upstream refpolicy has already removed these permissions from xenstored.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>