### PR TITLE
OXT-776: QEMU CVEs

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-8669-char-serial-check-divider-value-against-baud-base.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-8669-char-serial-check-divider-value-against-baud-base.patch
@@ -1,0 +1,48 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: char: serial: check divider value against baud base
+CVE-2016-8669
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit: 3592fe0c919cf27a81d8e9f9b4f269553418bb01
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Wed, 12 Oct 2016 11:28:08 +0530
+Subject: char: serial: check divider value against baud base
+
+16550A UART device uses an oscillator to generate frequencies
+(baud base), which decide communication speed. This speed could
+be changed by dividing it by a divider. If the divider is
+greater than the baud base, speed is set to zero, leading to a
+divide by zero error. Add check to avoid it.
+
+Reported-by: Huawei PSIRT <psirt@huawei.com>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Message-Id: <1476251888-20238-1-git-send-email-ppandit@redhat.com>
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+
+CVE-2016-8669
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/hw/char/serial.c b/hw/char/serial.c
+index 6d815b5..3998131 100644
+--- a/hw/char/serial.c
++++ b/hw/char/serial.c
+@@ -152,8 +152,9 @@ static void serial_update_parameters(SerialState *s)
+     int speed, parity, data_bits, stop_bits, frame_size;
+     QEMUSerialSetParams ssp;
+ 
+-    if (s->divider == 0)
++    if (s->divider == 0 || s->divider > s->baudbase) {
+         return;
++    }
+ 
+     /* Start bit. */
+     frame_size = 1;
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-8909-audio-intel-hda-check-stream-entry-count-during-tran.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-8909-audio-intel-hda-check-stream-entry-count-during-tran.patch
@@ -1,0 +1,49 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+CVE-2016-8909
+audio: intel-hda: check stream entry count during transfer
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+QEMU Upstream Commit 0c0fc2b5fd534786051889459848764edd798050
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Thu, 20 Oct 2016 13:10:24 +0530
+Subject: [PATCH] audio: intel-hda: check stream entry count during transfer
+
+Intel HDA emulator uses stream of buffers during DMA data
+transfers. Each entry has buffer length and buffer pointer
+position, which are used to derive bytes to 'copy'. If this
+length and buffer pointer were to be same, 'copy' could be
+set to zero(0), leading to an infinite loop. Add check to
+avoid it.
+
+Reported-by: Huawei PSIRT <psirt@huawei.com>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Reviewed-by: Stefan Hajnoczi <stefanha@redhat.com>
+Message-id: 1476949224-6865-1-git-send-email-ppandit@redhat.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+
+CVE-2016-8909
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/hw/audio/intel-hda.c b/hw/audio/intel-hda.c
+index d372d4a..cd3b03c 100644
+--- a/hw/audio/intel-hda.c
++++ b/hw/audio/intel-hda.c
+@@ -415,7 +415,8 @@ static bool intel_hda_xfer(HDACodecDevice *dev, uint32_t stnr, bool output,
+     }
+ 
+     left = len;
+-    while (left > 0) {
++    s = st->bentries;
++    while (left > 0 && s-- > 0) {
+         copy = left;
+         if (copy > st->bsize - st->lpib)
+             copy = st->bsize - st->lpib;
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-8910-net-rtl8139-limit-processing-of-ring-descriptors.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-8910-net-rtl8139-limit-processing-of-ring-descriptors.patch
@@ -1,0 +1,45 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: net: rtl8139: limit processing of ring descriptors
+CVE-2016-8910
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit c7c35916692fe010fef25ac338443d3fe40be225
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Fri, 21 Oct 2016 17:39:29 +0530
+Subject: net: rtl8139: limit processing of ring descriptors
+
+RTL8139 ethernet controller in C+ mode supports multiple
+descriptor rings, each with maximum of 64 descriptors. While
+processing transmit descriptor ring in 'rtl8139_cplus_transmit',
+it does not limit the descriptor count and runs forever. Add
+check to avoid it.
+
+Reported-by: Andrew Henderson <hendersa@icculus.org>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Signed-off-by: Jason Wang <jasowang@redhat.com>
+
+CVE-2016-8910
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/hw/net/rtl8139.c b/hw/net/rtl8139.c
+index 1e5ec14..138fa62 100644
+--- a/hw/net/rtl8139.c
++++ b/hw/net/rtl8139.c
+@@ -2379,7 +2379,7 @@ static void rtl8139_cplus_transmit(RTL8139State *s)
+ {
+     int txcount = 0;
+ 
+-    while (rtl8139_cplus_transmit_one(s))
++    while (txcount < 64 && rtl8139_cplus_transmit_one(s))
+     {
+         ++txcount;
+     }
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-9923-char-Fix-Possible-use-after-free.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2016-9923-char-Fix-Possible-use-after-free.patch
@@ -1,0 +1,76 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: char: Fix Possible use-after-free (CVE-2016-9923)
+CVE-2016-9923
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+From: Jason Andryuk <jandryuk@gmail.com>
+Subject: char: Fix Possible use-after-free (CVE-2016-9923)
+
+From the CVE:
+Quick Emulator (Qemu) built with the 'chardev' backend support is
+vulnerable to a use after free issue. It could occur while hotplug and
+unplugging the device in the guest. A guest user/process could use this
+flaw to crash a Qemu process on the host resulting in DoS.
+
+The upstream fix incorporates other code changes, but the relevant
+portion is pointed out by Paolo Bonzini in this email:
+
+https://lists.gnu.org/archive/html/qemu-devel/2016-10/msg05597.html
+
+Upstream commit a4afa548fc6dd9842ed86639b4d37d4d1c4ad480
+
+The upstream commit also mentions
+    Also a mux CharDriver should go through mux->backends[focused], since
+    chr->be will stay NULL. Before that, it was possible to call
+    chr->handler by mistake with surprising results, for ex through
+    qemu_chr_be_can_write(), which would result in calling the last set
+    handler front end, not the one with focus.
+
+This is not fixed.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+
+CVE-2016-9923
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/qemu-char.c b/qemu-char.c
+index 7627719..b1e28c0 100644
+--- a/qemu-char.c
++++ b/qemu-char.c
+@@ -4761,6 +4761,17 @@ out_error:
+     return NULL;
+ }
+ 
++static bool qemu_chr_is_busy(CharDriverState *chr)
++{
++    if (chr->is_mux) {
++        MuxDriver *d = chr->opaque;
++        return d->mux_cnt >= 0;
++    } else {
++        return (chr->chr_can_read || chr->chr_read ||
++                chr->chr_event || chr->handler_opaque);
++    }
++}
++
+ void qmp_chardev_remove(const char *id, Error **errp)
+ {
+     CharDriverState *chr;
+@@ -4770,8 +4781,7 @@ void qmp_chardev_remove(const char *id, Error **errp)
+         error_setg(errp, "Chardev '%s' not found", id);
+         return;
+     }
+-    if (chr->chr_can_read || chr->chr_read ||
+-        chr->chr_event || chr->handler_opaque) {
++    if (qemu_chr_is_busy(chr)) {
+         error_setg(errp, "Chardev '%s' is busy", id);
+         return;
+     }
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-5525-audio-ac97-add-exit-function.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-5525-audio-ac97-add-exit-function.patch
@@ -1,0 +1,60 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: audio: ac97: add exit function
+CVE-2017-5525
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit 12351a91da97b414eec8cdb09f1d9f41e535a401
+From: Li Qiang <liqiang6-s@360.cn>
+Date: Wed, 14 Dec 2016 18:30:21 -0800
+Subject: audio: ac97: add exit function
+
+Currently the ac97 device emulation doesn't have a exit function,
+hot unplug this device will leak some memory. Add a exit function to
+avoid this.
+
+Signed-off-by: Li Qiang <liqiang6-s@360.cn>
+Reviewed-by: Marc-André Lureau <marcandre.lureau@redhat.com>
+Message-id: 58520052.4825ed0a.27a71.6cae@mx.google.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+
+CVE-2017-5525
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/hw/audio/ac97.c b/hw/audio/ac97.c
+index 671155e..6e98539 100644
+--- a/hw/audio/ac97.c
++++ b/hw/audio/ac97.c
+@@ -1396,6 +1396,16 @@ static void ac97_realize(PCIDevice *dev, Error **errp)
+     ac97_on_reset (&s->dev.qdev);
+ }
+ 
++static void ac97_exit(PCIDevice *dev)
++{
++    AC97LinkState *s = DO_UPCAST(AC97LinkState, dev, dev);
++
++    AUD_close_in(&s->card, s->voice_pi);
++    AUD_close_out(&s->card, s->voice_po);
++    AUD_close_in(&s->card, s->voice_mc);
++    AUD_remove_card(&s->card);
++}
++
+ static int ac97_init (PCIBus *bus)
+ {
+     pci_create_simple (bus, -1, "AC97");
+@@ -1413,6 +1423,7 @@ static void ac97_class_init (ObjectClass *klass, void *data)
+     PCIDeviceClass *k = PCI_DEVICE_CLASS (klass);
+ 
+     k->realize = ac97_realize;
++    k->exit = ac97_exit;
+     k->vendor_id = PCI_VENDOR_ID_INTEL;
+     k->device_id = PCI_DEVICE_ID_INTEL_82801AA_5;
+     k->revision = 0x01;
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-5579-serial-fix-memory-leak-in-serial-exit.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-5579-serial-fix-memory-leak-in-serial-exit.patch
@@ -1,0 +1,51 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: serial: fix memory leak in serial exit
+CVE-2017-5579
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit 8409dc884a201bf74b30a9d232b6bbdd00cb7e2b
+From: Li Qiang <liqiang6-s@360.cn>
+Date: Wed, 4 Jan 2017 00:43:16 -0800
+Subject: serial: fix memory leak in serial exit
+
+The serial_exit_core function doesn't free some resources.
+This can lead memory leak when hotplug and unplug. This
+patch avoid this.
+
+Signed-off-by: Li Qiang <liqiang6-s@360.cn>
+Message-Id: <586cb5ab.f31d9d0a.38ac3.acf2@mx.google.com>
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+
+CVE-2017-5579
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/hw/char/serial.c b/hw/char/serial.c
+index 3998131..ebf507b 100644
+--- a/hw/char/serial.c
++++ b/hw/char/serial.c
+@@ -869,6 +869,16 @@ void serial_realize_core(SerialState *s, Error **errp)
+ void serial_exit_core(SerialState *s)
+ {
+     qemu_chr_add_handlers(s->chr, NULL, NULL, NULL, NULL);
++
++    timer_del(s->modem_status_poll);
++    timer_free(s->modem_status_poll);
++
++    timer_del(s->fifo_timeout_timer);
++    timer_free(s->fifo_timeout_timer);
++
++    fifo8_destroy(&s->recv_fifo);
++    fifo8_destroy(&s->xmit_fifo);
++
+     qemu_unregister_reset(serial_reset, s);
+ }
+ 
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-8284-tcg-i386-Check-the-size-of-instruction-being-transla.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-8284-tcg-i386-Check-the-size-of-instruction-being-transla.patch
@@ -1,0 +1,52 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: tcg/i386: Check the size of instruction being translated
+CVE-2017-8284
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit 30663fd26c0307e414622c7a8607fbc04f92ec14
+From: Pranith Kumar <bobby.prani@gmail.com>
+Date: Thu, 23 Mar 2017 13:58:51 -0400
+Subject: tcg/i386: Check the size of instruction being translated
+
+This fixes the bug: 'user-to-root privesc inside VM via bad translation
+caching' reported by Jann Horn here:
+https://bugs.chromium.org/p/project-zero/issues/detail?id=1122
+
+Reviewed-by: Richard Henderson <rth@twiddle.net>
+CC: Peter Maydell <peter.maydell@linaro.org>
+CC: Paolo Bonzini <pbonzini@redhat.com>
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Pranith Kumar <bobby.prani@gmail.com>
+Message-Id: <20170323175851.14342-1-bobby.prani@gmail.com>
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+
+CVE-2017-8284
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/target-i386/translate.c b/target-i386/translate.c
+index 922347c..ee9c65b 100644
+--- a/target-i386/translate.c
++++ b/target-i386/translate.c
+@@ -4353,6 +4353,13 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
+     s->vex_l = 0;
+     s->vex_v = 0;
+  next_byte:
++    /* x86 has an upper limit of 15 bytes for an instruction. Since we
++     * do not want to decode and generate IR for an illegal
++     * instruction, the following check limits the instruction size to
++     * 25 bytes: 14 prefix + 1 opc + 6 (modrm+sib+ofs) + 4 imm */
++    if (s->pc - pc_start > 14) {
++        goto illegal_op;
++    }
+     b = cpu_ldub_code(env, s->pc);
+     s->pc++;
+     /* Collect prefixes.  */
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-8309-audio-release-capture-buffers.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-8309-audio-release-capture-buffers.patch
@@ -1,0 +1,49 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: audio: release capture buffers
+CVE-2017-8309
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit 3268a845f41253fb55852a8429c32b50f36f349a
+From: Gerd Hoffmann <kraxel@redhat.com>
+Date: Fri, 28 Apr 2017 09:56:12 +0200
+Subject: audio: release capture buffers
+
+AUD_add_capture() allocates two buffers which are never released.
+Add the missing calls to AUD_del_capture().
+
+Impact: Allows vnc clients to exhaust host memory by repeatedly
+starting and stopping audio capture.
+
+Fixes: CVE-2017-8309
+Cc: P J P <ppandit@redhat.com>
+Cc: Huawei PSIRT <PSIRT@huawei.com>
+Reported-by: "Jiangxin (hunter, SCC)" <jiangxin1@huawei.com>
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Reviewed-by: Prasad J Pandit <pjp@fedoraproject.org>
+Message-id: 20170428075612.9997-1-kraxel@redhat.com
+
+CVE-2017-8309
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/audio/audio.c b/audio/audio.c
+index e60c124..956716d 100644
+--- a/audio/audio.c
++++ b/audio/audio.c
+@@ -2019,6 +2019,8 @@ void AUD_del_capture (CaptureVoiceOut *cap, void *cb_opaque)
+                     sw = sw1;
+                 }
+                 QLIST_REMOVE (cap, entries);
++                g_free (cap->hw.mix_buf);
++                g_free (cap->buf);
+                 g_free (cap);
+             }
+             return;
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-8379-input-limit-kbd-queue-depth.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/CVE-2017-8379-input-limit-kbd-queue-depth.patch
@@ -1,0 +1,101 @@
+###############################################################################
+SHORT DESCRIPTION:
+###############################################################################
+QEMU: input: limit kbd queue depth
+CVE-2017-8379
+
+###############################################################################
+LONG DESCRIPTION:
+###############################################################################
+Upstream Commit fa18f36a461984eae50ab957e47ec78dae3c14fc
+From: Gerd Hoffmann <kraxel@redhat.com>
+Date: Fri, 28 Apr 2017 10:42:37 +0200
+Subject: input: limit kbd queue depth
+
+Apply a limit to the number of items we accept into the keyboard queue.
+
+Impact: Without this limit vnc clients can exhaust host memory by
+sending keyboard events faster than qemu feeds them to the guest.
+
+Fixes: CVE-2017-8379
+Cc: P J P <ppandit@redhat.com>
+Cc: Huawei PSIRT <PSIRT@huawei.com>
+Reported-by: jiangxin1@huawei.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Message-id: 20170428084237.23960-1-kraxel@redhat.com
+
+CVE-2017-8379
+
+###############################################################################
+PATCHES:
+###############################################################################
+diff --git a/ui/input.c b/ui/input.c
+index ed88cda..fb1f404 100644
+--- a/ui/input.c
++++ b/ui/input.c
+@@ -41,6 +41,8 @@ static QTAILQ_HEAD(QemuInputEventQueueHead, QemuInputEventQueue) kbd_queue =
+     QTAILQ_HEAD_INITIALIZER(kbd_queue);
+ static QEMUTimer *kbd_timer;
+ static uint32_t kbd_default_delay_ms = 10;
++static uint32_t queue_count;
++static uint32_t queue_limit = 1024;
+ 
+ QemuInputHandlerState *qemu_input_handler_register(DeviceState *dev,
+                                                    QemuInputHandler *handler)
+@@ -268,6 +270,7 @@ static void qemu_input_queue_process(void *opaque)
+             break;
+         }
+         QTAILQ_REMOVE(queue, item, node);
++        queue_count--;
+         g_free(item);
+     }
+ }
+@@ -282,6 +285,7 @@ static void qemu_input_queue_delay(struct QemuInputEventQueueHead *queue,
+     item->delay_ms = delay_ms;
+     item->timer = timer;
+     QTAILQ_INSERT_TAIL(queue, item, node);
++    queue_count++;
+ 
+     if (start_timer) {
+         timer_mod(item->timer, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL)
+@@ -298,6 +302,7 @@ static void qemu_input_queue_event(struct QemuInputEventQueueHead *queue,
+     item->src = src;
+     item->evt = evt;
+     QTAILQ_INSERT_TAIL(queue, item, node);
++    queue_count++;
+ }
+ 
+ static void qemu_input_queue_sync(struct QemuInputEventQueueHead *queue)
+@@ -306,6 +311,7 @@ static void qemu_input_queue_sync(struct QemuInputEventQueueHead *queue)
+ 
+     item->type = QEMU_INPUT_QUEUE_SYNC;
+     QTAILQ_INSERT_TAIL(queue, item, node);
++    queue_count++;
+ }
+ 
+ void qemu_input_event_send_impl(QemuConsole *src, InputEvent *evt)
+@@ -381,7 +387,7 @@ void qemu_input_event_send_key(QemuConsole *src, KeyValue *key, bool down)
+         qemu_input_event_send(src, evt);
+         qemu_input_event_sync();
+         qapi_free_InputEvent(evt);
+-    } else {
++    } else if (queue_count < queue_limit) {
+         qemu_input_queue_event(&kbd_queue, src, evt);
+         qemu_input_queue_sync(&kbd_queue);
+     }
+@@ -409,8 +415,10 @@ void qemu_input_event_send_key_delay(uint32_t delay_ms)
+         kbd_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL, qemu_input_queue_process,
+                                  &kbd_queue);
+     }
+-    qemu_input_queue_delay(&kbd_queue, kbd_timer,
+-                           delay_ms ? delay_ms : kbd_default_delay_ms);
++    if (queue_count < queue_limit) {
++        qemu_input_queue_delay(&kbd_queue, kbd_timer,
++                               delay_ms ? delay_ms : kbd_default_delay_ms);
++    }
+ }
+ 
+ InputEvent *qemu_input_event_new_btn(InputButton btn, bool down)
+-- 
+2.9.4
+

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -41,6 +41,13 @@ SRC_URI += "file://compile-time-stubdom-flag.patch \
             file://block-remove-unused-block-format-support.patch \
             file://net-Remove-unused-network-options.patch \
             file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
