### PR TITLE
OXT-1152: xsa: 216,217,218,219,220,221,222,224

### DIFF
--- a/recipes-extended/xen/files/xsa217.patch
+++ b/recipes-extended/xen/files/xsa217.patch
@@ -1,0 +1,43 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86/mm: disallow page stealing from HVM domains
+
+The operation's success can't be controlled by the guest, as the device
+model may have an active mapping of the page. If we nevertheless
+permitted this operation, we'd have to add further TLB flushing to
+prevent scenarios like
+
+"Domains A (HVM), B (PV), C (PV); B->target==A
+ Steps:
+ 1. B maps page X from A as writable
+ 2. B unmaps page X without a TLB flush
+ 3. A sends page X to C via GNTTABOP_transfer
+ 4. C maps page X as pagetable (potentially causing a TLB flush in C,
+ but not in B)
+
+ At this point, X would be mapped as a pagetable in C while being
+ writable through a stale TLB entry in B."
+
+A similar scenario could be constructed for A using XENMEM_exchange and
+some arbitrary PV domain C then having this page allocated.
+
+This is XSA-217.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: George Dunlap <george.dunlap@citrix.com>
+Reviewed-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+
+Index: xen-4.6.5/xen/arch/x86/mm.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/mm.c
++++ xen-4.6.5/xen/arch/x86/mm.c
+@@ -4311,6 +4311,9 @@ int steal_page(
+     bool_t drop_dom_ref = 0;
+     const struct domain *owner = dom_xen;
+ 
++    if ( paging_mode_external(d) )
++        return -1;
++
+     spin_lock(&d->page_alloc_lock);
+ 
+     if ( is_xen_heap_page(page) || ((owner = page_get_owner(page)) != d) )

--- a/recipes-extended/xen/files/xsa218-4.6/0001-IOMMU-handle-IOMMU-mapping-and-unmapping-failures.patch
+++ b/recipes-extended/xen/files/xsa218-4.6/0001-IOMMU-handle-IOMMU-mapping-and-unmapping-failures.patch
@@ -1,0 +1,75 @@
+From d5f169f853cc6ae4295565e3c4765a270278c5c0 Mon Sep 17 00:00:00 2001
+From: Quan Xu <quan.xu@intel.com>
+Date: Fri, 2 Jun 2017 12:30:34 +0100
+Subject: [PATCH 1/4] IOMMU: handle IOMMU mapping and unmapping failures
+
+Treat IOMMU mapping and unmapping failures as a fatal to the DomU
+If IOMMU mapping and unmapping failed, crash the DomU and propagate
+the error up to the call trees.
+
+No spamming of the log can occur. For DomU, we avoid logging any
+message for already dying domains. For Dom0, that'll still be more
+verbose than we'd really like, but it at least wouldn't outright
+flood the console.
+
+Signed-off-by: Quan Xu <quan.xu@intel.com>
+Reviewed-by: Kevin Tian <kevin.tian@intel.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/drivers/passthrough/iommu.c | 30 ++++++++++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)
+
+Index: xen-4.6.5/xen/drivers/passthrough/iommu.c
+===================================================================
+--- xen-4.6.5.orig/xen/drivers/passthrough/iommu.c
++++ xen-4.6.5/xen/drivers/passthrough/iommu.c
+@@ -228,21 +228,47 @@ int iommu_map_page(struct domain *d, uns
+                    unsigned int flags)
+ {
+     const struct domain_iommu *hd = dom_iommu(d);
++    int rc;
+ 
+     if ( !iommu_enabled || !hd->platform_ops )
+         return 0;
+ 
+-    return hd->platform_ops->map_page(d, gfn, mfn, flags);
++    rc = hd->platform_ops->map_page(d, gfn, mfn, flags);
++    if ( unlikely(rc) )
++    {
++        if ( !d->is_shutting_down && printk_ratelimit() )
++            printk(XENLOG_ERR
++                   "d%d: IOMMU mapping gfn %#lx to mfn %#lx failed: %d\n",
++                   d->domain_id, gfn, mfn, rc);
++
++        if ( !is_hardware_domain(d) )
++            domain_crash(d);
++    }
++
++    return rc;
+ }
+ 
+ int iommu_unmap_page(struct domain *d, unsigned long gfn)
+ {
+     const struct domain_iommu *hd = dom_iommu(d);
++    int rc;
+ 
+     if ( !iommu_enabled || !hd->platform_ops )
+         return 0;
+ 
+-    return hd->platform_ops->unmap_page(d, gfn);
++    rc = hd->platform_ops->unmap_page(d, gfn);
++    if ( unlikely(rc) )
++    {
++        if ( !d->is_shutting_down && printk_ratelimit() )
++            printk(XENLOG_ERR
++                   "d%d: IOMMU unmapping gfn %#lx failed: %d\n",
++                   d->domain_id, gfn, rc);
++
++        if ( !is_hardware_domain(d) )
++            domain_crash(d);
++    }
++
++    return rc;
+ }
+ 
+ static void iommu_free_pagetables(unsigned long unused)

--- a/recipes-extended/xen/files/xsa218-4.6/0002-gnttab-fix-unmap-pin-accounting-race.patch
+++ b/recipes-extended/xen/files/xsa218-4.6/0002-gnttab-fix-unmap-pin-accounting-race.patch
@@ -1,0 +1,99 @@
+From 951da330060745d7c5ffe3628ca78be34d0b325b Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 2 Jun 2017 12:22:42 +0100
+Subject: [PATCH 2/4] gnttab: fix unmap pin accounting race
+
+Once all {writable} mappings of a grant entry have been unmapped, the
+hypervisor informs the guest that the grant entry has been released by
+clearing the _GTF_{reading,writing} usage flags in the guest's grant
+table as appropriate.
+
+Unfortunately, at the moment, the code that updates the accounting
+happens in a different critical section than the one which updates the
+usage flags; this means that under the right circumstances, there may be
+a window in time after the hypervisor reported the grant as being free
+during which the grant referee still had access to the page.
+
+Move the grant accounting code into the same critical section as the
+reporting code to make sure this kind of race can't happen.
+
+This is part of XSA-218.
+
+Reported-by: Jann Horn <jannh.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/grant_table.c | 32 +++++++++++++++++---------------
+ 1 file changed, 17 insertions(+), 15 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -1137,15 +1137,8 @@ __gnttab_unmap_common(
+             PIN_FAIL(act_release_out, GNTST_general_error,
+                      "Bad frame number doesn't match gntref. (%lx != %lx)\n",
+                      op->frame, act->frame);
+-        if ( op->flags & GNTMAP_device_map )
+-        {
+-            ASSERT(act->pin & (GNTPIN_devw_mask | GNTPIN_devr_mask));
+-            op->map->flags &= ~GNTMAP_device_map;
+-            if ( op->flags & GNTMAP_readonly )
+-                act->pin -= GNTPIN_devr_inc;
+-            else
+-                act->pin -= GNTPIN_devw_inc;
+-        }
++
++        op->map->flags &= ~GNTMAP_device_map;
+     }
+ 
+     if ( (op->host_addr != 0) && (op->flags & GNTMAP_host_map) )
+@@ -1155,12 +1148,7 @@ __gnttab_unmap_common(
+                                               op->flags)) < 0 )
+             goto act_release_out;
+ 
+-        ASSERT(act->pin & (GNTPIN_hstw_mask | GNTPIN_hstr_mask));
+         op->map->flags &= ~GNTMAP_host_map;
+-        if ( op->flags & GNTMAP_readonly )
+-            act->pin -= GNTPIN_hstr_inc;
+-        else
+-            act->pin -= GNTPIN_hstw_inc;
+     }
+ 
+  act_release_out:
+@@ -1253,6 +1241,12 @@ __gnttab_unmap_common_complete(struct gn
+             else
+                 put_page_and_type(pg);
+         }
++
++        ASSERT(act->pin & (GNTPIN_devw_mask | GNTPIN_devr_mask));
++        if ( op->flags & GNTMAP_readonly )
++            act->pin -= GNTPIN_devr_inc;
++        else
++            act->pin -= GNTPIN_devw_inc;
+     }
+ 
+     if ( (op->host_addr != 0) && (op->flags & GNTMAP_host_map) )
+@@ -1261,7 +1255,9 @@ __gnttab_unmap_common_complete(struct gn
+         {
+             /*
+              * Suggests that __gntab_unmap_common failed in
+-             * replace_grant_host_mapping() so nothing further to do
++             * replace_grant_host_mapping() or IOMMU handling, so nothing
++             * further to do (short of re-establishing the mapping in the
++             * latter case).
+              */
+             goto act_release_out;
+         }
+@@ -1272,6 +1268,12 @@ __gnttab_unmap_common_complete(struct gn
+                 put_page_type(pg);
+             put_page(pg);
+         }
++
++        ASSERT(act->pin & (GNTPIN_hstw_mask | GNTPIN_hstr_mask));
++        if ( op->flags & GNTMAP_readonly )
++            act->pin -= GNTPIN_hstr_inc;
++        else
++            act->pin -= GNTPIN_hstw_inc;
+     }
+ 
+     if ( (op->map->flags & (GNTMAP_device_map|GNTMAP_host_map)) == 0 )

