### PR TITLE
STABLE-7: OXT-1164: xen-libxl: Install xl.conf.

### DIFF
--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -102,4 +102,7 @@ do_install() {
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${WORKDIR}/xen-init-dom0.initscript \
                     ${D}${sysconfdir}/init.d/xen-init-dom0
+    install -d ${D}${sysconfdir}/xen
+    install -m 0644 ${WORKDIR}/xl.conf \
+                    ${D}${sysconfdir}/xen/xl.conf
 }


### PR DESCRIPTION
The dummy configuration file is not installed.
Amend that to silence:
Failed to read config file: /etc/xen/xl.conf: No such file or directory

Origin: https://github.com/OpenXT/xenclient-oe/pull/702