### PR TITLE
STABLE-7: OXT-1107: Add lvmetad to dom0 & installer

### DIFF
--- a/recipes-core/images/xenclient-dom0-image.bb
+++ b/recipes-core/images/xenclient-dom0-image.bb
@@ -128,7 +128,19 @@ activate_xenstored_initscript() {
     update-rc.d -r ${IMAGE_ROOTFS} xenstored defaults 05
 }
 
-ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; remove_initscripts; activate_xenstored_initscript; process_tmp_stubdomain_items; "
+# packagegroup-xenclient-dom0 provides lvm2, so have lvmetad running as lvm2
+# utilities try to use it and warn in its absence.
+activate_lvmetad_initscript() {
+    update-rc.d -r ${IMAGE_ROOTFS} lvm2-lvmetad defaults 06
+}
+
+ROOTFS_POSTPROCESS_COMMAND += " \
+    post_rootfs_shell_commands; \
+    remove_initscripts; \
+    activate_xenstored_initscript; \
+    activate_lvmetad_initscript; \
+    process_tmp_stubdomain_items; \
+"
 
 inherit openxt-selinux-image
 #inherit validate-package-versions

--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -92,7 +92,16 @@ post_rootfs_shell_commands() {
 	touch ${IMAGE_ROOTFS}/etc/xenclient-host-installer;
 }
 
-ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; "
+# packagegroup-xenclient-dom0 provides lvm2, so have lvmetad running as lvm2
+# utilities try to use it and warn in its absence.
+activate_lvmetad_initscript() {
+    update-rc.d -r ${IMAGE_ROOTFS} lvm2-lvmetad defaults 06
+}
+
+ROOTFS_POSTPROCESS_COMMAND += " \
+    activate_lvmetad_initscript; \
+    post_rootfs_shell_commands; \
+"
 
 do_post_rootfs_items() {
 	install -d ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}/netboot

--- a/recipes-core/images/xenclient-installer-part2-image.bb
+++ b/recipes-core/images/xenclient-installer-part2-image.bb
@@ -32,7 +32,9 @@ post_rootfs_shell_commands() {
 	mv -f ${IMAGE_ROOTFS}/run.installer ${IMAGE_ROOTFS}/run;
 }
 
-ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; "
+ROOTFS_POSTPROCESS_COMMAND += " \
+    post_rootfs_shell_commands; \
+"
 
 LICENSE = "GPLv2 & MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6      \

--- a/recipes-kernel/linux/4.9/defconfigs/xenclient-dom0/defconfig
+++ b/recipes-kernel/linux/4.9/defconfigs/xenclient-dom0/defconfig
@@ -1241,7 +1241,8 @@ CONFIG_DM_CRYPT=y
 # CONFIG_DM_THIN_PROVISIONING is not set
 # CONFIG_DM_CACHE is not set
 # CONFIG_DM_ERA is not set
