### PR TITLE
STABLE-7 : OXT-1095: SELinux policy: allow xenstored to signal itself

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
@@ -446,7 +446,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
 -allow xenstored_t self:unix_stream_socket { accept listen };
 +allow xenstored_t self:unix_stream_socket { accept listen create_stream_socket_perms };
 +allow xenstored_t self:unix_dgram_socket create_socket_perms;
-+allow xenstored_t self:process setrlimit;
++allow xenstored_t self:process { setrlimit signal };
  
  manage_files_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
  manage_dirs_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)


### PR DESCRIPTION
This is in response to observed avcs when libxl releases a watch.

C xenstored has pipe handling code which includes managing response
to SIGPIPE. Allow that signal to be triggered by the xenstored process.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>