### PR TITLE
SELinux: add coredump support

### DIFF
--- a/recipes-core/base-files/base-files/fstab.xenclient-dom0
+++ b/recipes-core/base-files/base-files/fstab.xenclient-dom0
@@ -13,7 +13,7 @@ tmpfs                         /dev/shm      tmpfs  mode=0777,size=1M            
 tmpfs                         /mnt/upgrade  tmpfs  defaults,size=1M                                             0  0
 ramfs                         /mnt/secure   ramfs  context=system_u:object_r:xc_secure_t:s0,size=1M             0  0
 /dev/mapper/log               /var/log      ext4   errors=remount-ro,noatime                                    1  2
-/dev/mapper/cores             /var/cores    ext4   errors=remount-ro,noatime                                    1  3
+/dev/mapper/cores             /var/cores    ext4   errors=remount-ro,noatime,rootcontext=system_u:object_r:var_core_t:s0    1  3
 /dev/mapper/xenclient-boot    /boot/system  ext4   errors=remount-ro,noatime                                    1  4
 /dev/mapper/xenclient-storage /storage      ext4   errors=remount-ro,user_xattr,noatime                         1  5
 /dev/mapper/swap              none          swap   sw                                                           0  0

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.kernel.files.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.kernel.files.diff
@@ -48,7 +48,7 @@ Index: refpolicy/policy/modules/kernel/files.fc
  
  /var/spool(/.*)?		gen_context(system_u:object_r:var_spool_t,s0)
  /var/spool/postfix/etc(/.*)?	gen_context(system_u:object_r:etc_t,s0)
-@@ -274,6 +285,14 @@ ifndef(`distro_redhat',`
+@@ -274,6 +285,17 @@ ifndef(`distro_redhat',`
  /var/tmp/systemd-private-[^/]+/tmp	-d	gen_context(system_u:object_r:tmp_t,s0-mls_systemhigh)
  /var/tmp/systemd-private-[^/]+/tmp/.*	<<none>>
  /var/tmp/vi\.recover	-d	gen_context(system_u:object_r:tmp_t,s0)
@@ -60,6 +60,9 @@ Index: refpolicy/policy/modules/kernel/files.fc
 +/var/volatile/run                      -d      gen_context(system_u:object_r:var_run_t,s0-mls_systemhigh)
 +/var/volatile/run/.*                   gen_context(system_u:object_r:var_run_t,s0)
 +/var/volatile/run/.*\.*pid             <<none>>
++
++/var/cores		-d	gen_context(system_u:object_r:var_core_t,s0)
++/var/cores/*		--	gen_context(system_u:object_r:var_core_t,s0)
  
  ifdef(`distro_debian',`
  /var/run/motd		--	gen_context(system_u:object_r:initrc_var_run_t,s0)
@@ -375,7 +378,7 @@ Index: refpolicy/policy/modules/kernel/files.if
  	allow $1 var_t:dir search_dir_perms;
  	manage_files_pattern($1, var_lib_t, var_lib_t)
  ')
-@@ -5913,6 +6027,50 @@ interface(`files_lock_filetrans',`
+@@ -5913,6 +6027,69 @@ interface(`files_lock_filetrans',`
  
  ########################################
  ## <summary>
@@ -423,10 +426,29 @@ Index: refpolicy/policy/modules/kernel/files.if
 +
 +########################################
 +## <summary>
++##	Create core dumps
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`files_create_core_dump',`
++	gen_require(`
++		type var_core_t;
++	')
++
++	allow $1 var_core_t:dir add_entry_dir_perms;
++	allow $1 var_core_t:file { create_file_perms rw_file_perms };
++')
++
++########################################
++## <summary>
  ##	Do not audit attempts to get the attributes
  ##	of the /var/run directory.
  ## </summary>
-@@ -5933,6 +6091,25 @@ interface(`files_dontaudit_getattr_pid_d
+@@ -5933,6 +6110,25 @@ interface(`files_dontaudit_getattr_pid_d
  
  ########################################
  ## <summary>
@@ -452,7 +474,7 @@ Index: refpolicy/policy/modules/kernel/files.if
  ##	Set the attributes of the /var/run directory.
  ## </summary>
  ## <param name="domain">
-@@ -5968,6 +6145,7 @@ interface(`files_search_pids',`
+@@ -5968,6 +6164,7 @@ interface(`files_search_pids',`
  
  	allow $1 var_run_t:lnk_file read_lnk_file_perms;
  	search_dirs_pattern($1, var_t, var_run_t)
@@ -460,7 +482,7 @@ Index: refpolicy/policy/modules/kernel/files.if
  ')
  
  ########################################
-@@ -6188,6 +6366,7 @@ interface(`files_dontaudit_getattr_all_p
+@@ -6188,6 +6385,7 @@ interface(`files_dontaudit_getattr_all_p
  interface(`files_dontaudit_write_all_pids',`
  	gen_require(`
  		attribute pidfile;
@@ -468,7 +490,7 @@ Index: refpolicy/policy/modules/kernel/files.if
  	')
  
  	dontaudit $1 var_run_t:lnk_file read_lnk_file_perms;
-@@ -6196,6 +6375,42 @@ interface(`files_dontaudit_write_all_pid
+@@ -6196,6 +6394,42 @@ interface(`files_dontaudit_write_all_pid
  
  ########################################
  ## <summary>
@@ -511,7 +533,7 @@ Index: refpolicy/policy/modules/kernel/files.if
  ##	Do not audit attempts to ioctl daemon runtime data files.
  ## </summary>
  ## <param name="domain">
-@@ -6264,6 +6479,24 @@ interface(`files_delete_all_pids',`
+@@ -6264,6 +6498,24 @@ interface(`files_delete_all_pids',`
  
  ########################################
  ## <summary>
@@ -536,7 +558,7 @@ Index: refpolicy/policy/modules/kernel/files.if
  ##	Delete all process ID directories.
  ## </summary>
  ## <param name="domain">
-@@ -6547,3 +6780,21 @@ interface(`files_unconfined',`
+@@ -6547,3 +6799,21 @@ interface(`files_unconfined',`
  
  	typeattribute $1 files_unconfined_type;
  ')
@@ -580,7 +602,21 @@ Index: refpolicy/policy/modules/kernel/files.te
  # compatibility aliases for removed types:
  typealias etc_t alias automount_etc_t;
  typealias etc_t alias snmpd_etc_t;
-@@ -221,3 +225,14 @@ allow files_unconfined_type file_type:fi
+@@ -172,6 +176,13 @@ files_pid_file(var_run_t)
+ files_mountpoint(var_run_t)
+ 
+ #
++# var_core_t is the type of /var/cores, used
++# for core dumps.
++#
++type var_core_t;
++files_mountpoint(var_core_t)
++
++#
+ # var_spool_t is the type of /var/spool
+ #
+ type var_spool_t;
+@@ -221,3 +232,14 @@ allow files_unconfined_type file_type:fi
  tunable_policy(`allow_execmod',`
  	allow files_unconfined_type file_type:file execmod;
  ')


### PR DESCRIPTION
Label /var/cores and the files inside it.

Signed-off-by: Jed <lejosnej@ainfosec.com>