### PR TITLE
STABLE-7: [tpm2.0] Set the correct flag if detected tpm_own

### DIFF
--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -152,7 +152,7 @@ tpm_is_owned() {
         tpm2_dump_capability --capability=properties-variable | grep -q 'ownerAuthSet:[[:space:]]\+set'
         ret=$?
         if [ "${ret}" -eq 0 ]; then
-            state=0
+            state=1
         fi
     else
         state=$(cat ${tpm}/owned)


### PR DESCRIPTION
  Fix backwards logic for tpm_is_owned call from installer.

  OXT-1116

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>