### PR TITLE
STABLE-6: OXT-1161: updatemgr: SELinux perms to read ssl certs files.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/updatemgr.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/updatemgr.te
@@ -84,3 +84,5 @@ allow updatemgr_t self:capability { dac_override chown fowner fsetid };
 
 kernel_request_load_module(updatemgr_t)
 
+# openssl need to check certificates.
+miscfiles_read_generic_certs(updatemgr_t)


### PR DESCRIPTION
Authorize updatemgr to read certificates and configuration required for
openssl.