-# CONFIG_DM_MIRROR is not set
+CONFIG_DM_MIRROR=m
+# CONFIG_DM_LOG_USERSPACE is not set
 # CONFIG_DM_RAID is not set
 # CONFIG_DM_ZERO is not set
 # CONFIG_DM_MULTIPATH is not set

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/lvmetad-add-rules.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/lvmetad-add-rules.patch
@@ -1,0 +1,27 @@
+Index: refpolicy/policy/modules/system/lvm.fc
+===================================================================
+--- refpolicy.orig/policy/modules/system/lvm.fc
++++ refpolicy/policy/modules/system/lvm.fc
+@@ -57,6 +57,7 @@ ifdef(`distro_gentoo',`
+ /sbin/lvdisplay		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvextend		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvm		--	gen_context(system_u:object_r:lvm_exec_t,s0)
++/sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvm\.static	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvmchange		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvmdiskscan	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+@@ -106,6 +107,7 @@ ifdef(`distro_gentoo',`
+ /usr/sbin/clvmd		--	gen_context(system_u:object_r:clvmd_exec_t,s0)
+ /usr/sbin/cryptsetup	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvm		--	gen_context(system_u:object_r:lvm_exec_t,s0)
++/usr/sbin/lvmetad	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ 
+ #
+ # /var
+@@ -116,3 +118,6 @@ ifdef(`distro_gentoo',`
+ /var/lock/lvm(/.*)?		gen_context(system_u:object_r:lvm_lock_t,s0)
+ /var/run/multipathd\.sock -s	gen_context(system_u:object_r:lvm_var_run_t,s0)
+ /var/run/dmevent.*		gen_context(system_u:object_r:lvm_var_run_t,s0)
++/var/run/lvm(/.*)?		gen_context(system_u:object_r:lvm_var_run_t,s0)
++/run/lvm(/.*)?			gen_context(system_u:object_r:lvm_var_run_t,s0)
++

--- a/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.20141203.bbappend
@@ -179,8 +179,9 @@ SRC_URI += " \
     file://patches/openxt-init-spec-domtrans.patch;patch=1 \
     file://patches/busybox-mmap-read-execute-checks-from-new-domain.patch \
     file://patches/tpm2util.patch;patch=1 \
+    file://patches/lvmetad-add-rules.patch \
     "
-    
+
 def get_poltype(f):
     import re
     config = open (f, "r")

--- a/recipes-support/lvm2/lvm2/yocto-initscripts.patch
+++ b/recipes-support/lvm2/lvm2/yocto-initscripts.patch
@@ -1,0 +1,322 @@
+Index: LVM2.2.02.125/scripts/Makefile.in
+===================================================================
+--- LVM2.2.02.125.orig/scripts/Makefile.in
++++ LVM2.2.02.125/scripts/Makefile.in
+@@ -88,6 +88,19 @@ ifeq ("@BLKDEACTIVATE@", "yes")
+ 	$(INSTALL_SCRIPT) blk_availability_init_red_hat $(initdir)/blk-availability
+ endif
+ 
++# FIXME Some are not ported yet.
++install_initscripts_yocto:
++	$(INSTALL_DIR) $(initdir)
++ifeq ("@BUILD_DMEVENTD@", "yes")
++	$(INSTALL_SCRIPT) lvm2_monitoring_init_yocto $(initdir)/lvm2-monitor
++endif
++ifeq ("@BUILD_LVMETAD@", "yes")
++	$(INSTALL_SCRIPT) lvm2_lvmetad_init_yocto $(initdir)/lvm2-lvmetad
++endif
++ifeq ("@BUILD_LVMPOLLD@", "yes")
++	$(INSTALL_SCRIPT) lvm2_lvmpolld_init_yocto $(initdir)/lvm2-lvmpolld
++endif
++
+ CFLAGS_lvm2_activation_generator_systemd_red_hat.o += $(EXTRA_EXEC_CFLAGS)
+ 
+ lvm2_activation_generator_systemd_red_hat: $(OBJECTS) $(DEPLIBS)
+Index: LVM2.2.02.125/scripts/lvm2_lvmetad_init_yocto.in
+===================================================================
+--- /dev/null
++++ LVM2.2.02.125/scripts/lvm2_lvmetad_init_yocto.in
+@@ -0,0 +1,81 @@
++#!/bin/bash
++#
++# Copyright (C) 2017 Assured Information Security, Inc. All rights reserved.
++#
++# This copyrighted material is made available to anyone wishing to use,
++# modify, copy, or redistribute it subject to the terms and conditions
++# of the GNU General Public License v.2.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program; if not, write to the Free Software Foundation,
++# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
++#
++# This file is part of LVM2.
++# It is required for the proper handling of failures of LVM2 mirror
++# devices that were created using the -m option of lvcreate.
++# chkconfig: 12345 02 99
++# description: Starts and stops LVM metadata daemon
++#
++### BEGIN INIT INFO
++# Provides: lvm2-lvmetad
++# Required-Start: $local_fs
++# Required-Stop: $local_fs
++# Default-Start: 1 2 3 4 5
++# Default-Stop: 0 6
++# Short-Description: A daemon that maintains LVM metadata state for improved
++#                    performance by avoiding further scans while running
++#                    subsequent LVM commands or while using lvm2app library.
++### END INIT INFO
++
++. /etc/init.d/functions
++
++DAEMON=lvmetad
++PID_FILE="@LVMETAD_PIDFILE@"
++
++usage()
++{
++    echo "Usage: /etc/init.d/lvm2-lvmetad {start|stop|status}"
++}
++
++do_status()
++{
++    if start-stop-daemon -K --test --quiet --pidfile $PID_FILE ; then
++        pid=`cat $PID_FILE`
++        echo "$DAEMON (pid $pid) is running."
++    elif [ -e "$PID_FILE" ]; then
++        pid=`cat $PID_FILE`
++        echo "$DAEMON died (pid was $pid)."
++    else
++        echo "$DAEMON is stopped."
++    fi
++}
++
++if [ $# != 1 ]; then
++    usage
++    exit 1
++fi
++
++rc=0
++case "$1" in
++   start)
++        mkdir -p /run/lvm
++        start-stop-daemon -S --oknodo --pidfile $PID_FILE --exec $DAEMON
++        rc=$?
++        ;;
++    stop|force-stop)
++        start-stop-daemon -K --oknodo --pidfile $PID_FILE
++        rm -f $PID_FILE
++        ;;
++    status)
++        do_status
++        exit 0
++        ;;
++    *)
++        usage
++        exit 1
++        ;;
++esac
++
++do_status
++
++exit $rc
+Index: LVM2.2.02.125/scripts/lvm2_lvmpolld_init_yocto.in
+===================================================================
+--- /dev/null
++++ LVM2.2.02.125/scripts/lvm2_lvmpolld_init_yocto.in
+@@ -0,0 +1,84 @@
++#!/bin/bash
++#
++# Copyright (C) 2017 Assured Information Security, Inc. All rights reserved.
++#
++# This copyrighted material is made available to anyone wishing to use,
++# modify, copy, or redistribute it subject to the terms and conditions
++# of the GNU General Public License v.2.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program; if not, write to the Free Software Foundation,
++# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
++#
++# This file is part of LVM2.
++# It is required for the proper handling of failures of LVM2 mirror
++# devices that were created using the -m option of lvcreate.
++#
++#
++# chkconfig: 12345 02 99
++# description: Starts and stops LVM poll daemon
++#
++### BEGIN INIT INFO
++# Provides: lvm2-lvmpolld
++# Required-Start: $local_fs
++# Required-Stop: $local_fs
++# Default-Start: 1 2 3 4 5
++# Default-Stop: 0 6
++# Short-Description: A daemon that is responsible for monitoring in-progress
++#		     and possibly longer term operations on logical volumes.
++#		     It helps to reduce the number of spawned processes if same
++#                    logical volume is requested to get monitored multiple times.
++#                    Also avoids unsolicited termination due to external factors.
++### END INIT INFO
++
++. /etc/init.d/functions
++
++DAEMON=lvmpolld
++PID_FILE="@LVMPOLLD_PIDFILE@"
++
++usage()
++{
++    echo "Usage: /etc/init.d/lvm2-lvmpolld {start|stop|status}"
++}
++
++do_status()
++{
++    if start-stop-daemon -K --test --quiet --pidfile $PID_FILE ; then
++        pid=`cat $PID_FILE`
++        echo "$DAEMON (pid $pid) is running."
++    elif [ -e "$PID_FILE" ]; then
++        pid=`cat $PID_FILE`
++        echo "$DAEMON died (pid was $pid)."
++    else
++        echo "$DAEMON is stopped."
++    fi
++}
++
++if [ $# != 1 ]; then
++    usage
++    exit 1
++fi
++
++rc=0
++case "$1" in
++    start)
++        start-stop-daemon -S --oknodo --pidfile $PID_FILE --exec $DAEMON
++        rc=$?
++        ;;
++    stop|force-stop)
++        start-stop-daemon -K --oknodo --pidfile $PID_FILE
++        rm -f $PID_FILE
++        ;;
++    status)
++        do_status
++        exit 0
++        ;;
++    *)
++        usage
++        exit 1
++        ;;
++esac
++
++do_status
++
++exit $rc
+Index: LVM2.2.02.125/scripts/lvm2_monitoring_init_yocto.in
+===================================================================
+--- /dev/null
++++ LVM2.2.02.125/scripts/lvm2_monitoring_init_yocto.in
+@@ -0,0 +1,82 @@
++#!/bin/bash
++#
++# Copyright (C) 2017 Assured Information Security, Inc. All rights reserved.
++#
++# This copyrighted material is made available to anyone wishing to use,
++# modify, copy, or redistribute it subject to the terms and conditions
++# of the GNU General Public License v.2.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program; if not, write to the Free Software Foundation,
++# Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
++#
++# This file is part of LVM2.
++# It is required for the proper handling of failures of LVM2 mirror
++# devices that were created using the -m option of lvcreate.
++#
++#
++# chkconfig: 12345 02 99
++# description: Starts and stops dmeventd monitoring for lvm2
++#
++### BEGIN INIT INFO
++# Provides: lvm2-monitor
++# Required-Start: $local_fs
++# Required-Stop: $local_fs
++# Default-Start: 1 2 3 4 5
++# Default-Stop: 0 6
++# Short-Description: A daemon to monitor device mapper events. Library plugins
++#                    can register and carry out actions triggered when
++#                    particular events occur.
++### END INIT INFO
++
++. /etc/init.d/functions
++
++DAEMON=dmeventd
++PID_FILE="@DMEVENTD_PIDFILE@"
++
++usage()
++{
++    echo "Usage: /etc/init.d/lvm2-monitor {start|stop|status}"
++}
++
++do_status()
++{
++    if start-stop-daemon -K --test --quiet --pidfile $PID_FILE ; then
++        pid=`cat $PID_FILE`
++        echo "$DAEMON (pid $pid) is running."
++    elif [ -e "$PID_FILE" ]; then
++        pid=`cat $PID_FILE`
++        echo "$DAEMON died (pid was $pid)."
++    else
++        echo "$DAEMON is stopped."
++    fi
++}
++
++if [ $# != 1 ]; then
++    usage
++    exit 1
++fi
++
++rc=0
++case "$1" in
++    start)
++        start-stop-daemon -S --oknodo --pidfile $PID_FILE --exec $DAEMON
++        rc=$?
++        ;;
++    stop|force-stop)
++        start-stop-daemon -K --oknodo --pidfile $PID_FILE
++        rm -f $PID_FILE
++        ;;
++    status)
++        do_status
++        exit 0
++        ;;
++    *)
++        usage
++        exit 1
++        ;;
++esac
++
++do_status
++
++exit $rc
+Index: LVM2.2.02.125/Makefile.in
+===================================================================
+--- LVM2.2.02.125.orig/Makefile.in
++++ LVM2.2.02.125/Makefile.in
+@@ -143,6 +143,9 @@ install_system_dirs:
+ install_initscripts: 
+ 	$(MAKE) -C scripts install_initscripts
+ 
++install_initscripts_yocto:
++	$(MAKE) -C scripts install_initscripts_yocto
++
+ install_systemd_generators:
+ 	$(MAKE) -C scripts install_systemd_generators
+ 	$(MAKE) -C man install_systemd_generators
+Index: LVM2.2.02.125/configure.in
+===================================================================
+--- LVM2.2.02.125.orig/configure.in
++++ LVM2.2.02.125/configure.in
+@@ -2067,14 +2067,17 @@ scripts/lvm2_cluster_activation_systemd_
+ scripts/lvm2_clvmd_systemd_red_hat.service
+ scripts/lvm2_cmirrord_systemd_red_hat.service
+ scripts/lvm2_lvmetad_init_red_hat
++scripts/lvm2_lvmetad_init_yocto
+ scripts/lvm2_lvmetad_systemd_red_hat.service
+ scripts/lvm2_lvmetad_systemd_red_hat.socket
+ scripts/lvm2_lvmpolld_init_red_hat
++scripts/lvm2_lvmpolld_init_yocto
+ scripts/lvm2_lvmpolld_systemd_red_hat.service
+ scripts/lvm2_lvmpolld_systemd_red_hat.socket
+ scripts/lvm2_lvmlockd_systemd_red_hat.service
+ scripts/lvm2_lvmlocking_systemd_red_hat.service
+ scripts/lvm2_monitoring_init_red_hat
++scripts/lvm2_monitoring_init_yocto
+ scripts/lvm2_monitoring_systemd_red_hat.service
+ scripts/lvm2_pvscan_systemd_red_hat@.service
+ scripts/lvm2_tmpfiles_red_hat.conf

