### PR TITLE
OXT 782 QEMU minimization

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/block-remove-unused-block-format-support.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/block-remove-unused-block-format-support.patch
@@ -1,0 +1,85 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU remove unused block format support
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+In an effort to minimize the size of QEMU, we remove unused features.  Here, we
+build-time disable many of the unused block formats.  These cannot be disabled
+in the configure script, so we set them to 'n' in Makefile.objs.
+
+block.c needed modification to remove references to the disabled qcow2
+format.
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/block.c b/block.c
+index 951f5f4..3bad8ef 100644
+--- a/block.c
++++ b/block.c
+@@ -1405,7 +1405,7 @@ done:
+     qdict_del(options, bdref_key);
+     return c;
+ }
+-
++#if 0 /* OpenXT remove reference to Qcow2 */
+ static int bdrv_append_temp_snapshot(BlockDriverState *bs, int flags,
+                                      QDict *snapshot_options, Error **errp)
+ {
+@@ -1471,7 +1471,7 @@ out:
+     g_free(tmp_filename);
+     return ret;
+ }
+-
++#endif
+ /*
+  * Opens a disk image (raw, qcow2, vmdk, ...)
+  *
+@@ -1702,8 +1702,10 @@ static int bdrv_open_inherit(BlockDriverState **pbs, const char *filename,
+     /* For snapshot=on, create a temporary qcow2 overlay. bs points to the
+      * temporary snapshot afterwards. */
+     if (snapshot_flags) {
++#if 0 /* OpenXT remove reference to Qcow2 */
+         ret = bdrv_append_temp_snapshot(bs, snapshot_flags, snapshot_options,
+                                         &local_err);
++#endif
+         snapshot_options = NULL;
+         if (local_err) {
+             goto close_and_fail;
+diff --git a/block/Makefile.objs b/block/Makefile.objs
+index cdb33cc..ab80617 100644
+--- a/block/Makefile.objs
++++ b/block/Makefile.objs
+@@ -1,10 +1,11 @@
+-block-obj-y += raw_bsd.o qcow.o vdi.o vmdk.o cloop.o bochs.o vpc.o vvfat.o
+-block-obj-y += qcow2.o qcow2-refcount.o qcow2-cluster.o qcow2-snapshot.o qcow2-cache.o
+-block-obj-y += qed.o qed-gencb.o qed-l2-cache.o qed-table.o qed-cluster.o
+-block-obj-y += qed-check.o
++block-obj-y += raw_bsd.o
++block-obj-n += qcow.o vdi.o vmdk.o cloop.o bochs.o vpc.o vvfat.o
++block-obj-n += qcow2.o qcow2-refcount.o qcow2-cluster.o qcow2-snapshot.o qcow2-cache.o
++block-obj-n += qed.o qed-gencb.o qed-l2-cache.o qed-table.o qed-cluster.o
++block-obj-n += qed-check.o
+ block-obj-$(CONFIG_VHDX) += vhdx.o vhdx-endian.o vhdx-log.o
+-block-obj-y += quorum.o
+-block-obj-y += parallels.o blkdebug.o blkverify.o blkreplay.o
++block-obj-n += quorum.o
++block-obj-n += parallels.o blkdebug.o blkverify.o blkreplay.o
+ block-obj-y += block-backend.o snapshot.o qapi.o
+ block-obj-$(CONFIG_WIN32) += raw-win32.o win32-aio.o
+ block-obj-$(CONFIG_POSIX) += raw-posix.o
+@@ -13,7 +14,7 @@ block-obj-$(CONFIG_ATAPI_PT) += atapi-pt-protocol.o
+ block-obj-y += null.o mirror.o io.o
+ block-obj-y += throttle-groups.o
+ 
+-block-obj-y += nbd.o nbd-client.o sheepdog.o
++block-obj-n += nbd.o nbd-client.o sheepdog.o
+ block-obj-$(CONFIG_LIBISCSI) += iscsi.o
+ block-obj-$(CONFIG_LIBNFS) += nfs.o
+ block-obj-$(CONFIG_CURL) += curl.o
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/net-Remove-unused-network-options.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/net-Remove-unused-network-options.patch
@@ -1,0 +1,56 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU remove unused networking support
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+In an effort to minimize the size of QEMU, we remove unused features.  Here, we
+build-time disable unused network support.  These cannot be disabled in the
+configure script, so we set them to 'n' in Makefile.objs.
+
+net/net.c needed modification to avoid a link error as net_init_dump resides in
+the now disabled dump.o.
+
+###############################################################################
+PATCHES:
+###############################################################################
+
+diff --git a/net/Makefile.objs b/net/Makefile.objs
+index b7c22fd..4be8117 100644
+--- a/net/Makefile.objs
++++ b/net/Makefile.objs
+@@ -1,6 +1,6 @@
+ common-obj-y = net.o queue.o checksum.o util.o hub.o
+ common-obj-y += socket.o
+-common-obj-y += dump.o
++common-obj-n += dump.o
+ common-obj-y += eth.o
+ common-obj-$(CONFIG_L2TPV3) += l2tpv3.o
+ common-obj-$(CONFIG_POSIX) += tap.o vhost-user.o
+@@ -14,5 +14,5 @@ common-obj-$(CONFIG_SLIRP) += slirp.o
+ common-obj-$(CONFIG_VDE) += vde.o
+ common-obj-$(CONFIG_NETMAP) += netmap.o
+ common-obj-y += filter.o
+-common-obj-y += filter-buffer.o
+-common-obj-y += filter-mirror.o
++common-obj-n += filter-buffer.o
++common-obj-n += filter-mirror.o
+diff --git a/net/net.c b/net/net.c
+index 15a3920..cb6f74a 100644
+--- a/net/net.c
++++ b/net/net.c
+@@ -964,7 +964,9 @@ static int (* const net_client_init_fun[NET_CLIENT_OPTIONS_KIND__MAX])(
+ #ifdef CONFIG_NETMAP
+         [NET_CLIENT_OPTIONS_KIND_NETMAP]    = net_init_netmap,
+ #endif
++#if 0 /* OpenXT disabled dump.o */
+         [NET_CLIENT_OPTIONS_KIND_DUMP]      = net_init_dump,
++#endif
+ #ifdef CONFIG_NET_BRIDGE
+         [NET_CLIENT_OPTIONS_KIND_BRIDGE]    = net_init_bridge,
+ #endif
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -38,6 +38,8 @@ SRC_URI += "file://compile-time-stubdom-flag.patch \
             file://exit-mainloop-on-reset.patch \
             file://write-acpi-state-to-xenstore.patch \
             file://set-blockdev-ro.patch \
+            file://block-remove-unused-block-format-support.patch \
+            file://net-Remove-unused-network-options.patch \
             file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
             "
 

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -115,14 +115,15 @@ CFLAGS_append = " -Wno-unused-parameter -Wno-unused-local-typedefs --param ssp-b
 INC_PR = "r17"
 
 do_configure_append() {
-
 	sed -i -s '/^CONFIG_L2TPV3=y/d' config-host.mak
+}
+
+do_compile_prepend() {
+	rm -f i386-softmmu/config-devices.mak
+	oe_runmake i386-softmmu/config-devices.mak
 
 	dev_disable() {
-		sed -i -e 's/\('$1'=\).*$/\1n/' default-configs/pci.mak \
-						default-configs/usb.mak \
-						default-configs/sound.mak \
-						default-configs/i386-softmmu.mak
+		sed -i -e 's/\('$1'=\).*$/\1n/' i386-softmmu/config-devices.mak
 	}
 
 	dev_disable CONFIG_VGA_ISA

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -151,9 +151,7 @@ do_configure_append() {
 	dev_disable CONFIG_HYPERV_TESTDEV
 	dev_disable CONFIG_VIRTIO_PCI
 	dev_disable CONFIG_VIRTIO
-	dev_disable CONFIG_USB_UHCI
 	dev_disable CONFIG_USB_OHCI
-	dev_disable CONFIG_USB_EHCI
 	dev_disable CONFIG_USB_XHCI
 	dev_disable CONFIG_NE2000_PCI
 	dev_disable CONFIG_EEPRO100_PCI

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -178,6 +178,9 @@ do_configure_append() {
 	dev_disable CONFIG_ADLIB
 	dev_disable CONFIG_GUS
 	dev_disable CONFIG_CS4231A
+	dev_disable CONFIG_USB_STORAGE_BOT
+	dev_disable CONFIG_USB_STORAGE_UAS
+	dev_disable CONFIG_USB_STORAGE_MTP
 	dev_disable CONFIG_USB_SMARTCARD
 	dev_disable CONFIG_USB_AUDIO
 	dev_disable CONFIG_USB_SERIAL

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -1,9 +1,7 @@
 LICENSE = "GPLv2 & LGPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac  \
                     file://COPYING.LIB;md5=79ffa0ec772fa86740948cb7327a0cc7"
-DEPENDS = "xen alsa-lib pciutils libpng xen-blktap libv4v openssl zlib libcap-ng libdmbus"
-
-RDEPENDS_${PN} += "libusb1 nettle gnutls"
+DEPENDS = "xen alsa-lib pciutils libpng xen-blktap libv4v zlib libcap-ng libdmbus"
 
 # Leave this in it's own definition so that it can be replaced with a local
 # tarball (the QEMU download speed is terrible). If this is combined with the
@@ -80,13 +78,28 @@ EXTRA_OECONF += " \
     --disable-kvm \
     --disable-tools \
     --disable-fdt \
+    --disable-uuid \
+    --disable-vhdx \
+    --disable-qom-cast-debug \
+    --disable-tcg-interpreter \
+    --disable-vhost-net \
+    --disable-vhost-scsi \
+    --disable-bzip2 \
+    --disable-libusb \
+    --disable-usb-redir \
+    --disable-lzo \
+    --disable-gnutls \
+    --disable-nettle \
+    --disable-gcrypt \
+    --disable-tpm \
     --enable-pie \
     --enable-werror \
     --enable-surfman \
     --enable-atapi-pt \
     --enable-atapi-pt-v4v \
     --enable-readonly-ide \
-    --enable-debug \
+    --enable-debug-info \
+    --enable-trace-backends=nop \
 "
 
 do_configure(){

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -111,3 +111,78 @@ EXTRA_OEMAKE += "AUTOCONF_HOST='--host=`arch`' DESTDIR=${D} STRIP=''"
 CFLAGS_append = " -Wno-unused-parameter -Wno-unused-local-typedefs --param ssp-buffer-size=4 -ftrapv -D_FORTIFY_SOURCE=2"
 
 INC_PR = "r17"
+
+do_configure_append() {
+
+	sed -i -s '/^CONFIG_L2TPV3=y/d' config-host.mak
+
+	dev_disable() {
+		sed -i -e 's/\('$1'=\).*$/\1n/' default-configs/pci.mak \
+						default-configs/usb.mak \
+						default-configs/sound.mak \
+						default-configs/i386-softmmu.mak
+	}
+
+	dev_disable CONFIG_VGA_ISA
+	dev_disable CONFIG_VGA_CIRRUS
+	dev_disable CONFIG_VMWARE_VGA
+	dev_disable CONFIG_VIRTIO_VGA
+	dev_disable CONFIG_VMMOUSE
+	dev_disable CONFIG_IPMI
+	dev_disable CONFIG_IPMI_LOCAL
+	dev_disable CONFIG_IPMI_EXTERN
+	dev_disable CONFIG_ISA_IPMI_KCS
+	dev_disable CONFIG_ISA_IPMI_BT
+	dev_disable CONFIG_PARALLEL
+	dev_disable CONFIG_NE2000_ISA
+	dev_disable CONFIG_APPLESMC
+	#dev_disable CONFIG_PFLASH_CFI01
+	dev_disable CONFIG_WDT_IB700
+	dev_disable CONFIG_ISA_DEBUG
+	dev_disable CONFIG_ISA_TESTDEV
+	dev_disable CONFIG_VMPORT
+	dev_disable CONFIG_SGA
+	#dev_disable CONFIG_PVPANIC
+	#dev_disable CONFIG_NVDIMM
+	#dev_disable CONFIG_ACPI_NVDIMM
+	dev_disable CONFIG_XIO3130
+	dev_disable CONFIG_IOH3420
+	dev_disable CONFIG_I82801B11
+	dev_disable CONFIG_HYPERV_TESTDEV
+	dev_disable CONFIG_VIRTIO_PCI
+	dev_disable CONFIG_VIRTIO
+	dev_disable CONFIG_USB_UHCI
+	dev_disable CONFIG_USB_OHCI
+	dev_disable CONFIG_USB_EHCI
+	dev_disable CONFIG_USB_XHCI
+	dev_disable CONFIG_NE2000_PCI
+	dev_disable CONFIG_EEPRO100_PCI
+	dev_disable CONFIG_PCNET_PCI
+	dev_disable CONFIG_PCNET_COMMON
+	dev_disable CONFIG_ES1370
+	dev_disable CONFIG_LSI_SCSI_PCI
+	dev_disable CONFIG_VMW_PVSCSI_SCSI_PCI
+	dev_disable CONFIG_MEGASAS_SCSI_PCI
+	dev_disable CONFIG_MPTSAS_SCSI_PCI
+	dev_disable CONFIG_VMXNET3_PCI
+	dev_disable CONFIG_ESP
+	dev_disable CONFIG_ESP_PCI
+	dev_disable CONFIG_IPACK
+	dev_disable CONFIG_WDT_IB6300ESB
+	dev_disable CONFIG_PCI_TESTDEV
+	dev_disable CONFIG_NVME_PCI
+	dev_disable CONFIG_SD
+	dev_disable CONFIG_SDHCI
+	dev_disable CONFIG_EDU
+	dev_disable CONFIG_IVSHMEM
+	dev_disable CONFIG_ROCKER
+	dev_disable CONFIG_SB16
+	dev_disable CONFIG_ADLIB
+	dev_disable CONFIG_GUS
+	dev_disable CONFIG_CS4231A
+	dev_disable CONFIG_USB_SMARTCARD
+	dev_disable CONFIG_USB_AUDIO
+	dev_disable CONFIG_USB_SERIAL
+	dev_disable CONFIG_USB_NETWORK
+	dev_disable CONFIG_USB_BLUETOOTH
+}


### PR DESCRIPTION
This minimizes the set of QEMU emulated devices.
1) configure --disables many options
2) deselects many devices in the device configuration
3) patches out some block format and network functionality.

Size shrank from ~8.1MB to 6.3MB