--- a/recipes-extended/xen/files/xsa218-4.6/0003-gnttab-Avoid-potential-double-put-of-maptrack-entry.patch
+++ b/recipes-extended/xen/files/xsa218-4.6/0003-gnttab-Avoid-potential-double-put-of-maptrack-entry.patch
@@ -1,0 +1,229 @@
+From 12edc6f9a567808b1e1f8fb1bc8ef0d1611c756a Mon Sep 17 00:00:00 2001
+From: George Dunlap <george.dunlap@citrix.com>
+Date: Thu, 15 Jun 2017 12:05:14 +0100
+Subject: [PATCH 3/4] gnttab: Avoid potential double-put of maptrack entry
+
+Each grant mapping for a particular domain is tracked by an in-Xen
+"maptrack" entry.  This entry is is referenced by a "handle", which is
+given to the guest when it calls gnttab_map_grant_ref().
+
+There are two types of mapping a particular handle can refer to:
+GNTMAP_host_map and GNTMAP_device_map.  A given
+gnttab_unmap_grant_ref() call can remove either only one or both of
+these entries.  When a particular handle has no entries left, it must
+be freed.
+
+gnttab_unmap_grant_ref() loops through its grant unmap request list
+twice.  It first removes entries from any host pagetables and (if
+appropraite) iommus; then it does a single domain TLB flush; then it
+does the clean-up, including telling the granter that entries are no
+longer being used (if appropriate).
+
+At the moment, it's during the first pass that the maptrack flags are
+cleared, but the second pass that the maptrack entry is freed.
+
+Unfortunately this allows the following race, which results in a
+double-free:
+
+ A: (pass 1) clear host_map
+ B: (pass 1) clear device_map
+ A: (pass 2) See that maptrack entry has no mappings, free it
+ B: (pass 2) See that maptrack entry has no mappings, free it #
+
+Unfortunately, unlike the active entry pinning update, we can't simply
+move the maptrack flag changes to the second half, because the
+maptrack flags are used to determine if iommu entries need to be
+added: a domain's iommu must never have fewer permissions than the
+maptrack flags indicate, or a subsequent map_grant_ref() might fail to
+add the necessary iommu entries.
+
+Instead, free the maptrack entry in the first pass if there are no
+further mappings.
+
+This is part of XSA-218.
+
+Reported-by: Jan Beulich <jbeulich.com>
+Signed-off-by: George Dunlap <george.dunlap@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/grant_table.c | 79 +++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 54 insertions(+), 25 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -98,8 +98,8 @@ struct gnttab_unmap_common {
+     /* Shared state beteen *_unmap and *_unmap_complete */
+     u16 flags;
+     unsigned long frame;
+-    struct grant_mapping *map;
+     struct domain *rd;
++    grant_ref_t ref;
+ };
+ 
+ /* Number of unmap operations that are done between each tlb flush */
+@@ -1066,6 +1066,8 @@ __gnttab_unmap_common(
+     struct grant_table *lgt, *rgt;
+     struct active_grant_entry *act;
+     s16              rc = 0;
++    struct grant_mapping *map;
++    bool_t put_handle = 0;
+ 
+     ld = current->domain;
+     lgt = ld->grant_table;
+@@ -1079,11 +1081,11 @@ __gnttab_unmap_common(
+         return;
+     }
+ 
+-    op->map = &maptrack_entry(lgt, op->handle);
++    map = &maptrack_entry(lgt, op->handle);
+ 
+     read_lock(&lgt->lock);
+ 
+-    if ( unlikely(!read_atomic(&op->map->flags)) )
++    if ( unlikely(!read_atomic(&map->flags)) )
+     {
+         read_unlock(&lgt->lock);
+         gdprintk(XENLOG_INFO, "Zero flags for handle (%d).\n", op->handle);
+@@ -1091,7 +1093,7 @@ __gnttab_unmap_common(
+         return;
+     }
+ 
+-    dom = op->map->domid;
++    dom = map->domid;
+     read_unlock(&lgt->lock);
+ 
+     if ( unlikely((rd = rcu_lock_domain_by_id(dom)) == NULL) )
+@@ -1116,16 +1118,43 @@ __gnttab_unmap_common(
+ 
+     read_lock(&rgt->lock);
+ 
+-    op->flags = read_atomic(&op->map->flags);
+-    if ( unlikely(!op->flags) || unlikely(op->map->domid != dom) )
++    op->rd = rd;
++    op->ref = map->ref;
++
++    /*
++     * We can't assume there was no racing unmap for this maptrack entry,
++     * and hence we can't assume map->ref is valid for rd. While the checks
++     * below (with the active entry lock held) will reject any such racing
++     * requests, we still need to make sure we don't attempt to acquire an
++     * invalid lock.
++     */
++    smp_rmb();
++    if ( unlikely(op->ref >= nr_grant_entries(rgt)) )
+     {
+-        gdprintk(XENLOG_WARNING, "Unstable handle %u\n", op->handle);
++        gdprintk(XENLOG_WARNING, "Unstable handle %#x\n", op->handle);
+         rc = GNTST_bad_handle;
+-        goto unmap_out;
++        goto unlock_out;
+     }
+ 
+-    op->rd = rd;
+-    act = active_entry_acquire(rgt, op->map->ref);
++    act = active_entry_acquire(rgt, op->ref);
++
++    /*
++     * Note that we (ab)use the active entry lock here to protect against
++     * multiple unmaps of the same mapping here. We don't want to hold lgt's
++     * lock, and we only hold rgt's lock for reading (but the latter wouldn't
++     * be the right one anyway). Hence the easiest is to rely on a lock we
++     * hold anyway; see docs/misc/grant-tables.txt's "Locking" section.
++     */
++
++    op->flags = read_atomic(&map->flags);
++    smp_rmb();
++    if ( unlikely(!op->flags) || unlikely(map->domid != dom) ||
++         unlikely(map->ref != op->ref) )
++    {
++        gdprintk(XENLOG_WARNING, "Unstable handle %#x\n", op->handle);
++        rc = GNTST_bad_handle;
++        goto act_release_out;
++    }
+ 
+     if ( op->frame == 0 )
+     {
+@@ -1138,7 +1167,7 @@ __gnttab_unmap_common(
+                      "Bad frame number doesn't match gntref. (%lx != %lx)\n",
+                      op->frame, act->frame);
+ 
+-        op->map->flags &= ~GNTMAP_device_map;
++        map->flags &= ~GNTMAP_device_map;
+     }
+ 
+     if ( (op->host_addr != 0) && (op->flags & GNTMAP_host_map) )
+@@ -1148,14 +1177,23 @@ __gnttab_unmap_common(
+                                               op->flags)) < 0 )
+             goto act_release_out;
+ 
+-        op->map->flags &= ~GNTMAP_host_map;
++        map->flags &= ~GNTMAP_host_map;
++    }
++
++    if ( !(map->flags & (GNTMAP_device_map|GNTMAP_host_map)) )
++    {
++        map->flags = 0;
++        put_handle = 1;
+     }
+ 
+  act_release_out:
+     active_entry_release(act);
+- unmap_out:
++ unlock_out:
+     read_unlock(&rgt->lock);
+ 
++    if ( put_handle )
++        put_maptrack_handle(lgt, op->handle);
++
+     if ( rc == GNTST_okay && gnttab_need_iommu_mapping(ld) )
+     {
+         unsigned int kind;
+@@ -1192,7 +1230,6 @@ __gnttab_unmap_common_complete(struct gn
+     grant_entry_header_t *sha;
+     struct page_info *pg;
+     uint16_t *status;
+-    bool_t put_handle = 0;
+ 
+     if ( rd == NULL )
+     { 
+@@ -1213,13 +1250,13 @@ __gnttab_unmap_common_complete(struct gn
+     if ( rgt->gt_version == 0 )
+         goto unlock_out;
+ 
+-    act = active_entry_acquire(rgt, op->map->ref);
+-    sha = shared_entry_header(rgt, op->map->ref);
++    act = active_entry_acquire(rgt, op->ref);
++    sha = shared_entry_header(rgt, op->ref);
+ 
+     if ( rgt->gt_version == 1 )
+         status = &sha->flags;
+     else
+-        status = &status_entry(rgt, op->map->ref);
++        status = &status_entry(rgt, op->ref);
+ 
+     if ( unlikely(op->frame != act->frame) ) 
+     {
+@@ -1276,9 +1313,6 @@ __gnttab_unmap_common_complete(struct gn
+             act->pin -= GNTPIN_hstw_inc;
+     }
+ 
+-    if ( (op->map->flags & (GNTMAP_device_map|GNTMAP_host_map)) == 0 )
+-        put_handle = 1;
+-
+     if ( ((act->pin & (GNTPIN_devw_mask|GNTPIN_hstw_mask)) == 0) &&
+          !(op->flags & GNTMAP_readonly) )
+         gnttab_clear_flag(_GTF_writing, status);
+@@ -1291,11 +1325,6 @@ __gnttab_unmap_common_complete(struct gn
+  unlock_out:
+     read_unlock(&rgt->lock);
+ 
+-    if ( put_handle )
+-    {
+-        op->map->flags = 0;
+-        put_maptrack_handle(ld->grant_table, op->handle);
+-    }
+     rcu_unlock_domain(rd);
+ }
+ 

--- a/recipes-extended/xen/files/xsa218-4.6/0004-gnttab-correct-maptrack-table-accesses.patch
+++ b/recipes-extended/xen/files/xsa218-4.6/0004-gnttab-correct-maptrack-table-accesses.patch
@@ -1,0 +1,81 @@
+From 44b38e8fa323252238fa6a55111001389aff2412 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Thu, 15 Jun 2017 12:05:29 +0100
+Subject: [PATCH 4/4] gnttab: correct maptrack table accesses
+
+In order to observe a consistent (limit,pointer-table) pair, the reader
+needs to either hold the maptrack lock (in line with documentation) or
+both sides need to order their accesses suitably (the writer side
+barrier was removed by commit dff515dfea ["gnttab: use per-VCPU
+maptrack free lists"], and a read side barrier has never been there).
+
+Make the writer publish a new table page before limit (for bounds
+checks to work), and new list head last (for racing maptrack_entry()
+invocations to work). At the same time add read barriers to lockless
+readers.
+
+Additionally get_maptrack_handle() must not assume ->maptrack_head to
+not change behind its back: Another handle may be put (updating only
+->maptrack_tail) and then got or stolen (updating ->maptrack_head).
+
+This is part of XSA-218.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: George Dunlap <george.dunlap@citrix.com>
+---
+ xen/common/grant_table.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -387,7 +387,7 @@ get_maptrack_handle(
+     struct grant_table *lgt)
+ {
+     struct vcpu          *curr = current;
+-    int                   i;
++    unsigned int          i, head;
+     grant_handle_t        handle;
+     struct grant_mapping *new_mt;
+ 
+@@ -443,17 +443,20 @@ get_maptrack_handle(
+         new_mt[i].ref = handle + i + 1;
+         new_mt[i].vcpu = curr->vcpu_id;
+     }
+-    new_mt[i - 1].ref = curr->maptrack_head;
+ 
+     /* Set tail directly if this is the first page for this VCPU. */
+     if ( curr->maptrack_tail == MAPTRACK_TAIL )
+         curr->maptrack_tail = handle + MAPTRACK_PER_PAGE - 1;
+ 
+-    write_atomic(&curr->maptrack_head, handle + 1);
+-
+     lgt->maptrack[nr_maptrack_frames(lgt)] = new_mt;
++    smp_wmb();
+     lgt->maptrack_limit += MAPTRACK_PER_PAGE;
+ 
++    do {
++        new_mt[i - 1].ref = read_atomic(&curr->maptrack_head);
++        head = cmpxchg(&curr->maptrack_head, new_mt[i - 1].ref, handle + 1);
++    } while ( head != new_mt[i - 1].ref );
++
+     spin_unlock(&lgt->maptrack_lock);
+ 
+     return handle;
+@@ -713,6 +716,7 @@ static unsigned int mapkind(
+     for ( handle = 0; !(kind & MAPKIND_WRITE) &&
+                       handle < lgt->maptrack_limit; handle++ )
+     {
++        smp_rmb();
+         map = &maptrack_entry(lgt, handle);
+         if ( !(map->flags & (GNTMAP_device_map|GNTMAP_host_map)) ||
+              map->domid != rd->domain_id )
+@@ -1081,6 +1085,7 @@ __gnttab_unmap_common(
+         return;
+     }
+ 
++    smp_rmb();
+     map = &maptrack_entry(lgt, op->handle);
+ 
+     read_lock(&lgt->lock);

--- a/recipes-extended/xen/files/xsa219-4.6.patch
+++ b/recipes-extended/xen/files/xsa219-4.6.patch
@@ -1,0 +1,149 @@
+From 977e619dcd53bec72314188aeef25f032975135f Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 11 May 2017 14:47:00 +0100
+Subject: [PATCH] x86/shadow: Hold references for the duration of emulated
+ writes
+
+The (misnamed) emulate_gva_to_mfn() function translates a linear address to an
+mfn, but releases its page reference before returning the mfn to its caller.
+
+sh_emulate_map_dest() uses the results of one or two translations to construct
+a virtual mapping to the underlying frames, completes an emulated
+write/cmpxchg, then unmaps the virtual mappings.
+
+The page references need holding until the mappings are unmapped, or the
+frames can change ownership before the writes occurs.
+
+This is XSA-219
+
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Tim Deegan <tim@xen.org>
+---
+ xen/arch/x86/mm/shadow/multi.c | 56 +++++++++++++++++++++++++++++-------------
+ 1 file changed, 39 insertions(+), 17 deletions(-)
+
+Index: xen-4.6.5/xen/arch/x86/mm/shadow/multi.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/mm/shadow/multi.c
++++ xen-4.6.5/xen/arch/x86/mm/shadow/multi.c
+@@ -4586,7 +4586,10 @@ static void sh_pagetable_dying(struct vc
+ /**************************************************************************/
+ /* Handling HVM guest writes to pagetables  */
+ 
+-/* Translate a VA to an MFN, injecting a page-fault if we fail */
++/*
++ * Translate a VA to an MFN, injecting a page-fault if we fail.  If the
++ * mapping succeeds, a reference will be held on the underlying page.
++ */
+ #define BAD_GVA_TO_GFN (~0UL)
+ #define BAD_GFN_TO_MFN (~1UL)
+ #define READONLY_GFN   (~2UL)
+@@ -4635,14 +4638,15 @@ static mfn_t emulate_gva_to_mfn(struct v
+     ASSERT(mfn_valid(mfn));
+ 
+     v->arch.paging.last_write_was_pt = !!sh_mfn_is_a_page_table(mfn);
+-    /* Note shadow cannot page out or unshare this mfn, so the map won't
+-     * disappear. Otherwise, caller must hold onto page until done. */
+-    put_page(page);
++
+     return mfn;
+ }
+ 
+-/* Check that the user is allowed to perform this write.
+- * Returns a mapped pointer to write to, or NULL for error. */
++/*
++ * Check that the user is allowed to perform this write.  If a mapping is
++ * returned, page references will be held on sh_ctxt->mfn1 and
++ * sh_ctxt->mfn2 iff !INVALID_MFN.
++ */
+ #define MAPPING_UNHANDLEABLE ((void *)(unsigned long)X86EMUL_UNHANDLEABLE)
+ #define MAPPING_EXCEPTION    ((void *)(unsigned long)X86EMUL_EXCEPTION)
+ #define MAPPING_SILENT_FAIL  ((void *)(unsigned long)X86EMUL_OKAY)
+@@ -4655,13 +4659,6 @@ static void *emulate_map_dest(struct vcp
+     struct domain *d = v->domain;
+     void *map = NULL;
+ 
+-    sh_ctxt->mfn1 = emulate_gva_to_mfn(v, vaddr, sh_ctxt);
+-    if ( !mfn_valid(sh_ctxt->mfn1) )
+-        return ((mfn_x(sh_ctxt->mfn1) == BAD_GVA_TO_GFN) ?
+-                MAPPING_EXCEPTION :
+-                (mfn_x(sh_ctxt->mfn1) == READONLY_GFN) ?
+-                MAPPING_SILENT_FAIL : MAPPING_UNHANDLEABLE);
+-
+ #ifndef NDEBUG
+     /* We don't emulate user-mode writes to page tables */
+     if ( hvm_get_seg_reg(x86_seg_ss, sh_ctxt)->attr.fields.dpl == 3 )
+@@ -4672,6 +4669,17 @@ static void *emulate_map_dest(struct vcp
+     }
+ #endif
+ 
++    sh_ctxt->mfn1 = emulate_gva_to_mfn(v, vaddr, sh_ctxt);
++    if ( !mfn_valid(sh_ctxt->mfn1) )
++    {
++        switch ( mfn_x(sh_ctxt->mfn1) )
++        {
++        case BAD_GVA_TO_GFN: return MAPPING_EXCEPTION;
++        case READONLY_GFN:   return MAPPING_SILENT_FAIL;
++        default:             return MAPPING_UNHANDLEABLE;
++        }
++    }
++
+     /* Unaligned writes mean probably this isn't a pagetable */
+     if ( vaddr & (bytes - 1) )
+         sh_remove_shadows(d, sh_ctxt->mfn1, 0, 0 /* Slow, can fail */ );
+@@ -4689,16 +4697,24 @@ static void *emulate_map_dest(struct vcp
+         /* Cross-page emulated writes are only supported for HVM guests;
+          * PV guests ought to know better */
+         if ( !is_hvm_domain(d) )
++        {
++            put_page(mfn_to_page(sh_ctxt->mfn1));
+             return MAPPING_UNHANDLEABLE;
++        }
+ 
+         /* This write crosses a page boundary.  Translate the second page */
+         sh_ctxt->mfn2 = emulate_gva_to_mfn(v, (vaddr + bytes - 1) & PAGE_MASK,
+                                            sh_ctxt);
+         if ( !mfn_valid(sh_ctxt->mfn2) )
+-            return ((mfn_x(sh_ctxt->mfn2) == BAD_GVA_TO_GFN) ?
+-                    MAPPING_EXCEPTION :
+-                    (mfn_x(sh_ctxt->mfn2) == READONLY_GFN) ?
+-                    MAPPING_SILENT_FAIL : MAPPING_UNHANDLEABLE);
++        {
++            put_page(mfn_to_page(sh_ctxt->mfn1));
++            switch ( mfn_x(sh_ctxt->mfn2) )
++            {
++            case BAD_GVA_TO_GFN: return MAPPING_EXCEPTION;
++            case READONLY_GFN:   return MAPPING_SILENT_FAIL;
++            default:             return MAPPING_UNHANDLEABLE;
++            }
++        }
+ 
+         /* Cross-page writes mean probably not a pagetable */
+         sh_remove_shadows(d, sh_ctxt->mfn2, 0, 0 /* Slow, can fail */ );
+@@ -4707,7 +4723,11 @@ static void *emulate_map_dest(struct vcp
+         mfns[1] = sh_ctxt->mfn2;
+         map = vmap(mfns, 2);
+         if ( !map )
++        {
++            put_page(mfn_to_page(sh_ctxt->mfn1));
++            put_page(mfn_to_page(sh_ctxt->mfn2));
+             return MAPPING_UNHANDLEABLE;
++        }
+         map += (vaddr & ~PAGE_MASK);
+     }
+ 
+@@ -4782,10 +4802,12 @@ static void emulate_unmap_dest(struct vc
+     }
+ 
+     paging_mark_dirty(v->domain, mfn_x(sh_ctxt->mfn1));
++    put_page(mfn_to_page(sh_ctxt->mfn1));
+ 
+     if ( unlikely(mfn_valid(sh_ctxt->mfn2)) )
+     {
+         paging_mark_dirty(v->domain, mfn_x(sh_ctxt->mfn2));
++        put_page(mfn_to_page(sh_ctxt->mfn2));
+         vunmap((void *)((unsigned long)addr & PAGE_MASK));
+     }
+     else

--- a/recipes-extended/xen/files/xsa220-4.6.patch
+++ b/recipes-extended/xen/files/xsa220-4.6.patch
@@ -1,0 +1,100 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86: avoid leaking BND* between vCPU-s
+
+For MPX (BND<n>, BNDCFGU, and BNDSTATUS) the situation is less clear,
+and the SDM has not entirely consistent information for that case.
+While experimentally the instructions don't change register state as
+long as the two XCR0 bits aren't both 1, be on the safe side and enable
+both if BNDCFGS.EN is being set the first time.
+
+This is XSA-220.
+
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+Index: xen-4.6.5/xen/arch/x86/hvm/vmx/vmx.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/hvm/vmx/vmx.c
++++ xen-4.6.5/xen/arch/x86/hvm/vmx/vmx.c
+@@ -31,6 +31,7 @@
+ #include <asm/regs.h>
+ #include <asm/cpufeature.h>
+ #include <asm/processor.h>
++#include <asm/xstate.h>
+ #include <asm/guest_access.h>
+ #include <asm/debugreg.h>
+ #include <asm/msr.h>
+@@ -626,6 +627,45 @@ static int vmx_load_vmcs_ctxt(struct vcp
+     return 0;
+ }
+ 
++static bool_t vmx_set_guest_bndcfgs(struct vcpu *v, u64 val)
++{
++    if ( !cpu_has_mpx || !cpu_has_vmx_mpx ||
++         !is_canonical_address(val) ||
++         (val & IA32_BNDCFGS_RESERVED) )
++        return 0;
++
++    /*
++     * While MPX instructions are supposed to be gated on XCR0.BND*, let's
++     * nevertheless force the relevant XCR0 bits on when the feature is being
++     * enabled in BNDCFGS.
++     */
++    if ( (val & IA32_BNDCFGS_ENABLE) &&
++         !(v->arch.xcr0_accum & (XSTATE_BNDREGS | XSTATE_BNDCSR)) )
++    {
++        uint64_t xcr0 = get_xcr0();
++        int rc;
++
++        if ( v != current )
++            return 0;
++
++        rc = handle_xsetbv(XCR_XFEATURE_ENABLED_MASK,
++                           xcr0 | XSTATE_BNDREGS | XSTATE_BNDCSR);
++
++        if ( rc )
++        {
++            HVM_DBG_LOG(DBG_LEVEL_1, "Failed to force XCR0.BND*: %d", rc);
++            return 0;
++        }
++
++        if ( handle_xsetbv(XCR_XFEATURE_ENABLED_MASK, xcr0) )
++            /* nothing, best effort only */;
++    }
++
++    __vmwrite(GUEST_BNDCFGS, val);
++
++    return 1;
++}
++
+ static unsigned int __init vmx_init_msr(void)
+ {
+     return cpu_has_mpx && cpu_has_vmx_mpx;
+@@ -657,11 +697,8 @@ static int vmx_load_msr(struct vcpu *v,
+         switch ( ctxt->msr[i].index )
+         {
+         case MSR_IA32_BNDCFGS:
+-            if ( cpu_has_mpx && cpu_has_vmx_mpx &&
+-                 is_canonical_address(ctxt->msr[i].val) &&
+-                 !(ctxt->msr[i].val & IA32_BNDCFGS_RESERVED) )
+-                __vmwrite(GUEST_BNDCFGS, ctxt->msr[i].val);
+-            else
++            if ( !vmx_set_guest_bndcfgs(v, ctxt->msr[i].val) &&
++                 ctxt->msr[i].val )
+                 err = -ENXIO;
+             break;
+         default:
+@@ -2573,11 +2610,8 @@ static int vmx_msr_write_intercept(unsig
+         break;
+     }
+     case MSR_IA32_BNDCFGS:
+-        if ( !cpu_has_mpx || !cpu_has_vmx_mpx ||
+-             !is_canonical_address(msr_content) ||
+-             (msr_content & IA32_BNDCFGS_RESERVED) )
++        if ( !vmx_set_guest_bndcfgs(v, msr_content) )
+             goto gp_fault;
+-        __vmwrite(GUEST_BNDCFGS, msr_content);
+         break;
+     case IA32_FEATURE_CONTROL_MSR:
+     case MSR_IA32_VMX_BASIC...MSR_IA32_VMX_TRUE_ENTRY_CTLS:

--- a/recipes-extended/xen/files/xsa221.patch
+++ b/recipes-extended/xen/files/xsa221.patch
@@ -1,0 +1,206 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: evtchn: avoid NULL derefs
+
+Commit fbbd5009e6 ("evtchn: refactor low-level event channel port ops")
+added a de-reference of the struct evtchn pointer for a port without
+first making sure the bucket pointer is non-NULL. This de-reference is
+actually entirely unnecessary, as all relevant callers (beyond the
+problematic do_poll()) already hold the port number in their hands, and
+the actual leaf functions need nothing else.
+
+For FIFO event channels there's a second problem in that the ordering
+of reads and updates to ->num_evtchns and ->event_array[] was so far
+undefined (the read side isn't always holding the domain's event lock).
+Add respective barriers.
+
+This is XSA-221.
+
+Reported-by: Ankur Arora <ankur.a.arora@oracle.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+
+Index: xen-4.6.5/xen/arch/x86/irq.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/irq.c
++++ xen-4.6.5/xen/arch/x86/irq.c
+@@ -1484,7 +1484,7 @@ int pirq_guest_unmask(struct domain *d)
+         {
+             pirq = pirqs[i]->pirq;
+             if ( pirqs[i]->masked &&
+-                 !evtchn_port_is_masked(d, evtchn_from_port(d, pirqs[i]->evtchn)) )
++                 !evtchn_port_is_masked(d, pirqs[i]->evtchn) )
+                 pirq_guest_eoi(pirqs[i]);
+         }
+     } while ( ++pirq < d->nr_pirqs && n == ARRAY_SIZE(pirqs) );
+@@ -2242,7 +2242,6 @@ static void dump_irqs(unsigned char key)
+     int i, irq, pirq;
+     struct irq_desc *desc;
+     irq_guest_action_t *action;
+-    struct evtchn *evtchn;
+     struct domain *d;
+     const struct pirq *info;
+     unsigned long flags;
+@@ -2285,11 +2284,10 @@ static void dump_irqs(unsigned char key)
+                 d = action->guest[i];
+                 pirq = domain_irq_to_pirq(d, irq);
+                 info = pirq_info(d, pirq);
+-                evtchn = evtchn_from_port(d, info->evtchn);
+                 printk("%u:%3d(%c%c%c)",
+                        d->domain_id, pirq,
+-                       (evtchn_port_is_pending(d, evtchn) ? 'P' : '-'),
+-                       (evtchn_port_is_masked(d, evtchn) ? 'M' : '-'),
++                       evtchn_port_is_pending(d, info->evtchn) ? 'P' : '-',
++                       evtchn_port_is_masked(d, info->evtchn) ? 'M' : '-',
+                        (info->masked ? 'M' : '-'));
+                 if ( i != action->nr_guests )
+                     printk(",");
+Index: xen-4.6.5/xen/common/event_2l.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/event_2l.c
++++ xen-4.6.5/xen/common/event_2l.c
+@@ -68,16 +68,20 @@ static void evtchn_2l_unmask(struct doma
+     }
+ }
+ 
+-static bool_t evtchn_2l_is_pending(struct domain *d,
+-                                   const struct evtchn *evtchn)
++static bool_t evtchn_2l_is_pending(struct domain *d, evtchn_port_t port)
+ {
+-    return test_bit(evtchn->port, &shared_info(d, evtchn_pending));
++    unsigned int max_ports = BITS_PER_EVTCHN_WORD(d) * BITS_PER_EVTCHN_WORD(d);
++
++    ASSERT(port < max_ports);
++    return port < max_ports && test_bit(port, &shared_info(d, evtchn_pending));
+ }
+ 
+-static bool_t evtchn_2l_is_masked(struct domain *d,
+-                                  const struct evtchn *evtchn)
++static bool_t evtchn_2l_is_masked(struct domain *d, evtchn_port_t port)
+ {
+-    return test_bit(evtchn->port, &shared_info(d, evtchn_mask));
++    unsigned int max_ports = BITS_PER_EVTCHN_WORD(d) * BITS_PER_EVTCHN_WORD(d);
++
++    ASSERT(port < max_ports);
++    return port >= max_ports || test_bit(port, &shared_info(d, evtchn_mask));
+ }
+ 
+ static void evtchn_2l_print_state(struct domain *d,
+Index: xen-4.6.5/xen/common/event_channel.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/event_channel.c
++++ xen-4.6.5/xen/common/event_channel.c
+@@ -1386,8 +1386,8 @@ static void domain_dump_evtchn_info(stru
+ 
+         printk("    %4u [%d/%d/",
+                port,
+-               !!evtchn_port_is_pending(d, chn),
+-               !!evtchn_port_is_masked(d, chn));
++               evtchn_port_is_pending(d, port),
++               evtchn_port_is_masked(d, port));
+         evtchn_port_print_state(d, chn);
+         printk("]: s=%d n=%d x=%d",
+                chn->state, chn->notify_vcpu_id, chn->xen_consumer);
+Index: xen-4.6.5/xen/common/event_fifo.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/event_fifo.c
++++ xen-4.6.5/xen/common/event_fifo.c
+@@ -28,6 +28,12 @@ static inline event_word_t *evtchn_fifo_
+     if ( unlikely(port >= d->evtchn_fifo->num_evtchns) )
+         return NULL;
+ 
++    /*
++     * Callers aren't required to hold d->event_lock, so we need to synchronize
++     * with add_page_to_event_array().
++     */
++    smp_rmb();
++
+     p = port / EVTCHN_FIFO_EVENT_WORDS_PER_PAGE;
+     w = port % EVTCHN_FIFO_EVENT_WORDS_PER_PAGE;
+ 
+@@ -288,24 +294,22 @@ static void evtchn_fifo_unmask(struct do
+         evtchn_fifo_set_pending(v, evtchn);
+ }
+ 
+-static bool_t evtchn_fifo_is_pending(struct domain *d,
+-                                     const struct evtchn *evtchn)
++static bool_t evtchn_fifo_is_pending(struct domain *d, evtchn_port_t port)
+ {
+     event_word_t *word;
+ 
+-    word = evtchn_fifo_word_from_port(d, evtchn->port);
++    word = evtchn_fifo_word_from_port(d, port);
+     if ( unlikely(!word) )
+         return 0;
+ 
+     return test_bit(EVTCHN_FIFO_PENDING, word);
+ }
+ 
+-static bool_t evtchn_fifo_is_masked(struct domain *d,
+-                                    const struct evtchn *evtchn)
++static bool_t evtchn_fifo_is_masked(struct domain *d, evtchn_port_t port)
+ {
+     event_word_t *word;
+ 
+-    word = evtchn_fifo_word_from_port(d, evtchn->port);
++    word = evtchn_fifo_word_from_port(d, port);
+     if ( unlikely(!word) )
+         return 1;
+ 
+@@ -594,6 +598,10 @@ static int add_page_to_event_array(struc
+         return rc;
+ 
+     d->evtchn_fifo->event_array[slot] = virt;
++
++    /* Synchronize with evtchn_fifo_word_from_port(). */
++    smp_wmb();
++
+     d->evtchn_fifo->num_evtchns += EVTCHN_FIFO_EVENT_WORDS_PER_PAGE;
+ 
+     /*
+Index: xen-4.6.5/xen/common/schedule.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/schedule.c
++++ xen-4.6.5/xen/common/schedule.c
+@@ -870,7 +870,7 @@ static long do_poll(struct sched_poll *s
+             goto out;
+ 
+         rc = 0;
+-        if ( evtchn_port_is_pending(d, evtchn_from_port(d, port)) )
++        if ( evtchn_port_is_pending(d, port) )
+             goto out;
+     }
+ 
+Index: xen-4.6.5/xen/include/xen/event.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/xen/event.h
++++ xen-4.6.5/xen/include/xen/event.h
+@@ -134,8 +134,8 @@ struct evtchn_port_ops {
+     void (*set_pending)(struct vcpu *v, struct evtchn *evtchn);
+     void (*clear_pending)(struct domain *d, struct evtchn *evtchn);
+     void (*unmask)(struct domain *d, struct evtchn *evtchn);
+-    bool_t (*is_pending)(struct domain *d, const struct evtchn *evtchn);
+-    bool_t (*is_masked)(struct domain *d, const struct evtchn *evtchn);
++    bool_t (*is_pending)(struct domain *d, evtchn_port_t port);
++    bool_t (*is_masked)(struct domain *d, evtchn_port_t port);
+     /*
+      * Is the port unavailable because it's still being cleaned up
+      * after being closed?
+@@ -172,15 +172,15 @@ static inline void evtchn_port_unmask(st
+ }
+ 
+ static inline bool_t evtchn_port_is_pending(struct domain *d,
+-                                            const struct evtchn *evtchn)
++                                            evtchn_port_t port)
+ {
+-    return d->evtchn_port_ops->is_pending(d, evtchn);
++    return d->evtchn_port_ops->is_pending(d, port);
+ }
+ 
+ static inline bool_t evtchn_port_is_masked(struct domain *d,
+-                                           const struct evtchn *evtchn)
++                                           evtchn_port_t port)
+ {
+-    return d->evtchn_port_ops->is_masked(d, evtchn);
++    return d->evtchn_port_ops->is_masked(d, port);
+ }
+ 
+ static inline bool_t evtchn_port_is_busy(struct domain *d, evtchn_port_t port)

--- a/recipes-extended/xen/files/xsa222-1-4.6.patch
+++ b/recipes-extended/xen/files/xsa222-1-4.6.patch
@@ -1,0 +1,123 @@
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: xen/memory: Fix return value handing of guest_remove_page()
+
+Despite the description in mm.h, guest_remove_page() previously returned 0 for
+paging errors.
+
+Switch guest_remove_page() to having regular 0/-error semantics, and propagate
+the return values from clear_mmio_p2m_entry() and mem_sharing_unshare_page()
+to the callers (although decrease_reservation() is the only caller which
+currently cares).
+
+This is part of XSA-222.
+
+Reported-by: Julien Grall <julien.grall@arm.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Index: xen-4.6.5/xen/common/memory.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/memory.c
++++ xen-4.6.5/xen/common/memory.c
+@@ -238,6 +238,7 @@ int guest_remove_page(struct domain *d,
+     p2m_type_t p2mt;
+ #endif
+     unsigned long mfn;
++    int rc;
+ 
+ #ifdef CONFIG_X86
+     mfn = mfn_x(get_gfn_query(d, gmfn, &p2mt)); 
+@@ -255,13 +256,15 @@ int guest_remove_page(struct domain *d,
+                 put_page(page);
+         }
+         p2m_mem_paging_drop_page(d, gmfn, p2mt);
+-        return 1;
++
++        return 0;
+     }
+     if ( p2mt == p2m_mmio_direct )
+     {
+-        clear_mmio_p2m_entry(d, gmfn, _mfn(mfn));
++        rc = clear_mmio_p2m_entry(d, gmfn, _mfn(mfn));
+         put_gfn(d, gmfn);
+-        return 1;
++
++        return rc;
+     }
+ #else
+     mfn = gmfn_to_mfn(d, gmfn);
+@@ -271,21 +274,25 @@ int guest_remove_page(struct domain *d,
+         put_gfn(d, gmfn);
+         gdprintk(XENLOG_INFO, "Domain %u page number %lx invalid\n",
+                 d->domain_id, gmfn);
+-        return 0;
++
++        return -EINVAL;
+     }
+             
+ #ifdef CONFIG_X86
+     if ( p2m_is_shared(p2mt) )
+     {
+-        /* Unshare the page, bail out on error. We unshare because 
+-         * we might be the only one using this shared page, and we
+-         * need to trigger proper cleanup. Once done, this is 
+-         * like any other page. */
+-        if ( mem_sharing_unshare_page(d, gmfn, 0) )
++        /*
++         * Unshare the page, bail out on error. We unshare because we
++         * might be the only one using this shared page, and we need to
++         * trigger proper cleanup. Once done, this is like any other page.
++         */
++        rc = mem_sharing_unshare_page(d, gmfn, 0);
++        if ( rc )
+         {
+             put_gfn(d, gmfn);
+             (void)mem_sharing_notify_enomem(d, gmfn, 0);
+-            return 0;
++
++            return rc;
+         }
+         /* Maybe the mfn changed */
+         mfn = mfn_x(get_gfn_query_unlocked(d, gmfn, &p2mt));
+@@ -298,7 +305,8 @@ int guest_remove_page(struct domain *d,
+     {
+         put_gfn(d, gmfn);
+         gdprintk(XENLOG_INFO, "Bad page free for domain %u\n", d->domain_id);
+-        return 0;
++
++        return -ENXIO;
+     }
+ 
+     if ( test_and_clear_bit(_PGT_pinned, &page->u.inuse.type_info) )
+@@ -312,7 +320,7 @@ int guest_remove_page(struct domain *d,
+     put_page(page);
+     put_gfn(d, gmfn);
+ 
+-    return 1;
++    return 0;
+ }
+ 
+ static void decrease_reservation(struct memop_args *a)
+@@ -363,7 +371,7 @@ static void decrease_reservation(struct
+             continue;
+ 
+         for ( j = 0; j < (1 << a->extent_order); j++ )
+-            if ( !guest_remove_page(a->domain, gmfn + j) )
++            if ( guest_remove_page(a->domain, gmfn + j) )
+                 goto out;
+     }
+ 
+Index: xen-4.6.5/xen/include/xen/mm.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/xen/mm.h
++++ xen-4.6.5/xen/include/xen/mm.h
+@@ -447,8 +447,7 @@ int xenmem_add_to_physmap_one(struct dom
+                               domid_t foreign_domid,
+                               unsigned long idx, xen_pfn_t gpfn);
+ 
+-/* Returns 1 on success, 0 on error, negative if the ring
+- * for event propagation is full in the presence of paging */
++/* Returns 0 on success, or negative on error. */
+ int guest_remove_page(struct domain *d, unsigned long gmfn);
+ 
+ #define RAM_TYPE_CONVENTIONAL 0x00000001

--- a/recipes-extended/xen/files/xsa222-2-4.6.patch
+++ b/recipes-extended/xen/files/xsa222-2-4.6.patch
@@ -1,0 +1,413 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: guest_physmap_remove_page() needs its return value checked
+
+Callers, namely such subsequently freeing the page, must not blindly
+assume success - the function may namely fail when needing to shatter a
+super page, but there not being memory available for the then needed
+intermediate page table.
+
+As it happens, guest_remove_page() callers now also all check the
+return value.
+
+Furthermore a missed put_gfn() on an error path in gnttab_transfer() is
+also being taken care of.
+
+This is part of XSA-222.
+
+Reported-by: Julien Grall <julien.grall@arm.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Julien Grall <julien.grall@arm.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+Index: xen-4.6.5/xen/arch/arm/mm.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/arm/mm.c
++++ xen-4.6.5/xen/arch/arm/mm.c
+@@ -1283,13 +1283,14 @@ int replace_grant_host_mapping(unsigned
+ {
+     unsigned long gfn = (unsigned long)(addr >> PAGE_SHIFT);
+     struct domain *d = current->domain;
++    int rc;
+ 
+     if ( new_addr != 0 || (flags & GNTMAP_contains_pte) )
+         return GNTST_general_error;
+ 
+-    guest_physmap_remove_page(d, gfn, mfn, 0);
++    rc = guest_physmap_remove_page(d, gfn, mfn, 0);
+ 
+-    return GNTST_okay;
++    return rc ? GNTST_general_error : GNTST_okay;
+ }
+ 
+ int is_iomem_page(unsigned long mfn)
+Index: xen-4.6.5/xen/arch/arm/p2m.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/arm/p2m.c
++++ xen-4.6.5/xen/arch/arm/p2m.c
+@@ -1176,15 +1176,14 @@ int guest_physmap_add_entry(struct domai
+                              d->arch.p2m.default_access);
+ }
+ 
+-void guest_physmap_remove_page(struct domain *d,
+-                               unsigned long gpfn,
+-                               unsigned long mfn, unsigned int page_order)
++int guest_physmap_remove_page(struct domain *d, unsigned long gfn,
++                              unsigned long mfn, unsigned int page_order)
+ {
+-    apply_p2m_changes(d, REMOVE,
+-                      pfn_to_paddr(gpfn),
+-                      pfn_to_paddr(gpfn + (1<<page_order)),
+-                      pfn_to_paddr(mfn), MATTR_MEM, 0, p2m_invalid,
+-                      d->arch.p2m.default_access);
++    return apply_p2m_changes(d, REMOVE,
++                             pfn_to_paddr(gfn),
++                             pfn_to_paddr(gfn + (1 << page_order)),
++                             pfn_to_paddr(mfn), MATTR_MEM, 0, p2m_invalid,
++                             d->arch.p2m.default_access);
+ }
+ 
+ int p2m_alloc_table(struct domain *d)
+Index: xen-4.6.5/xen/arch/x86/domain_build.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/domain_build.c
++++ xen-4.6.5/xen/arch/x86/domain_build.c
+@@ -427,7 +427,9 @@ static __init void pvh_add_mem_mapping(s
+         if ( !iomem_access_permitted(d, mfn + i, mfn + i) )
+         {
+             omfn = get_gfn_query_unlocked(d, gfn + i, &t);
+-            guest_physmap_remove_page(d, gfn + i, mfn_x(omfn), PAGE_ORDER_4K);
++            if ( guest_physmap_remove_page(d, gfn + i, mfn_x(omfn),
++                                           PAGE_ORDER_4K) )
++                /* nothing, best effort only */;
+             continue;
+         }
+ 
+Index: xen-4.6.5/xen/arch/x86/hvm/hvm.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/hvm/hvm.c
++++ xen-4.6.5/xen/arch/x86/hvm/hvm.c
+@@ -671,8 +671,9 @@ bool_t is_ioreq_server_page(struct domai
+ static void hvm_remove_ioreq_gmfn(
+     struct domain *d, struct hvm_ioreq_page *iorp)
+ {
+-    guest_physmap_remove_page(d, iorp->gmfn, 
+-                              page_to_mfn(iorp->page), 0);
++    if ( guest_physmap_remove_page(d, iorp->gmfn,
++                                   page_to_mfn(iorp->page), 0) )
++        domain_crash(d);
+     clear_page(iorp->va);
+ }
+ 
+Index: xen-4.6.5/xen/arch/x86/mm.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/mm.c
++++ xen-4.6.5/xen/arch/x86/mm.c
+@@ -4182,7 +4182,11 @@ static int replace_grant_p2m_mapping(
+                 type, mfn_x(old_mfn), frame);
+         return GNTST_general_error;
+     }
+-    guest_physmap_remove_page(d, gfn, frame, PAGE_ORDER_4K);
++    if ( guest_physmap_remove_page(d, gfn, frame, PAGE_ORDER_4K) )
++    {
++        put_gfn(d, gfn);
++        return GNTST_general_error;
++    }
+ 
+     put_gfn(d, gfn);
+     return GNTST_okay;
+@@ -4709,7 +4713,7 @@ int xenmem_add_to_physmap_one(
+     struct page_info *page = NULL;
+     unsigned long gfn = 0; /* gcc ... */
+     unsigned long prev_mfn, mfn = 0, old_gpfn;
+-    int rc;
++    int rc = 0;
+     p2m_type_t p2mt;
+     int unmap_shinfo = 0;
+     xen_pfn_t gpfn_new = gpfn;
+@@ -4802,25 +4806,30 @@ int xenmem_add_to_physmap_one(
+     {
+         if ( is_xen_heap_mfn(prev_mfn) )
+             /* Xen heap frames are simply unhooked from this phys slot. */
+-            guest_physmap_remove_page(d, gpfn_new, prev_mfn, PAGE_ORDER_4K);
++            rc = guest_physmap_remove_page(d, gpfn, prev_mfn, PAGE_ORDER_4K);
+         else if ( space != XENMAPSPACE_shared_info )
+             /* Normal domain memory is freed, to avoid leaking memory. */
+-            guest_remove_page(d, gpfn_new);
++            rc = guest_remove_page(d, gpfn);
+     }
+     /* In the XENMAPSPACE_gmfn case we still hold a ref on the old page. */
+     put_gfn(d, gpfn_new);
+ 
++    if ( rc )
++        goto put_both;
++
+     /* Unmap from old location, if any. */
+     old_gpfn = get_gpfn_from_mfn(mfn);
+     ASSERT( old_gpfn != SHARED_M2P_ENTRY );
+     if ( space == XENMAPSPACE_gmfn || space == XENMAPSPACE_gmfn_range )
+         ASSERT( old_gpfn == gfn );
+     if ( old_gpfn != INVALID_M2P_ENTRY )
+-        guest_physmap_remove_page(d, old_gpfn, mfn, PAGE_ORDER_4K);
++        rc = guest_physmap_remove_page(d, old_gpfn, mfn, PAGE_ORDER_4K);
+ 
+     /* Map at new location. */
+-    rc = guest_physmap_add_page(d, gpfn_new, mfn, PAGE_ORDER_4K);
++    if ( !rc )
++        rc = guest_physmap_add_page(d, gpfn, mfn, PAGE_ORDER_4K);
+ 
++ put_both:
+     /* In the XENMAPSPACE_gmfn, we took a ref of the gfn at the top */
+     if ( space == XENMAPSPACE_gmfn || space == XENMAPSPACE_gmfn_range )
+         put_gfn(d, gfn);
+Index: xen-4.6.5/xen/arch/x86/mm/p2m.c
+===================================================================
+--- xen-4.6.5.orig/xen/arch/x86/mm/p2m.c
++++ xen-4.6.5/xen/arch/x86/mm/p2m.c
+@@ -2784,10 +2784,12 @@ int p2m_add_foreign(struct domain *tdom,
+     {
+         if ( is_xen_heap_mfn(prev_mfn) )
+             /* Xen heap frames are simply unhooked from this phys slot */
+-            guest_physmap_remove_page(tdom, gpfn, prev_mfn, 0);
++            rc = guest_physmap_remove_page(tdom, gpfn, prev_mfn, 0);
+         else
+             /* Normal domain memory is freed, to avoid leaking memory. */
+-            guest_remove_page(tdom, gpfn);
++            rc = guest_remove_page(tdom, gpfn);
++        if ( rc )
++            goto put_both;
+     }
+     /*
+      * Create the new mapping. Can't use guest_physmap_add_page() because it
+@@ -2800,6 +2802,7 @@ int p2m_add_foreign(struct domain *tdom,
+                  "gpfn:%lx mfn:%lx fgfn:%lx td:%d fd:%d\n",
+                  gpfn, mfn, fgfn, tdom->domain_id, fdom->domain_id);
+ 
++ put_both:
+     put_page(page);
+ 
+     /*
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -1791,6 +1791,7 @@ gnttab_transfer(
+     for ( i = 0; i < count; i++ )
+     {
+         bool_t okay;
++        int rc;
+ 
+         if (i && hypercall_preempt_check())
+             return i;
+@@ -1841,27 +1842,33 @@ gnttab_transfer(
+             goto copyback;
+         }
+ 
+-        guest_physmap_remove_page(d, gop.mfn, mfn, 0);
++        rc = guest_physmap_remove_page(d, gop.mfn, mfn, 0);
+         gnttab_flush_tlb(d);
++        if ( rc )
++        {
++            gdprintk(XENLOG_INFO,
++                     "gnttab_transfer: can't remove GFN %"PRI_xen_pfn" (MFN %lx)\n",
++                     gop.mfn, mfn);
++            gop.status = GNTST_general_error;
++            goto put_gfn_and_copyback;
++        }
+ 
+         /* Find the target domain. */
+         if ( unlikely((e = rcu_lock_domain_by_id(gop.domid)) == NULL) )
+         {
+-            put_gfn(d, gop.mfn);
+             gdprintk(XENLOG_INFO, "gnttab_transfer: can't find domain %d\n",
+                     gop.domid);
+-            page->count_info &= ~(PGC_count_mask|PGC_allocated);
+-            free_domheap_page(page);
+             gop.status = GNTST_bad_domain;
+-            goto copyback;
++            goto put_gfn_and_copyback;
+         }
+ 
+         if ( xsm_grant_transfer(XSM_HOOK, d, e) )
+         {
+-            put_gfn(d, gop.mfn);
+             gop.status = GNTST_permission_denied;
+         unlock_and_copyback:
+             rcu_unlock_domain(e);
++        put_gfn_and_copyback:
++            put_gfn(d, gop.mfn);
+             page->count_info &= ~(PGC_count_mask|PGC_allocated);
+             free_domheap_page(page);
+             goto copyback;
+@@ -1910,12 +1917,8 @@ gnttab_transfer(
+                          "Transferee (d%d) has no headroom (tot %u, max %u)\n",
+                          e->domain_id, e->tot_pages, e->max_pages);
+ 
+-            rcu_unlock_domain(e);
+-            put_gfn(d, gop.mfn);
+-            page->count_info &= ~(PGC_count_mask|PGC_allocated);
+-            free_domheap_page(page);
+             gop.status = GNTST_general_error;
+-            goto copyback;
++            goto unlock_and_copyback;
+         }
+ 
+         /* Okay, add the page to 'e'. */
+@@ -1944,13 +1947,8 @@ gnttab_transfer(
+ 
+             if ( drop_dom_ref )
+                 put_domain(e);
+-            rcu_unlock_domain(e);
+-
+-            put_gfn(d, gop.mfn);
+-            page->count_info &= ~(PGC_count_mask|PGC_allocated);
+-            free_domheap_page(page);
+             gop.status = GNTST_general_error;
+-            goto copyback;
++            goto unlock_and_copyback;
+         }
+ 
+         page_list_add_tail(page, &e->page_list);
+Index: xen-4.6.5/xen/common/memory.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/memory.c
++++ xen-4.6.5/xen/common/memory.c
+@@ -244,8 +244,12 @@ int guest_remove_page(struct domain *d,
+     mfn = mfn_x(get_gfn_query(d, gmfn, &p2mt)); 
+     if ( unlikely(p2m_is_paging(p2mt)) )
+     {
+-        guest_physmap_remove_page(d, gmfn, mfn, 0);
++        rc = guest_physmap_remove_page(d, gmfn, mfn, 0);
+         put_gfn(d, gmfn);
++
++        if ( rc )
++            return rc;
++
+         /* If the page hasn't yet been paged out, there is an
+          * actual page that needs to be released. */
+         if ( p2mt == p2m_ram_paging_out )
+@@ -309,18 +313,18 @@ int guest_remove_page(struct domain *d,
+         return -ENXIO;
+     }
+ 
+-    if ( test_and_clear_bit(_PGT_pinned, &page->u.inuse.type_info) )
++    rc = guest_physmap_remove_page(d, gmfn, mfn, 0);
++
++    if ( !rc && test_and_clear_bit(_PGT_pinned, &page->u.inuse.type_info) )
+         put_page_and_type(page);
+             
+-    if ( test_and_clear_bit(_PGC_allocated, &page->count_info) )
++    if ( !rc && test_and_clear_bit(_PGC_allocated, &page->count_info) )
+         put_page(page);
+ 
+-    guest_physmap_remove_page(d, gmfn, mfn, 0);
+-
+     put_page(page);
+     put_gfn(d, gmfn);
+ 
+-    return 0;
++    return rc;
+ }
+ 
+ static void decrease_reservation(struct memop_args *a)
+@@ -718,7 +722,8 @@ static long memory_exchange(XEN_GUEST_HA
+             gfn = mfn_to_gmfn(d, mfn);
+             /* Pages were unshared above */
+             BUG_ON(SHARED_M2P(gfn));
+-            guest_physmap_remove_page(d, gfn, mfn, 0);
++            if ( guest_physmap_remove_page(d, gfn, mfn, 0) )
++                domain_crash(d);
+             put_page(page);
+         }
+ 
+@@ -1249,7 +1254,7 @@ long do_memory_op(unsigned long cmd, XEN
+         page = get_page_from_gfn(d, xrfp.gpfn, NULL, P2M_ALLOC);
+         if ( page )
+         {
+-            guest_physmap_remove_page(d, xrfp.gpfn, page_to_mfn(page), 0);
++            rc = guest_physmap_remove_page(d, xrfp.gpfn, page_to_mfn(page), 0);
+             put_page(page);
+         }
+         else
+Index: xen-4.6.5/xen/drivers/passthrough/arm/smmu.c
+===================================================================
+--- xen-4.6.5.orig/xen/drivers/passthrough/arm/smmu.c
++++ xen-4.6.5/xen/drivers/passthrough/arm/smmu.c
+@@ -2787,9 +2787,7 @@ static int arm_smmu_unmap_page(struct do
+ 	if ( !is_domain_direct_mapped(d) )
+ 		return -EINVAL;
+ 
+-	guest_physmap_remove_page(d, gfn, gfn, 0);
+-
+-	return 0;
++	return guest_physmap_remove_page(d, gfn, gfn, 0);
+ }
+ 
+ static const struct iommu_ops arm_smmu_iommu_ops = {
+Index: xen-4.6.5/xen/include/asm-arm/p2m.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/asm-arm/p2m.h
++++ xen-4.6.5/xen/include/asm-arm/p2m.h
+@@ -173,10 +173,6 @@ static inline int guest_physmap_add_page
+     return guest_physmap_add_entry(d, gfn, mfn, page_order, p2m_ram_rw);
+ }
+ 
+-void guest_physmap_remove_page(struct domain *d,
+-                               unsigned long gpfn,
+-                               unsigned long mfn, unsigned int page_order);
+-
+ unsigned long gmfn_to_mfn(struct domain *d, unsigned long gpfn);
+ 
+ /*
+Index: xen-4.6.5/xen/include/asm-x86/p2m.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/asm-x86/p2m.h
++++ xen-4.6.5/xen/include/asm-x86/p2m.h
+@@ -536,11 +536,6 @@ static inline int guest_physmap_add_page
+     return guest_physmap_add_entry(d, gfn, mfn, page_order, p2m_ram_rw);
+ }
+ 
+-/* Remove a page from a domain's p2m table */
+-int guest_physmap_remove_page(struct domain *d,
+-                              unsigned long gfn,
+-                              unsigned long mfn, unsigned int page_order);
+-
+ /* Set a p2m range as populate-on-demand */
+ int guest_physmap_mark_populate_on_demand(struct domain *d, unsigned long gfn,
+                                           unsigned int order);
+Index: xen-4.6.5/xen/include/xen/p2m-common.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/xen/p2m-common.h
++++ xen-4.6.5/xen/include/xen/p2m-common.h
+@@ -1,6 +1,7 @@
+ #ifndef _XEN_P2M_COMMON_H
+ #define _XEN_P2M_COMMON_H
+ 
++#include <xen/mm.h>
+ #include <public/vm_event.h>
+ 
+ /*
+@@ -33,6 +34,11 @@ typedef enum {
+     /* NOTE: Assumed to be only 4 bits right now on x86. */
+ } p2m_access_t;
+ 
++/* Remove a page from a domain's p2m table */
++int __must_check
++guest_physmap_remove_page(struct domain *d, unsigned long gfn,
++                          unsigned long mfn, unsigned int page_order);
++
+ /* Map MMIO regions in the p2m: start_gfn and nr describe the range in
+  *  * the guest physical address space to map, starting from the machine
+  *   * frame number mfn. */
+Index: xen-4.6.5/xen/include/xen/mm.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/xen/mm.h
++++ xen-4.6.5/xen/include/xen/mm.h
+@@ -448,7 +448,7 @@ int xenmem_add_to_physmap_one(struct dom
+                               unsigned long idx, xen_pfn_t gpfn);
+ 
+ /* Returns 0 on success, or negative on error. */
+-int guest_remove_page(struct domain *d, unsigned long gmfn);
++int __must_check guest_remove_page(struct domain *d, unsigned long gmfn);
+ 
+ #define RAM_TYPE_CONVENTIONAL 0x00000001
+ #define RAM_TYPE_RESERVED     0x00000002

--- a/recipes-extended/xen/files/xsa224-4.6/0001-gnttab-Fix-handling-of-dev_bus_addr-during-unmap.patch
+++ b/recipes-extended/xen/files/xsa224-4.6/0001-gnttab-Fix-handling-of-dev_bus_addr-during-unmap.patch
@@ -1,0 +1,108 @@
+From 62e73c9a3e11c6bffa18e20a97329ef7fb694635 Mon Sep 17 00:00:00 2001
+From: George Dunlap <george.dunlap@citrix.com>
+Date: Thu, 15 Jun 2017 16:24:02 +0100
+Subject: [PATCH 1/4] gnttab: Fix handling of dev_bus_addr during unmap
+
+If a grant has been mapped with the GNTTAB_device_map flag, calling
+grant_unmap_ref() with dev_bus_addr set to zero should cause the
+GNTTAB_device_map part of the mapping to be left alone.
+
+Unfortunately, at the moment, op->dev_bus_addr is implicitly checked
+before clearing the map and adjusting the pin count, but only the bits
+above 12; and it is not checked at all before dropping page
+references.  This means a guest can repeatedly make such a call to
+cause the reference count to drop to zero, causing the page to be
+freed and re-used, even though it's still mapped in its pagetables.
+
+To fix this, always check op->dev_bus_addr explicitly for being
+non-zero, as well as op->flag & GNTMAP_device_map, before doing
+operations on the device_map.
+
+While we're here, make the logic a bit cleaner:
+
+* Always initialize op->frame to zero and set it from act->frame, to reduce the
+chance of untrusted input being used
+
+* Explicitly check the full dev_bus_addr against act->frame <<
+  PAGE_SHIFT, rather than ignoring the lower 12 bits
+
+This is part of XSA-224.
+
+Reported-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: George Dunlap <george.dunlap@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/grant_table.c | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -1076,8 +1076,6 @@ __gnttab_unmap_common(
+     ld = current->domain;
+     lgt = ld->grant_table;
+ 
+-    op->frame = (unsigned long)(op->dev_bus_addr >> PAGE_SHIFT);
+-
+     if ( unlikely(op->handle >= lgt->maptrack_limit) )
+     {
+         gdprintk(XENLOG_INFO, "Bad handle (%d).\n", op->handle);
+@@ -1161,16 +1159,14 @@ __gnttab_unmap_common(
+         goto act_release_out;
+     }
+ 
+-    if ( op->frame == 0 )
+-    {
+-        op->frame = act->frame;
+-    }
+-    else
++    op->frame = act->frame;
++
++    if ( op->dev_bus_addr )
+     {
+-        if ( unlikely(op->frame != act->frame) )
++        if ( unlikely(op->dev_bus_addr != pfn_to_paddr(act->frame)) )
+             PIN_FAIL(act_release_out, GNTST_general_error,
+-                     "Bad frame number doesn't match gntref. (%lx != %lx)\n",
+-                     op->frame, act->frame);
++                     "Bus address doesn't match gntref (%"PRIx64" != %"PRIpaddr")\n",
++                     op->dev_bus_addr, pfn_to_paddr(act->frame));
+ 
+         map->flags &= ~GNTMAP_device_map;
+     }
+@@ -1263,7 +1259,8 @@ __gnttab_unmap_common_complete(struct gn
+     else
+         status = &status_entry(rgt, op->ref);
+ 
+-    if ( unlikely(op->frame != act->frame) ) 
++    if ( op->dev_bus_addr &&
++         unlikely(op->dev_bus_addr != pfn_to_paddr(act->frame)) )
+     {
+         /*
+          * Suggests that __gntab_unmap_common failed early and so
+@@ -1274,7 +1271,7 @@ __gnttab_unmap_common_complete(struct gn
+ 
+     pg = mfn_to_page(op->frame);
+ 
+-    if ( op->flags & GNTMAP_device_map ) 
++    if ( op->dev_bus_addr && (op->flags & GNTMAP_device_map) )
+     {
+         if ( !is_iomem_page(act->frame) )
+         {
+@@ -1345,6 +1342,7 @@ __gnttab_unmap_grant_ref(
+     /* Intialise these in case common contains old state */
+     common->new_addr = 0;
+     common->rd = NULL;
++    common->frame = 0;
+ 
+     __gnttab_unmap_common(common);
+     op->status = common->status;
+@@ -1409,6 +1407,7 @@ __gnttab_unmap_and_replace(
+     /* Intialise these in case common contains old state */
+     common->dev_bus_addr = 0;
+     common->rd = NULL;
++    common->frame = 0;
+ 
+     __gnttab_unmap_common(common);
+     op->status = common->status;

--- a/recipes-extended/xen/files/xsa224-4.6/0002-gnttab-never-create-host-mapping-unless-asked-to.patch
+++ b/recipes-extended/xen/files/xsa224-4.6/0002-gnttab-never-create-host-mapping-unless-asked-to.patch
@@ -1,0 +1,39 @@
+From 82080ffca8cc95799b54e778923eaa20619ff961 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 2 Jun 2017 15:21:27 +0100
+Subject: [PATCH 2/4] gnttab: never create host mapping unless asked to
+
+We shouldn't create a host mapping unless asked to even in the case of
+mapping a granted MMIO page. In particular the mapping wouldn't be torn
+down when processing the matching unmap request.
+
+This is part of XSA-224.
+
+Reported-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/grant_table.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -898,10 +898,13 @@ __gnttab_map_grant_ref(
+             goto undo_out;
+         }
+ 
+-        rc = create_grant_host_mapping(
+-            op->host_addr, frame, op->flags, cache_flags);
+-        if ( rc != GNTST_okay )
+-            goto undo_out;
++        if ( op->flags & GNTMAP_host_map )
++        {
++            rc = create_grant_host_mapping(op->host_addr, frame, op->flags,
++                                           cache_flags);
++            if ( rc != GNTST_okay )
++                goto undo_out;
++        }
+     }
+     else if ( owner == rd || owner == dom_cow )
+     {

--- a/recipes-extended/xen/files/xsa224-4.6/0003-gnttab-correct-logic-to-get-page-references-during-m.patch
+++ b/recipes-extended/xen/files/xsa224-4.6/0003-gnttab-correct-logic-to-get-page-references-during-m.patch
@@ -1,0 +1,183 @@
+From 35b4cf7019e9c7631fbb462e5d907e5a3026a9c5 Mon Sep 17 00:00:00 2001
+From: George Dunlap <george.dunlap@citrix.com>
+Date: Fri, 2 Jun 2017 15:21:27 +0100
+Subject: [PATCH 3/4] gnttab: correct logic to get page references during map
+ requests
+
+The rules for reference counting are somewhat complicated:
+
+* Each of GNTTAB_host_map and GNTTAB_device_map need their own
+reference count
+
+* If the mapping is writeable:
+ - GNTTAB_host_map needs a type count under only some conditions
+ - GNTTAB_device_map always needs a type count
+
+If the mapping succeeds, we need to keep all of these; if the mapping
+fails, we need to release whatever references we have acquired so far.
+
+Additionally, the code that does a lot of this calculation "inherits"
+a reference as part of the process of finding out who the owner is.
+
+Finally, if the grant is mapped as writeable (without the
+GNTMAP_readonly flag), but the hypervisor cannot grab a
+PGT_writeable_page type, the entire operation should fail.
+
+Unfortunately, the current code has several logic holes:
+
+* If a grant is mapped only GNTTAB_device_map, and with a writeable
+  mapping, but in conditions where a *host* type count is not
+  necessary, the code will fail to grab the necessary type count.
+
+* If a grant is mapped both GNTTAB_device_map and GNTTAB_host_map,
+  with a writeable mapping, in conditions where the host type count is
+  not necessary, *and* where the page cannot be changed to type
+  PGT_writeable, the condition will not be detected.
+
+In both cases, this means that on success, the type count will be
+erroneously reduced when the grant is unmapped.  In the second case,
+the type count will be erroneously reduced on the failure path as
+well.  (In the first case the failure path logic has the same hole
+as the reference grabbing logic.)
+
+Additionally, the return value of get_page() is not checked; but this
+may fail even if the first get_page() succeeded due to a reference
+counting overflow.
+
+First of all, simplify the restoration logic by explicitly counting
+the reference and type references acquired.
+
+Consider each mapping type separately, explicitly marking the
+'incoming' reference as used so we know when we need to grab a second
+one.
+
+Finally, always check the return value of get_page[_type]() and go to
+the failure path if appropriate.
+
+This is part of XSA-224.
+
+Reported-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: George Dunlap <george.dunlap@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/grant_table.c | 58 +++++++++++++++++++++++++++---------------------
+ 1 file changed, 33 insertions(+), 25 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -744,12 +744,12 @@ __gnttab_map_grant_ref(
+     struct grant_table *lgt, *rgt;
+     struct vcpu   *led;
+     int            handle;
+-    unsigned long  frame = 0, nr_gets = 0;
++    unsigned long  frame = 0;
+     struct page_info *pg = NULL;
+     int            rc = GNTST_okay;
+     u32            old_pin;
+     u32            act_pin;
+-    unsigned int   cache_flags;
++    unsigned int   cache_flags, refcnt = 0, typecnt = 0;
+     struct active_grant_entry *act = NULL;
+     struct grant_mapping *mt;
+     grant_entry_header_t *shah;
+@@ -876,11 +876,17 @@ __gnttab_map_grant_ref(
+     else
+         owner = page_get_owner(pg);
+ 
++    if ( owner )
++        refcnt++;
++
+     if ( !pg || (owner == dom_io) )
+     {
+         /* Only needed the reference to confirm dom_io ownership. */
+         if ( pg )
++        {
+             put_page(pg);
++            refcnt--;
++        }
+ 
+         if ( paging_mode_external(ld) )
+         {
+@@ -908,27 +914,38 @@ __gnttab_map_grant_ref(
+     }
+     else if ( owner == rd || owner == dom_cow )
+     {
+-        if ( gnttab_host_mapping_get_page_type(op, ld, rd) )
++        if ( (op->flags & GNTMAP_device_map) && !(op->flags & GNTMAP_readonly) )
+         {
+             if ( (owner == dom_cow) ||
+                  !get_page_type(pg, PGT_writable_page) )
+                 goto could_not_pin;
++            typecnt++;
+         }
+ 
+-        nr_gets++;
+         if ( op->flags & GNTMAP_host_map )
+         {
+-            rc = create_grant_host_mapping(op->host_addr, frame, op->flags, 0);
+-            if ( rc != GNTST_okay )
+-                goto undo_out;
+-
++            /*
++             * Only need to grab another reference if device_map claimed
++             * the other one.
++             */
+             if ( op->flags & GNTMAP_device_map )
+             {
+-                nr_gets++;
+-                (void)get_page(pg, rd);
+-                if ( !(op->flags & GNTMAP_readonly) )
+-                    get_page_type(pg, PGT_writable_page);
++                if ( !get_page(pg, rd) )
++                    goto could_not_pin;
++                refcnt++;
+             }
++
++            if ( gnttab_host_mapping_get_page_type(op, ld, rd) )
++            {
++                if ( (owner == dom_cow) ||
++                     !get_page_type(pg, PGT_writable_page) )
++                    goto could_not_pin;
++                typecnt++;
++            }
++
++            rc = create_grant_host_mapping(op->host_addr, frame, op->flags, 0);
++            if ( rc != GNTST_okay )
++                goto undo_out;
+         }
+     }
+     else
+@@ -937,8 +954,6 @@ __gnttab_map_grant_ref(
+         if ( !rd->is_dying )
+             gdprintk(XENLOG_WARNING, "Could not pin grant frame %lx\n",
+                      frame);
+-        if ( owner != NULL )
+-            put_page(pg);
+         rc = GNTST_general_error;
+         goto undo_out;
+     }
+@@ -1001,18 +1016,11 @@ __gnttab_map_grant_ref(
+     return;
+ 
+  undo_out:
+-    if ( nr_gets > 1 )
+-    {
+-        if ( !(op->flags & GNTMAP_readonly) )
+-            put_page_type(pg);
+-        put_page(pg);
+-    }
+-    if ( nr_gets > 0 )
+-    {
+-        if ( gnttab_host_mapping_get_page_type(op, ld, rd) )
+-            put_page_type(pg);
++    while ( typecnt-- )
++        put_page_type(pg);
++
++    while ( refcnt-- )
+         put_page(pg);
+-    }
+ 
+     read_lock(&rgt->lock);
+ 

--- a/recipes-extended/xen/files/xsa224-4.6/0004-gnttab-__gnttab_unmap_common_complete-is-all-or-noth.patch
+++ b/recipes-extended/xen/files/xsa224-4.6/0004-gnttab-__gnttab_unmap_common_complete-is-all-or-noth.patch
@@ -1,0 +1,316 @@
+From 804036f102d6933ce05a4457fd15ecffea43d33b Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Thu, 15 Jun 2017 16:25:27 +0100
+Subject: [PATCH 4/4] gnttab: __gnttab_unmap_common_complete() is
+ all-or-nothing
+
+All failures have to be detected in __gnttab_unmap_common(), the
+completion function must not skip part of its processing. In particular
+the GNTMAP_device_map related putting of page references and adjustment
+of pin count must not occur if __gnttab_unmap_common() signaled an
+error. Furthermore the function must not make adjustments to global
+state (here: clearing GNTTAB_device_map) before all possibly failing
+operations have been performed.
+
+There's one exception for IOMMU related failures: As IOMMU manipulation
+occurs after GNTMAP_*_map have been cleared already, the related page
+reference and pin count adjustments need to be done nevertheless. A
+fundamental requirement for the correctness of this is that
+iommu_{,un}map_page() crash any affected DomU in case of failure.
+
+The version check appears to be pointless (or could perhaps be a
+BUG_ON() or ASSERT()), but for the moment also move it.
+
+This is part of XSA-224.
+
+Reported-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/common/grant_table.c          | 108 ++++++++++++++++++--------------------
+ xen/include/asm-arm/grant_table.h |   2 +-
+ xen/include/asm-x86/grant_table.h |   5 +-
+ 3 files changed, 55 insertions(+), 60 deletions(-)
+
+Index: xen-4.6.5/xen/common/grant_table.c
+===================================================================
+--- xen-4.6.5.orig/xen/common/grant_table.c
++++ xen-4.6.5/xen/common/grant_table.c
+@@ -96,7 +96,7 @@ struct gnttab_unmap_common {
+     int16_t status;
+ 
+     /* Shared state beteen *_unmap and *_unmap_complete */
+-    u16 flags;
++    u16 done;
+     unsigned long frame;
+     struct domain *rd;
+     grant_ref_t ref;
+@@ -935,7 +935,8 @@ __gnttab_map_grant_ref(
+                 refcnt++;
+             }
+ 
+-            if ( gnttab_host_mapping_get_page_type(op, ld, rd) )
++            if ( gnttab_host_mapping_get_page_type(op->flags & GNTMAP_readonly,
++                                                   ld, rd) )
+             {
+                 if ( (owner == dom_cow) ||
+                      !get_page_type(pg, PGT_writable_page) )
+@@ -1082,6 +1083,7 @@ __gnttab_unmap_common(
+     struct active_grant_entry *act;
+     s16              rc = 0;
+     struct grant_mapping *map;
++    unsigned int flags;
+     bool_t put_handle = 0;
+ 
+     ld = current->domain;
+@@ -1132,6 +1134,20 @@ __gnttab_unmap_common(
+ 
+     read_lock(&rgt->lock);
+ 
++    if ( rgt->gt_version == 0 )
++    {
++        /*
++         * This ought to be impossible, as such a mapping should not have
++         * been established (see the nr_grant_entries(rgt) bounds check in
++         * __gnttab_map_grant_ref()). Doing this check only in
++         * __gnttab_unmap_common_complete() - as it used to be done - would,
++         * however, be too late.
++         */
++        rc = GNTST_bad_gntref;
++        flags = 0;
++        goto unlock_out;
++    }
++
+     op->rd = rd;
+     op->ref = map->ref;
+ 
+@@ -1147,6 +1163,7 @@ __gnttab_unmap_common(
+     {
+         gdprintk(XENLOG_WARNING, "Unstable handle %#x\n", op->handle);
+         rc = GNTST_bad_handle;
++        flags = 0;
+         goto unlock_out;
+     }
+ 
+@@ -1160,9 +1177,9 @@ __gnttab_unmap_common(
+      * hold anyway; see docs/misc/grant-tables.txt's "Locking" section.
+      */
+ 
+-    op->flags = read_atomic(&map->flags);
++    flags = read_atomic(&map->flags);
+     smp_rmb();
+-    if ( unlikely(!op->flags) || unlikely(map->domid != dom) ||
++    if ( unlikely(!flags) || unlikely(map->domid != dom) ||
+          unlikely(map->ref != op->ref) )
+     {
+         gdprintk(XENLOG_WARNING, "Unstable handle %#x\n", op->handle);
+@@ -1172,24 +1189,27 @@ __gnttab_unmap_common(
+ 
+     op->frame = act->frame;
+ 
+-    if ( op->dev_bus_addr )
+-    {
+-        if ( unlikely(op->dev_bus_addr != pfn_to_paddr(act->frame)) )
+-            PIN_FAIL(act_release_out, GNTST_general_error,
+-                     "Bus address doesn't match gntref (%"PRIx64" != %"PRIpaddr")\n",
+-                     op->dev_bus_addr, pfn_to_paddr(act->frame));
+-
+-        map->flags &= ~GNTMAP_device_map;
+-    }
++    if ( op->dev_bus_addr &&
++         unlikely(op->dev_bus_addr != pfn_to_paddr(act->frame)) )
++        PIN_FAIL(act_release_out, GNTST_general_error,
++                 "Bus address doesn't match gntref (%"PRIx64" != %"PRIpaddr")\n",
++                 op->dev_bus_addr, pfn_to_paddr(act->frame));
+ 
+-    if ( (op->host_addr != 0) && (op->flags & GNTMAP_host_map) )
++    if ( op->host_addr && (flags & GNTMAP_host_map) )
+     {
+         if ( (rc = replace_grant_host_mapping(op->host_addr,
+                                               op->frame, op->new_addr, 
+-                                              op->flags)) < 0 )
++                                              flags)) < 0 )
+             goto act_release_out;
+ 
+         map->flags &= ~GNTMAP_host_map;
++        op->done |= GNTMAP_host_map | (flags & GNTMAP_readonly);
++    }
++
++    if ( op->dev_bus_addr && (flags & GNTMAP_device_map) )
++    {
++        map->flags &= ~GNTMAP_device_map;
++        op->done |= GNTMAP_device_map | (flags & GNTMAP_readonly);
+     }
+ 
+     if ( !(map->flags & (GNTMAP_device_map|GNTMAP_host_map)) )
+@@ -1226,7 +1246,7 @@ __gnttab_unmap_common(
+     }
+ 
+     /* If just unmapped a writable mapping, mark as dirtied */
+-    if ( rc == GNTST_okay && !(op->flags & GNTMAP_readonly) )
++    if ( rc == GNTST_okay && !(flags & GNTMAP_readonly) )
+          gnttab_mark_dirty(rd, op->frame);
+ 
+     op->status = rc;
+@@ -1243,13 +1263,9 @@ __gnttab_unmap_common_complete(struct gn
+     struct page_info *pg;
+     uint16_t *status;
+ 
+-    if ( rd == NULL )
++    if ( !op->done )
+     { 
+-        /*
+-         * Suggests that __gntab_unmap_common failed in
+-         * rcu_lock_domain_by_id() or earlier, and so we have nothing
+-         * to complete
+-         */
++        /* __gntab_unmap_common() didn't do anything - nothing to complete. */
+         return;
+     }
+ 
+@@ -1259,8 +1275,6 @@ __gnttab_unmap_common_complete(struct gn
+     rgt = rd->grant_table;
+ 
+     read_lock(&rgt->lock);
+-    if ( rgt->gt_version == 0 )
+-        goto unlock_out;
+ 
+     act = active_entry_acquire(rgt, op->ref);
+     sha = shared_entry_header(rgt, op->ref);
+@@ -1270,72 +1284,50 @@ __gnttab_unmap_common_complete(struct gn
+     else
+         status = &status_entry(rgt, op->ref);
+ 
+-    if ( op->dev_bus_addr &&
+-         unlikely(op->dev_bus_addr != pfn_to_paddr(act->frame)) )
+-    {
+-        /*
+-         * Suggests that __gntab_unmap_common failed early and so
+-         * nothing further to do
+-         */
+-        goto act_release_out;
+-    }
+-
+     pg = mfn_to_page(op->frame);
+ 
+-    if ( op->dev_bus_addr && (op->flags & GNTMAP_device_map) )
++    if ( op->done & GNTMAP_device_map )
+     {
+         if ( !is_iomem_page(act->frame) )
+         {
+-            if ( op->flags & GNTMAP_readonly )
++            if ( op->done & GNTMAP_readonly )
+                 put_page(pg);
+             else
+                 put_page_and_type(pg);
+         }
+ 
+         ASSERT(act->pin & (GNTPIN_devw_mask | GNTPIN_devr_mask));
+-        if ( op->flags & GNTMAP_readonly )
++        if ( op->done & GNTMAP_readonly )
+             act->pin -= GNTPIN_devr_inc;
+         else
+             act->pin -= GNTPIN_devw_inc;
+     }
+ 
+-    if ( (op->host_addr != 0) && (op->flags & GNTMAP_host_map) )
++    if ( op->done & GNTMAP_host_map )
+     {
+-        if ( op->status != 0 ) 
++        if ( !is_iomem_page(op->frame) )
+         {
+-            /*
+-             * Suggests that __gntab_unmap_common failed in
+-             * replace_grant_host_mapping() or IOMMU handling, so nothing
+-             * further to do (short of re-establishing the mapping in the
+-             * latter case).
+-             */
+-            goto act_release_out;
+-        }
+-
+-        if ( !is_iomem_page(op->frame) ) 
+-        {
+-            if ( gnttab_host_mapping_get_page_type(op, ld, rd) )
++            if ( gnttab_host_mapping_get_page_type(op->done & GNTMAP_readonly,
++                                                   ld, rd) )
+                 put_page_type(pg);
+             put_page(pg);
+         }
+ 
+         ASSERT(act->pin & (GNTPIN_hstw_mask | GNTPIN_hstr_mask));
+-        if ( op->flags & GNTMAP_readonly )
++        if ( op->done & GNTMAP_readonly )
+             act->pin -= GNTPIN_hstr_inc;
+         else
+             act->pin -= GNTPIN_hstw_inc;
+     }
+ 
+     if ( ((act->pin & (GNTPIN_devw_mask|GNTPIN_hstw_mask)) == 0) &&
+-         !(op->flags & GNTMAP_readonly) )
++         !(op->done & GNTMAP_readonly) )
+         gnttab_clear_flag(_GTF_writing, status);
+ 
+     if ( act->pin == 0 )
+         gnttab_clear_flag(_GTF_reading, status);
+ 
+- act_release_out:
+     active_entry_release(act);
+- unlock_out:
+     read_unlock(&rgt->lock);
+ 
+     rcu_unlock_domain(rd);
+@@ -1351,6 +1343,7 @@ __gnttab_unmap_grant_ref(
+     common->handle = op->handle;
+ 
+     /* Intialise these in case common contains old state */
++    common->done = 0;
+     common->new_addr = 0;
+     common->rd = NULL;
+     common->frame = 0;
+@@ -1416,6 +1409,7 @@ __gnttab_unmap_and_replace(
+     common->handle = op->handle;
+     
+     /* Intialise these in case common contains old state */
++    common->done = 0;
+     common->dev_bus_addr = 0;
+     common->rd = NULL;
+     common->frame = 0;
+@@ -3374,7 +3368,9 @@ gnttab_release_mappings(
+                 if ( gnttab_release_host_mappings(d) &&
+                      !is_iomem_page(act->frame) )
+                 {
+-                    if ( gnttab_host_mapping_get_page_type(map, d, rd) )
++                    if ( gnttab_host_mapping_get_page_type((map->flags &
++                                                            GNTMAP_readonly),
++                                                           d, rd) )
+                         put_page_type(pg);
+                     put_page(pg);
+                 }
+Index: xen-4.6.5/xen/include/asm-arm/grant_table.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/asm-arm/grant_table.h
++++ xen-4.6.5/xen/include/asm-arm/grant_table.h
+@@ -9,7 +9,7 @@ void gnttab_clear_flag(unsigned long nr,
+ int create_grant_host_mapping(unsigned long gpaddr,
+         unsigned long mfn, unsigned int flags, unsigned int
+         cache_flags);
+-#define gnttab_host_mapping_get_page_type(op, d, rd) (0)
++#define gnttab_host_mapping_get_page_type(ro, ld, rd) (0)
+ int replace_grant_host_mapping(unsigned long gpaddr, unsigned long mfn,
+         unsigned long new_gpaddr, unsigned int flags);
+ void gnttab_mark_dirty(struct domain *d, unsigned long l);
+Index: xen-4.6.5/xen/include/asm-x86/grant_table.h
+===================================================================
+--- xen-4.6.5.orig/xen/include/asm-x86/grant_table.h
++++ xen-4.6.5/xen/include/asm-x86/grant_table.h
+@@ -58,9 +58,8 @@ static inline void gnttab_clear_flag(uns
+ }
+ 
+ /* Foreign mappings of HHVM-guest pages do not modify the type count. */
+-#define gnttab_host_mapping_get_page_type(op, ld, rd)   \
+-    (!((op)->flags & GNTMAP_readonly) &&                \
+-     (((ld) == (rd)) || !paging_mode_external(rd)))
++#define gnttab_host_mapping_get_page_type(ro, ld, rd)   \
++    (!(ro) && (((ld) == (rd)) || !paging_mode_external(rd)))
+ 
+ /* Done implicitly when page tables are destroyed. */
+ #define gnttab_release_host_mappings(domain) ( paging_mode_external(domain) )

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -85,6 +85,20 @@ SRC_URI_append = " \
     file://xsa-213-x86-64bit-PV-guest-breakout-via-pagetable-use-after-mode-change.patch \
     file://xsa-214-grant-transfer-allows-pv-guest-to-elevate-privileges.patch \
     file://xsa-215-possible-memory-corruption-via-failsafe-callback.patch \
+    file://xsa217.patch \
+    file://xsa218-4.6/0001-IOMMU-handle-IOMMU-mapping-and-unmapping-failures.patch \
+    file://xsa218-4.6/0002-gnttab-fix-unmap-pin-accounting-race.patch \
+    file://xsa218-4.6/0003-gnttab-Avoid-potential-double-put-of-maptrack-entry.patch \
+    file://xsa218-4.6/0004-gnttab-correct-maptrack-table-accesses.patch \
+    file://xsa219-4.6.patch \
+    file://xsa220-4.6.patch \
+    file://xsa221.patch \
+    file://xsa222-1-4.6.patch \
+    file://xsa222-2-4.6.patch \
+    file://xsa224-4.6/0001-gnttab-Fix-handling-of-dev_bus_addr-during-unmap.patch \
+    file://xsa224-4.6/0002-gnttab-never-create-host-mapping-unless-asked-to.patch \
+    file://xsa224-4.6/0003-gnttab-correct-logic-to-get-page-references-during-m.patch \
+    file://xsa224-4.6/0004-gnttab-__gnttab_unmap_common_complete-is-all-or-noth.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-kernel/linux/4.9/linux-openxt_4.9.27.bb
+++ b/recipes-kernel/linux/4.9/linux-openxt_4.9.27.bb
@@ -44,6 +44,7 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch;patch=1 \
+    file://xsa216-linux-4.11.patch;patch=1 \
     file://defconfig \
     "
 

--- a/recipes-kernel/linux/4.9/patches/xsa216-linux-4.11.patch
+++ b/recipes-kernel/linux/4.9/patches/xsa216-linux-4.11.patch
@@ -1,0 +1,118 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: xen-blkback: don't leak stack data via response ring
+
+Rather than constructing a local structure instance on the stack, fill
+the fields directly on the shared ring, just like other backends do.
+Build on the fact that all response structure flavors are actually
+identical (the old code did make this assumption too).
+
+This is XSA-216.
+
+Reported-by: Anthony Perard <anthony.perard@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+
+Index: kernel-source/drivers/block/xen-blkback/blkback.c
+===================================================================
+--- kernel-source.orig/drivers/block/xen-blkback/blkback.c
++++ kernel-source/drivers/block/xen-blkback/blkback.c
+@@ -1436,34 +1436,35 @@ static int dispatch_rw_block_io(struct x
+ static void make_response(struct xen_blkif_ring *ring, u64 id,
+ 			  unsigned short op, int st)
+ {
+-	struct blkif_response  resp;
++	struct blkif_response *resp;
+ 	unsigned long     flags;
+ 	union blkif_back_rings *blk_rings;
+ 	int notify;
+ 
+-	resp.id        = id;
+-	resp.operation = op;
+-	resp.status    = st;
+-
+ 	spin_lock_irqsave(&ring->blk_ring_lock, flags);
+ 	blk_rings = &ring->blk_rings;
+ 	/* Place on the response ring for the relevant domain. */
+ 	switch (ring->blkif->blk_protocol) {
+ 	case BLKIF_PROTOCOL_NATIVE:
+-		memcpy(RING_GET_RESPONSE(&blk_rings->native, blk_rings->native.rsp_prod_pvt),
+-		       &resp, sizeof(resp));
++		resp = RING_GET_RESPONSE(&blk_rings->native,
++					 blk_rings->native.rsp_prod_pvt);
+ 		break;
+ 	case BLKIF_PROTOCOL_X86_32:
+-		memcpy(RING_GET_RESPONSE(&blk_rings->x86_32, blk_rings->x86_32.rsp_prod_pvt),
+-		       &resp, sizeof(resp));
++		resp = RING_GET_RESPONSE(&blk_rings->x86_32,
++					 blk_rings->x86_32.rsp_prod_pvt);
+ 		break;
+ 	case BLKIF_PROTOCOL_X86_64:
+-		memcpy(RING_GET_RESPONSE(&blk_rings->x86_64, blk_rings->x86_64.rsp_prod_pvt),
+-		       &resp, sizeof(resp));
++		resp = RING_GET_RESPONSE(&blk_rings->x86_64,
++					 blk_rings->x86_64.rsp_prod_pvt);
+ 		break;
+ 	default:
+ 		BUG();
+ 	}
++
++	resp->id        = id;
++	resp->operation = op;
++	resp->status    = st;
++
+ 	blk_rings->common.rsp_prod_pvt++;
+ 	RING_PUSH_RESPONSES_AND_CHECK_NOTIFY(&blk_rings->common, notify);
+ 	spin_unlock_irqrestore(&ring->blk_ring_lock, flags);
+Index: kernel-source/drivers/block/xen-blkback/common.h
+===================================================================
+--- kernel-source.orig/drivers/block/xen-blkback/common.h
++++ kernel-source/drivers/block/xen-blkback/common.h
+@@ -75,9 +75,8 @@ extern unsigned int xenblk_max_queues;
+ struct blkif_common_request {
+ 	char dummy;
+ };
+-struct blkif_common_response {
+-	char dummy;
+-};
++
++/* i386 protocol version */
+ 
+ struct blkif_x86_32_request_rw {
+ 	uint8_t        nr_segments;  /* number of segments                   */
+@@ -129,14 +128,6 @@ struct blkif_x86_32_request {
+ 	} u;
+ } __attribute__((__packed__));
+ 
+-/* i386 protocol version */
+-#pragma pack(push, 4)
+-struct blkif_x86_32_response {
+-	uint64_t        id;              /* copied from request */
+-	uint8_t         operation;       /* copied from request */
+-	int16_t         status;          /* BLKIF_RSP_???       */
+-};
+-#pragma pack(pop)
+ /* x86_64 protocol version */
+ 
+ struct blkif_x86_64_request_rw {
+@@ -193,18 +184,12 @@ struct blkif_x86_64_request {
+ 	} u;
+ } __attribute__((__packed__));
+ 
+-struct blkif_x86_64_response {
+-	uint64_t       __attribute__((__aligned__(8))) id;
+-	uint8_t         operation;       /* copied from request */
+-	int16_t         status;          /* BLKIF_RSP_???       */
+-};
+-
+ DEFINE_RING_TYPES(blkif_common, struct blkif_common_request,
+-		  struct blkif_common_response);
++		  struct blkif_response);
+ DEFINE_RING_TYPES(blkif_x86_32, struct blkif_x86_32_request,
+-		  struct blkif_x86_32_response);
++		  struct blkif_response __packed);
+ DEFINE_RING_TYPES(blkif_x86_64, struct blkif_x86_64_request,
+-		  struct blkif_x86_64_response);
++		  struct blkif_response);
+ 
+ union blkif_back_rings {
+ 	struct blkif_back_ring        native;

--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/xsa216-qemuu-4.7.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/xsa216-qemuu-4.7.patch
@@ -1,0 +1,115 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: xen/disk: don't leak stack data via response ring
+
+Rather than constructing a local structure instance on the stack, fill
+the fields directly on the shared ring, just like other (Linux)
+backends do. Build on the fact that all response structure flavors are
+actually identical (the old code did make this assumption too).
+
+This is XSA-216.
+
+Reported-by: Anthony Perard <anthony.perard@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+Acked-by: Anthony PERARD <anthony.perard@citrix.com>
+
+Index: qemu-2.6.2/hw/block/xen_blkif.h
+===================================================================
+--- qemu-2.6.2.orig/hw/block/xen_blkif.h
++++ qemu-2.6.2/hw/block/xen_blkif.h
+@@ -12,9 +12,6 @@
+ struct blkif_common_request {
+ 	char dummy;
+ };
+-struct blkif_common_response {
+-	char dummy;
+-};
+ 
+ /* i386 protocol version */
+ #pragma pack(push, 4)
+@@ -26,13 +23,7 @@ struct blkif_x86_32_request {
+ 	blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
+ 	struct blkif_request_segment seg[BLKIF_MAX_SEGMENTS_PER_REQUEST];
+ };
+-struct blkif_x86_32_response {
+-	uint64_t        id;              /* copied from request */
+-	uint8_t         operation;       /* copied from request */
+-	int16_t         status;          /* BLKIF_RSP_???       */
+-};
+ typedef struct blkif_x86_32_request blkif_x86_32_request_t;
+-typedef struct blkif_x86_32_response blkif_x86_32_response_t;
+ #pragma pack(pop)
+ 
+ /* x86_64 protocol version */
+@@ -44,17 +35,14 @@ struct blkif_x86_64_request {
+ 	blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
+ 	struct blkif_request_segment seg[BLKIF_MAX_SEGMENTS_PER_REQUEST];
+ };
+-struct blkif_x86_64_response {
+-	uint64_t       __attribute__((__aligned__(8))) id;
+-	uint8_t         operation;       /* copied from request */
+-	int16_t         status;          /* BLKIF_RSP_???       */
+-};
+ typedef struct blkif_x86_64_request blkif_x86_64_request_t;
+-typedef struct blkif_x86_64_response blkif_x86_64_response_t;
+ 
+-DEFINE_RING_TYPES(blkif_common, struct blkif_common_request, struct blkif_common_response);
+-DEFINE_RING_TYPES(blkif_x86_32, struct blkif_x86_32_request, struct blkif_x86_32_response);
+-DEFINE_RING_TYPES(blkif_x86_64, struct blkif_x86_64_request, struct blkif_x86_64_response);
++DEFINE_RING_TYPES(blkif_common, struct blkif_common_request,
++                  struct blkif_response);
++DEFINE_RING_TYPES(blkif_x86_32, struct blkif_x86_32_request,
++                  struct blkif_response QEMU_PACKED);
++DEFINE_RING_TYPES(blkif_x86_64, struct blkif_x86_64_request,
++                  struct blkif_response);
+ 
+ union blkif_back_rings {
+ 	blkif_back_ring_t        native;
+Index: qemu-2.6.2/hw/block/xen_disk.c
+===================================================================
+--- qemu-2.6.2.orig/hw/block/xen_disk.c
++++ qemu-2.6.2/hw/block/xen_disk.c
+@@ -604,31 +604,30 @@ static int blk_send_response_one(struct
+     struct XenBlkDev  *blkdev = ioreq->blkdev;
+     int               send_notify   = 0;
+     int               have_requests = 0;
+-    blkif_response_t  resp;
+-    void              *dst;
+-
+-    resp.id        = ioreq->req.id;
+-    resp.operation = ioreq->req.operation;
+-    resp.status    = ioreq->status;
++    blkif_response_t  *resp;
+ 
+     /* Place on the response ring for the relevant domain. */
+     switch (blkdev->protocol) {
+     case BLKIF_PROTOCOL_NATIVE:
+-        dst = RING_GET_RESPONSE(&blkdev->rings.native, blkdev->rings.native.rsp_prod_pvt);
++        resp = RING_GET_RESPONSE(&blkdev->rings.native,
++                                 blkdev->rings.native.rsp_prod_pvt);
+         break;
+     case BLKIF_PROTOCOL_X86_32:
+-        dst = RING_GET_RESPONSE(&blkdev->rings.x86_32_part,
+-                                blkdev->rings.x86_32_part.rsp_prod_pvt);
++        resp = RING_GET_RESPONSE(&blkdev->rings.x86_32_part,
++                                 blkdev->rings.x86_32_part.rsp_prod_pvt);
+         break;
+     case BLKIF_PROTOCOL_X86_64:
+-        dst = RING_GET_RESPONSE(&blkdev->rings.x86_64_part,
+-                                blkdev->rings.x86_64_part.rsp_prod_pvt);
++        resp = RING_GET_RESPONSE(&blkdev->rings.x86_64_part,
++                                 blkdev->rings.x86_64_part.rsp_prod_pvt);
+         break;
+     default:
+-        dst = NULL;
+         return 0;
+     }
+-    memcpy(dst, &resp, sizeof(resp));
++
++    resp->id        = ioreq->req.id;
++    resp->operation = ioreq->req.operation;
++    resp->status    = ioreq->status;
++
+     blkdev->rings.common.rsp_prod_pvt++;
+ 
+     RING_PUSH_RESPONSES_AND_CHECK_NOTIFY(&blkdev->rings.common, send_notify);

--- a/recipes-openxt/qemu-dm/qemu-dm.inc
+++ b/recipes-openxt/qemu-dm/qemu-dm.inc
@@ -41,6 +41,7 @@ SRC_URI += "file://compile-time-stubdom-flag.patch \
             file://block-remove-unused-block-format-support.patch \
             file://net-Remove-unused-network-options.patch \
             file://xsa-197-qemu-incautious-about-shared-ring-processing.patch \
+            file://xsa216-qemuu-4.7.patch \
             file://CVE-2016-8669-char-serial-check-divider-value-against-baud-base.patch \
             file://CVE-2016-8909-audio-intel-hda-check-stream-entry-count-during-tran.patch \
             file://CVE-2016-8910-net-rtl8139-limit-processing-of-ring-descriptors.patch \


### PR DESCRIPTION
XSAs were released 2017-06-20, see https://xenbits.xen.org/xsa.

XSA-223 & XSA-225 are ARM specific, and were not ported in OpenXT
patch-queue for that reason.