--- a/recipes-support/lvm2/lvm2_%.bbappend
+++ b/recipes-support/lvm2/lvm2_%.bbappend
@@ -24,3 +24,11 @@ do_install() {
         rm -rf ${D}${sysconfdir}/rc.d
     fi
 }
+
+pkg_postinst_${PN}_append () {
+#! /bin/sh
+install -d /config/etc/lvm
+
+RESTORECON="/sbin/restorecon"
+[ -x "${RESTORECON}" ] && ${RESTORECON} -R -F /config/etc/lvm
+}

--- a/recipes-support/lvm2/lvm2_%.bbappend
+++ b/recipes-support/lvm2/lvm2_%.bbappend
@@ -2,6 +2,25 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += " \
     file://0004-tweak-MODPROBE_CMD-for-cross-compile.patch \
+    file://yocto-initscripts.patch \
 "
 
 CACHED_CONFIGUREVARS += "MODPROBE_CMD=${base_sbindir}/modprobe"
+
+do_install() {
+    autotools_do_install
+
+    # Install machine specific configuration file
+    install -m 0644 ${WORKDIR}/lvm.conf ${D}${sysconfdir}/lvm/lvm.conf
+    sed -i -e 's:@libdir@:${libdir}:g' ${D}${sysconfdir}/lvm/lvm.conf
+    if ${@base_contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        oe_runmake 'DESTDIR=${D}' install install_systemd_units
+        sed -i -e 's:/usr/bin/true:${base_bindir}/true:g' ${D}${systemd_system_unitdir}/blk-availability.service
+    else
+        # Use Yocto compatible initscripts instead of the RHEL ones provided by
+        # the tarball.
+        oe_runmake 'DESTDIR=${D}' install install_initscripts_yocto
+        mv ${D}${sysconfdir}/rc.d/init.d ${D}${sysconfdir}/init.d
+        rm -rf ${D}${sysconfdir}/rc.d
+    fi
+}


### PR DESCRIPTION
- Add initscripts compatible with the dom0 fs (and busybox binaries in general) for lvm2 lvmetad, dmeventd and dmpolld.
- Run lvmetad at std runlevel in dom0 and the installer to silence lvm2 utils warnings.
- Add dm-mirror to be able to pvmove during installation.