### PR TITLE
Update measured launch status checks

### DIFF
--- a/recipes-openxt/openxt/openxt-measuredlaunch/recovery-method
+++ b/recipes-openxt/openxt/openxt-measuredlaunch/recovery-method
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+config=${1:-"/dev/xenclient/config"}
+
+if [ ! -e "${config}" ]; then
+	echo "Unable to locate config volume: ${config}"
+	exit 1
+fi
+
+slot7=$(cryptsetup luksDump "${config}"|grep 'Slot 7'|awk '{ print $4 }')
+
+case $slot7 in
+ENABLED)
+	echo "System is using legacy recovery key scheme"
+;;
+DISABLED)
+	echo "System is using new recovery key scheme"
+;;
+*)
+	echo "Unable to determine recovery key scheme"
+;;
+esac

--- a/recipes-openxt/openxt/openxt-measuredlaunch_1.0.bb
+++ b/recipes-openxt/openxt/openxt-measuredlaunch_1.0.bb
@@ -7,11 +7,13 @@ inherit xenclient
 SRC_URI = " \
     file://ml-functions \
     file://seal-system \
+    file://recovery-method \
 "
 
 FILES_${PN} = "\
     ${libdir}/openxt/ml-functions \
     ${sbindir}/seal-system \
+    ${sbindir}/recovery-method \
     "
 
 do_install() {
@@ -19,6 +21,7 @@ do_install() {
     install -d ${D}${sbindir}
     install -m 0755 ${WORKDIR}/ml-functions ${D}${libdir}/openxt
     install -m 0755 ${WORKDIR}/seal-system ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/recovery-method ${D}${sbindir}
 }
 
 RDEPENDS_${PN} = " \

--- a/recipes-openxt/xenclient/xenclient-pcrdiff/pcr-data
+++ b/recipes-openxt/xenclient/xenclient-pcrdiff/pcr-data
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
+# Copyright (c) 2017 Daniel P. Smith
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +25,7 @@
 ROOT="${1}"
 tmp_dir="$(mktemp -dt pcrs-XXXXX)/pcr-info"
 PCRS_BAD_FILE="bad.pcrs"
-PCRS_BAD_SRC="${ROOT}/storage/${PCRS_BAD_FILE}"
+PCRS_BAD_SRC="${ROOT}/boot/system/tpm/${PCRS_BAD_FILE}"
 PCRS_BAD_DST="${tmp_dir}/${PCRS_BAD_FILE}"
 PCRS_GOOD_FILE="good.pcrs"
 PCRS_GOOD_SRC="${ROOT}/config/${PCRS_GOOD_FILE}"

--- a/recipes-openxt/xenclient/xenclient-pcrdiff/pcr-state
+++ b/recipes-openxt/xenclient/xenclient-pcrdiff/pcr-state
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
+# Copyright (c) 2017 Daniel P. Smith
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +24,7 @@
 
 ROOT="${1}"
 PCRS_BAD_FILE="bad.pcrs"
-PCRS_BAD_SRC="${ROOT}/storage/${PCRS_BAD_FILE}"
+PCRS_BAD_SRC="${ROOT}/boot/system/tpm/${PCRS_BAD_FILE}"
 PCRS_CFG="${ROOT}/config/config.pcrs"
 PCRS_GOOD_FILE="good.pcrs"
 PCRS_GOOD_SRC="${ROOT}/config/${PCRS_GOOD_FILE}"


### PR DESCRIPTION
This fixes the existing pcrdiff utils to provide reports on PCR changes and adds a utility to report the recovery key scheme that is in use on the device.

OXT-1062

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>
