### PR TITLE
Silence warnings during installation.

### DIFF
--- a/recipes-connectivity/openssh/files/sshd_config
+++ b/recipes-connectivity/openssh/files/sshd_config
@@ -95,7 +95,6 @@ UsePAM yes
 #PrintLastLog yes
 #TCPKeepAlive yes
 #UseLogin no
-UsePrivilegeSeparation yes
 #PermitUserEnvironment no
 Compression no
 ClientAliveInterval 15

--- a/recipes-connectivity/openssh/files/sshd_config_v4v
+++ b/recipes-connectivity/openssh/files/sshd_config_v4v
@@ -95,7 +95,6 @@ UsePAM yes
 #PrintLastLog yes
 #TCPKeepAlive yes
 #UseLogin no
-UsePrivilegeSeparation yes
 #PermitUserEnvironment no
 Compression no
 ClientAliveInterval 15

--- a/recipes-extended/xen/files/xl.conf
+++ b/recipes-extended/xen/files/xl.conf
@@ -1,0 +1,2 @@
+## Global XL config file ##
+# see xl.conf(5) for details.

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -39,6 +39,7 @@ DEPENDS += " \
     "
 SRC_URI_append = " \
     file://xen-init-dom0.initscript \
+    file://xl.conf \
     "
 
 PACKAGES = " \
@@ -56,6 +57,9 @@ FILES_${PN}-staticdev = " \
     ${libdir}/libxlutil.a \
     ${libdir}/libxenlight.a \
     "
+FILES_xen-libxlutil += " \
+    ${sysconfdir}/xen/xl.conf \
+"
 
 EXTRA_OEMAKE += "CROSS_SYS_ROOT=${STAGING_DIR_HOST} CROSS_COMPILE=${HOST_PREFIX}"
 EXTRA_OEMAKE += "CONFIG_IOEMU=n"


### PR DESCRIPTION
- ```xen-dom0-init```, run at startup, will log a warning if xl.conf is not present (xl binary seems to as well), so ship a default one.
- ```sshd``` configuration currently used contains deprecated options.