### PR TITLE
STABLE-7: [libxl] Ignore dead domains in uuid_to_domid

### DIFF
--- a/recipes-extended/xen/files/libxl-fixup-cmdline-ops.patch
+++ b/recipes-extended/xen/files/libxl-fixup-cmdline-ops.patch
@@ -127,7 +127,7 @@ Index: xen-4.6.5/tools/libxl/libxl_utils.c
 +
 +    for (i = 0; i < nb_domains; i++) {
 +        uuid = dominfo[i].uuid;
-+        if (libxl_uuid_compare(&uuid, &uuid2) == 0) {
++        if (libxl_uuid_compare(&uuid, &uuid2) == 0 && libxl_domid_to_name(ctx, dominfo[i].domid)) {
 +            *domid = dominfo[i].domid;
 +            ret = 0;
 +            break;


### PR DESCRIPTION
  When a domain crashes and for some reason its resources can't
  be released, xl lists it as (null). This is similar to xenvm
  and the deadbeef uuids. Since they still have a domid, xenmgr
  gets hung up on them, preventing that guest from booting again
  until a host reset.

  This patch will ignore the dead domain when xenmgr asks for a
  domid, providing better fault tolerance and allow the platform
  to continue to be usable.

  OXT-1176

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>