### PR TITLE
STABLE-7: lvm2: Amend initscript install.

### DIFF
--- a/recipes-support/lvm2/lvm2_%.bbappend
+++ b/recipes-support/lvm2/lvm2_%.bbappend
@@ -20,8 +20,6 @@ do_install() {
         # Use Yocto compatible initscripts instead of the RHEL ones provided by
         # the tarball.
         oe_runmake 'DESTDIR=${D}' install install_initscripts_yocto
-        mv ${D}${sysconfdir}/rc.d/init.d ${D}${sysconfdir}/init.d
-        rm -rf ${D}${sysconfdir}/rc.d
     fi
 }
 


### PR DESCRIPTION
do_install() was creating a spurious /etc/init.d/init.d directory.

Original PR: https://github.com/OpenXT/xenclient-oe/pull/686