### PR TITLE
OXT-1159 & OXT-1160: Attend lvm errors and warnings.

### DIFF
--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -8,6 +8,7 @@ SRC_URI = "file://initramfs-tcsd.conf \
            file://initramfs-passwd \
            file://initramfs-group \
            file://initramfs-nsswitch.conf \
+           file://initramfs-lvm.conf \
 "
 
 IMAGE_FSTYPES = "cpio.gz"
@@ -58,10 +59,11 @@ post_rootfs_shell_commands() {
 
 write_config_files() {
 	install -m 0600 -o tss -g tss ${WORKDIR}/initramfs-tcsd.conf ${IMAGE_ROOTFS}${sysconfdir}/tcsd.conf
+	chown tss:tss ${IMAGE_ROOTFS}${sysconfdir}/tcsd.conf
 	install -m 0644 ${WORKDIR}/initramfs-passwd ${IMAGE_ROOTFS}${sysconfdir}/passwd
 	install -m 0644 ${WORKDIR}/initramfs-group ${IMAGE_ROOTFS}${sysconfdir}/group
 	install -m 0644 ${WORKDIR}/initramfs-nsswitch.conf ${IMAGE_ROOTFS}${sysconfdir}/nsswitch.conf
-	chown tss:tss ${IMAGE_ROOTFS}${sysconfdir}/tcsd.conf
+	install -m 0644 ${WORKDIR}/initramfs-lvm.conf ${IMAGE_ROOTFS}/${sysconfdir}/lvm/lvm.conf
 }
 
 ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; write_config_files; "

--- a/recipes-core/images/xenclient-initramfs-image/initramfs-lvm.conf
+++ b/recipes-core/images/xenclient-initramfs-image/initramfs-lvm.conf
@@ -81,6 +81,31 @@ devices {
     md_component_detection = 1
 }
 
+# Configuration section allocation.
+# How LVM selects free space for Logical Volumes.
+allocation {
+	# Configuration option allocation/wipe_signatures_when_zeroing_new_lvs.
+	# Look for and erase any signatures while zeroing a new LV.
+	# Zeroing is controlled by the -Z/--zero option, and if not
+	# specified, zeroing is used by default if possible.
+	# Zeroing simply overwrites the first 4 KiB of a new LV
+	# with zeroes and does no signature detection or wiping.
+	# Signature wiping goes beyond zeroing and detects exact
+	# types and positions of signatures within the whole LV.
+	# It provides a cleaner LV after creation as all known
+	# signatures are wiped.  The LV is not claimed incorrectly
+	# by other tools because of old signatures from previous use.
+	# The number of signatures that LVM can detect depends on the
+	# detection code that is selected (see use_blkid_wiping.)
+	# Wiping each detected signature must be confirmed.
+	# The command line option -W/--wipesignatures takes precedence
+	# over this setting.
+	# When this setting is disabled, signatures on new LVs are
+	# not detected or erased unless the -W/--wipesignatures y
+	# option is used directly.
+	wipe_signatures_when_zeroing_new_lvs = 1
+}
+
 # This section that allows you to configure the nature of the
 # information that LVM2 reports.
 log {

--- a/recipes-core/images/xenclient-initramfs-image/initramfs-lvm.conf
+++ b/recipes-core/images/xenclient-initramfs-image/initramfs-lvm.conf
@@ -223,6 +223,41 @@ global {
 
     # Search this directory first for shared libraries.
     #   library_dir = "/lib"
+
+    # Configuration option global/use_lvmetad.
+    # Use lvmetad to cache metadata and reduce disk scanning.
+    # When enabled (and running), lvmetad provides LVM commands
+    # with VG metadata and PV state.  LVM commands then avoid
+    # reading this information from disks which can be slow.
+    # When disabled (or not running), LVM commands fall back to
+    # scanning disks to obtain VG metadata.
+    # lvmetad is kept updated via udev rules which must be set
+    # up for LVM to work correctly. (The udev rules should be
+    # installed by default.) Without a proper udev setup, changes
+    # in the system's block device configuration will be unknown
+    # to LVM, and ignored until a manual 'pvscan --cache' is run.
+    # If lvmetad was running while use_lvmetad was disabled,
+    # it must be stopped, use_lvmetad enabled, and then started.
+    # When using lvmetad, LV activation is switched to an automatic,
+    # event-based mode.  In this mode, LVs are activated based on
+    # incoming udev events that inform lvmetad when PVs appear on
+    # the system. When a VG is complete (all PVs present), it is
+    # auto-activated. The auto_activation_volume_list setting
+    # controls which LVs are auto-activated (all by default.)
+    # When lvmetad is updated (automatically by udev events, or
+    # directly by pvscan --cache), devices/filter is ignored and
+    # all devices are scanned by default. lvmetad always keeps
+    # unfiltered information which is provided to LVM commands.
+    # Each LVM command then filters based on devices/filter.
+    # This does not apply to other, non-regexp, filtering settings:
+    # component filters such as multipath and MD are checked
+    # during pvscan --cache.
+    # To filter a device and prevent scanning from the LVM system
+    # entirely, including lvmetad, use devices/global_filter.
+    # lvmetad is not compatible with locking_type 3 (clustering).
+    # LVM prints warnings and ignores lvmetad if this combination
+    # is seen.
+    use_lvmetad = 0
 }
 
 activation {

--- a/recipes-support/lvm2/lvm2/lvm.conf
+++ b/recipes-support/lvm2/lvm2/lvm.conf
@@ -81,6 +81,31 @@ devices {
     md_component_detection = 1
 }
 
+# Configuration section allocation.
+# How LVM selects free space for Logical Volumes.
+allocation {
+	# Configuration option allocation/wipe_signatures_when_zeroing_new_lvs.
+	# Look for and erase any signatures while zeroing a new LV.
+	# Zeroing is controlled by the -Z/--zero option, and if not
+	# specified, zeroing is used by default if possible.
+	# Zeroing simply overwrites the first 4 KiB of a new LV
+	# with zeroes and does no signature detection or wiping.
+	# Signature wiping goes beyond zeroing and detects exact
+	# types and positions of signatures within the whole LV.
+	# It provides a cleaner LV after creation as all known
+	# signatures are wiped.  The LV is not claimed incorrectly
+	# by other tools because of old signatures from previous use.
+	# The number of signatures that LVM can detect depends on the
+	# detection code that is selected (see use_blkid_wiping.)
+	# Wiping each detected signature must be confirmed.
+	# The command line option -W/--wipesignatures takes precedence
+	# over this setting.
+	# When this setting is disabled, signatures on new LVs are
+	# not detected or erased unless the -W/--wipesignatures y
+	# option is used directly.
+	wipe_signatures_when_zeroing_new_lvs = 1
+}
+
 # This section that allows you to configure the nature of the
 # information that LVM2 reports.
 log {


### PR DESCRIPTION
- commit https://github.com/OpenXT/xenclient-oe/commit/a9f50f4b39ada135f65f6cb4b2e3f2b1583d22cb failed to have the expected initscript installed.
- Avoid using lvmetad during early-boot (initramfs).
- Add wipe_signatures_when_zeroing_new_lvs = 1 to lvm.conf to wipe the detected signatures on created lvs when zeroing (default).