### PR TITLE
STABLE-7: OXT-1125: blktap: Backport XSA-155

### DIFF
--- a/recipes-extended/xen/files/xsa-155-xen-0001-xen-Add-RING_COPY_REQUEST.patch
+++ b/recipes-extended/xen/files/xsa-155-xen-0001-xen-Add-RING_COPY_REQUEST.patch
@@ -1,0 +1,56 @@
+From 12b11658a9d6a654a1e7acbf2f2d56ce9a396c86 Mon Sep 17 00:00:00 2001
+From: David Vrabel <david.vrabel@citrix.com>
+Date: Fri, 20 Nov 2015 11:59:05 -0500
+Subject: [PATCH 1/3] xen: Add RING_COPY_REQUEST()
+
+Using RING_GET_REQUEST() on a shared ring is easy to use incorrectly
+(i.e., by not considering that the other end may alter the data in the
+shared ring while it is being inspected).  Safe usage of a request
+generally requires taking a local copy.
+
+Provide a RING_COPY_REQUEST() macro to use instead of
+RING_GET_REQUEST() and an open-coded memcpy().  This takes care of
+ensuring that the copy is done correctly regardless of any possible
+compiler optimizations.
+
+Use a volatile source to prevent the compiler from reordering or
+omitting the copy.
+
+This is part of XSA155.
+
+Signed-off-by: David Vrabel <david.vrabel@citrix.com>
+Signed-off-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+---
+v2: Add comment about GCC bug.
+---
+ xen/include/public/io/ring.h | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/xen/include/public/io/ring.h b/xen/include/public/io/ring.h
+index ba9401b..801c0da 100644
+--- a/xen/include/public/io/ring.h
++++ b/xen/include/public/io/ring.h
+@@ -212,6 +212,20 @@ typedef struct __name##_back_ring __name##_back_ring_t
+ #define RING_GET_REQUEST(_r, _idx)                                      \
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].req))
+ 
++/*
++ * Get a local copy of a request.
++ *
++ * Use this in preference to RING_GET_REQUEST() so all processing is
++ * done on a local copy that cannot be modified by the other end.
++ *
++ * Note that https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58145 may cause this
++ * to be ineffective where _req is a struct which consists of only bitfields.
++ */
++#define RING_COPY_REQUEST(_r, _idx, _req) do {				\
++	/* Use volatile to force the copy into _req. */			\
++	*(_req) = *(volatile typeof(_req))RING_GET_REQUEST(_r, _idx);	\
++} while (0)
++
+ #define RING_GET_RESPONSE(_r, _idx)                                     \
+     (&((_r)->sring->ring[((_idx) & (RING_SIZE(_r) - 1))].rsp))
+ 
+-- 
+2.1.0
+

--- a/recipes-extended/xen/files/xsa-155-xen-0002-blktap2-Use-RING_COPY_REQUEST.patch
+++ b/recipes-extended/xen/files/xsa-155-xen-0002-blktap2-Use-RING_COPY_REQUEST.patch
@@ -1,0 +1,72 @@
+From 851ffb4eea917e2708c912291dea4d133026c0ac Mon Sep 17 00:00:00 2001
+From: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+Date: Fri, 20 Nov 2015 12:16:02 -0500
+Subject: [PATCH 2/3] blktap2: Use RING_COPY_REQUEST
+
+Instead of RING_GET_REQUEST. Using a local copy of the
+ring (and also with proper memory barriers) will mean
+we can do not have to worry about the compiler optimizing
+the code and doing a double-fetch in the shared memory space.
+
+This is part of XSA155.
+
+Signed-off-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+
+---
+v2: Fix compile issues with tapdisk-vbd
+---
+ tools/blktap2/drivers/block-log.c   | 3 ++-
+ tools/blktap2/drivers/tapdisk-vbd.c | 8 ++++----
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+Index: xen-4.6.5/tools/blktap2/drivers/block-log.c
+===================================================================
+--- xen-4.6.5.orig/tools/blktap2/drivers/block-log.c
++++ xen-4.6.5/tools/blktap2/drivers/block-log.c
+@@ -494,11 +494,12 @@ static int ctl_kick(struct tdlog_state*
+   reqstart = s->bring.req_cons;
+   reqend = s->sring->req_prod;
+ 
++  xen_mb();
+   BDPRINTF("ctl: ring kicked (start = %u, end = %u)", reqstart, reqend);
+ 
+   while (reqstart != reqend) {
+     /* XXX actually submit these! */
+-    memcpy(&req, RING_GET_REQUEST(&s->bring, reqstart), sizeof(req));
++    RING_COPY_REQUEST(&s->bring, reqstart, &req);
+     BDPRINTF("ctl: read request %"PRIu64":%u", req.sector, req.count);
+     s->bring.req_cons = ++reqstart;
+ 
+Index: xen-4.6.5/tools/blktap2/drivers/tapdisk-vbd.c
+===================================================================
+--- xen-4.6.5.orig/tools/blktap2/drivers/tapdisk-vbd.c
++++ xen-4.6.5/tools/blktap2/drivers/tapdisk-vbd.c
+@@ -1586,7 +1586,7 @@ tapdisk_vbd_pull_ring_requests(td_vbd_t
+ 	int idx;
+ 	RING_IDX rp, rc;
+ 	td_ring_t *ring;
+-	blkif_request_t *req;
++	blkif_request_t req;
+ 	td_vbd_request_t *vreq;
+ 
+ 	ring = &vbd->ring;
+@@ -1597,16 +1597,16 @@ tapdisk_vbd_pull_ring_requests(td_vbd_t
+ 	xen_rmb();
+ 
+ 	for (rc = ring->fe_ring.req_cons; rc != rp; rc++) {
+-		req = RING_GET_REQUEST(&ring->fe_ring, rc);
++		RING_COPY_REQUEST(&ring->fe_ring, rc, &req);
+ 		++ring->fe_ring.req_cons;
+ 
+-		idx  = req->id;
++		idx  = req.id;
+ 		vreq = &vbd->request_list[idx];
+ 
+ 		ASSERT(list_empty(&vreq->next));
+ 		ASSERT(vreq->secs_pending == 0);
+ 
+-		memcpy(&vreq->req, req, sizeof(blkif_request_t));
++		memcpy(&vreq->req, &req, sizeof(blkif_request_t));
+ 		vbd->received++;
+ 		vreq->vbd = vbd;
+ 

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -79,6 +79,8 @@ SRC_URI_append = " \
     file://libxl-vwif-support.patch \
     file://libxl-atapi-pt.patch \
     file://libxl-iso-hotswap.patch \
+    file://xsa-155-xen-0001-xen-Add-RING_COPY_REQUEST.patch \
+    file://xsa-155-xen-0002-blktap2-Use-RING_COPY_REQUEST.patch \
     file://xsa-212-x86-broken-check-in-memory_exchange.patch \
     file://xsa-213-x86-64bit-PV-guest-breakout-via-pagetable-use-after-mode-change.patch \
     file://xsa-214-grant-transfer-allows-pv-guest-to-elevate-privileges.patch \


### PR DESCRIPTION
http://xenbits.xen.org/xsa/advisory-155.html
While the rest of the XSA is upstream or patched in the kernel
(patches from QSB-23), the blktap part is missing in 4.6.5 upstream and
the OpenXT patch-queue.