+            file://CVE-2016-8669-char-serial-check-divider-value-against-baud-base.patch \
+            file://CVE-2016-8910-net-rtl8139-limit-processing-of-ring-descriptors.patch \
+            file://CVE-2017-5525-audio-ac97-add-exit-function.patch \
+            file://CVE-2017-5579-serial-fix-memory-leak-in-serial-exit.patch \
+            file://CVE-2017-8284-tcg-i386-Check-the-size-of-instruction-being-transla.patch \
+            file://CVE-2017-8309-audio-release-capture-buffers.patch \
+            file://CVE-2017-8379-input-limit-kbd-queue-depth.patch \
             "
 
 SRC_URI[md5sum] = "bdf1f3d0c177ebeb35a079a4bc3fc74e"

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -42,6 +42,7 @@ SRC_URI += "file://compile-time-stubdom-flag.patch \
             file://net-Remove-unused-network-options.patch \
             file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
             file://CVE-2016-8669-char-serial-check-divider-value-against-baud-base.patch \
+            file://CVE-2016-8909-audio-intel-hda-check-stream-entry-count-during-tran.patch \
             file://CVE-2016-8910-net-rtl8139-limit-processing-of-ring-descriptors.patch \
             file://CVE-2016-9923-char-Fix-Possible-use-after-free.patch \
             file://CVE-2017-5525-audio-ac97-add-exit-function.patch \

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -43,6 +43,7 @@ SRC_URI += "file://compile-time-stubdom-flag.patch \
             file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
             file://CVE-2016-8669-char-serial-check-divider-value-against-baud-base.patch \
             file://CVE-2016-8910-net-rtl8139-limit-processing-of-ring-descriptors.patch \
+            file://CVE-2016-9923-char-Fix-Possible-use-after-free.patch \
             file://CVE-2017-5525-audio-ac97-add-exit-function.patch \
             file://CVE-2017-5579-serial-fix-memory-leak-in-serial-exit.patch \
             file://CVE-2017-8284-tcg-i386-Check-the-size-of-instruction-being-transla.patch \


### PR DESCRIPTION
CVE fixes for the minimized QEMU configuration.

OXT-776

This is intended to apply on top of my other PR #641 oxt-782-qemu-mini-hda.  As it is, this includes both sets of commits together.