### PR TITLE
xenstored: enable core dumps to help diagnose crashes

### DIFF
--- a/recipes-extended/xen/files/xenstored.initscript
+++ b/recipes-extended/xen/files/xenstored.initscript
@@ -25,6 +25,8 @@ EXECUTABLE=/usr/sbin/xenstored
 
 start() {
 	echo -n "Starting xenstored: "
+	# Allow 55MB for core dumps
+	ulimit -c 112640
 	$EXECUTABLE --pid-file $PIDFILE 2> /dev/null 2>&1
 	for i in /usr/share/xenclient/xenstore-init*;
 	do

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.contrib.xen.diff
@@ -450,7 +450,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
  manage_dirs_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
-@@ -430,6 +532,7 @@ files_pid_filetrans(xenstored_t, xenstor
+@@ -430,6 +533,7 @@ files_pid_filetrans(xenstored_t, xenstor
  manage_dirs_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  append_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  create_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
@@ -458,7 +458,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  setattr_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  manage_sock_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  logging_log_filetrans(xenstored_t, xenstored_var_log_t, { sock_file file dir })
-@@ -447,6 +550,11 @@ kernel_read_xen_state(xenstored_t)
+@@ -447,6 +551,11 @@ kernel_read_xen_state(xenstored_t)
  dev_filetrans_xen(xenstored_t)
  dev_rw_xen(xenstored_t)
  dev_read_sysfs(xenstored_t)
@@ -470,7 +470,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  files_read_etc_files(xenstored_t)
  files_read_usr_files(xenstored_t)
-@@ -454,6 +562,7 @@ files_read_usr_files(xenstored_t)
+@@ -455,6 +564,7 @@ fs_search_xenfs(xenstored_t)
  fs_manage_xenfs_files(xenstored_t)
  
  term_use_generic_ptys(xenstored_t)
@@ -478,7 +478,16 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  init_use_fds(xenstored_t)
  init_use_script_ptys(xenstored_t)
-@@ -473,8 +586,8 @@ xen_append_log(xenstored_t)
+@@ -465,6 +575,8 @@ miscfiles_read_localization(xenstored_t)
+ 
+ xen_append_log(xenstored_t)
+ 
++files_create_core_dump(xenstored_t)
++
+ ########################################
+ #
+ # xm local policy
+@@ -473,8 +585,8 @@ xen_append_log(xenstored_t)
  allow xm_t self:capability { setpcap dac_override ipc_lock sys_nice sys_tty_config };
  allow xm_t self:process { getcap getsched setsched setcap signal };
  allow xm_t self:fifo_file rw_fifo_file_perms;
@@ -489,7 +498,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
  manage_fifo_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
-@@ -544,6 +657,10 @@ miscfiles_read_localization(xm_t)
+@@ -544,6 +656,10 @@ miscfiles_read_localization(xm_t)
  
  sysnet_dns_name_resolve(xm_t)
  
@@ -500,7 +509,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  tunable_policy(`xen_use_fusefs',`
  	fs_manage_fusefs_dirs(xm_t)
  	fs_manage_fusefs_files(xm_t)
-@@ -601,4 +718,23 @@ optional_policy(`
+@@ -601,4 +717,23 @@ optional_policy(`
  
  	fs_manage_xenfs_dirs(xm_ssh_t)
  	fs_manage_xenfs_files(xm_ssh_t)


### PR DESCRIPTION
Signed-off-by: Jed <lejosnej@ainfosec.com>