### PR TITLE
OXT-1189: fix libxl memory corruption from string handling in disk crypto dir patch

### DIFF
--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -1,18 +1,22 @@
 ################################################################################
 SHORT DESCRIPTION:
 ################################################################################
+Libxl support for passing a crypto key directory for a guest VM's disk(s).
+If absent, defaults to an OpenXT-specific "/config/platform-crypto-keys".
 
 ################################################################################
 LONG DESCRIPTION:
 ################################################################################
-Support passing a crypto key directory for a guest's disk(s). Otherwise uses
-platform default path
+Plumb "crypto_key_dir" through the toolstack to set TAPDISK2_CRYPTO_KEYDIR env.
 
 ################################################################################
 CHANGELOG
 ################################################################################
 Authors:
 Chris Rogers <rogersc@ainfosec.com>
+
+Revised by:
+Christopher Clark <christopher.clark6@baesystems.com>
 
 ################################################################################
 REMOVAL
@@ -21,6 +25,22 @@ REMOVAL
 ################################################################################
 UPSTREAM PLAN
 ################################################################################
+
+* The hardcoded filesystem path "/config/platform-crypto-keys" will need to be
+  removed from this libxl patch.
+
+* Review whether a crypto key directory per disk, rather than just per VM, is
+  the correct design.
+
+  The device_disk struct is used widely within libxl for various types of disks,
+  so modifying it requires care to ensure that all other sections of code
+  using it continue to be correct.
+    eg. This patch does not add support for reading the new crypto_key_dir data
+        member from a serialized disk config, which may be inconsistent with
+        the way other members of the struct are managed.
+
+  Adding crypto_key_dir to the disk struct is, however, a convenient way of
+  plumbing the data through to the site where it is used.
 
 ################################################################################
 INTERNAL DEPENDENCIES
@@ -33,7 +53,7 @@ Index: xen-4.6.6/tools/libxl/libxl.c
 ===================================================================
 --- xen-4.6.6.orig/tools/libxl/libxl.c
 +++ xen-4.6.6/tools/libxl/libxl.c
-@@ -2586,7 +2586,7 @@ static void device_disk_add(libxl__egc *
+@@ -2586,7 +2586,7 @@ static void device_disk_add(libxl__egc *egc, uint32_t domid,
              case LIBXL_DISK_BACKEND_TAP:
                  if (dev == NULL) {
                      dev = libxl__blktap_devpath(gc, disk->pdev_path,
@@ -42,6 +62,15 @@ Index: xen-4.6.6/tools/libxl/libxl.c
                      if (!dev) {
                          LOG(ERROR, "failed to get blktap devpath for %p",
                              disk->pdev_path);
+@@ -3181,6 +3181,8 @@ void libxl__device_disk_local_initiate_attach(libxl__egc *egc,
+     if (in_disk->script != NULL)
+         disk->script = libxl__strdup(gc, in_disk->script);
+     disk->vdev = NULL;
++    if (in_disk->crypto_key_dir != NULL)
++        disk->crypto_key_dir = libxl__strdup(gc, in_disk->crypto_key_dir);
+ 
+     rc = libxl__device_disk_setdefault(gc, disk);
+     if (rc) goto out;
 Index: xen-4.6.6/tools/libxl/libxl_blktap2.c
 ===================================================================
 --- xen-4.6.6.orig/tools/libxl/libxl_blktap2.c
@@ -52,18 +81,18 @@ Index: xen-4.6.6/tools/libxl/libxl_blktap2.c
                              const char *disk,
 -                            libxl_disk_format format)
 +                            libxl_disk_format format,
-+							char *keydir)
++                            char *keydir)
  {
      const char *type;
      char *params, *devname = NULL;
-@@ -40,6 +41,11 @@ char *libxl__blktap_devpath(libxl__gc *g
+@@ -40,6 +41,11 @@ char *libxl__blktap_devpath(libxl__gc *gc,
              return devname;
      }
  
-+	if(!keydir || !strcmp(keydir, ""))
-+	    setenv("TAPDISK2_CRYPTO_KEYDIR", "/config/platform-crypto-keys", 1);
-+	else
-+		setenv("TAPDISK2_CRYPTO_KEYDIR", keydir, 1);
++    if (!keydir || !strncmp(keydir, "", 1))
++        setenv("TAPDISK2_CRYPTO_KEYDIR", "/config/platform-crypto-keys", 1);
++    else
++        setenv("TAPDISK2_CRYPTO_KEYDIR", keydir, 1);
 +
      params = libxl__sprintf(gc, "%s:%s", type, disk);
      err = tap_ctl_create(params, &devname);
@@ -99,17 +128,17 @@ Index: xen-4.6.6/tools/libxl/libxl_types.idl
 ===================================================================
 --- xen-4.6.6.orig/tools/libxl/libxl_types.idl
 +++ xen-4.6.6/tools/libxl/libxl_types.idl
-@@ -432,6 +432,9 @@ libxl_domain_build_info = Struct("domain
+@@ -432,6 +432,9 @@ libxl_domain_build_info = Struct("domain_build_info",[
      ("cpuid",           libxl_cpuid_policy_list),
      ("blkdev_start",    string),
  
-+	#directory containing the crypto keys for the vm's disks
-+	("crypto_key_dir", string),
++    # directory containing the crypto keys for the VM's disks
++    ("crypto_key_dir", string),
 +
      ("vnuma_nodes", Array(libxl_vnode_info, "num_vnuma_nodes")),
      
      ("device_model_version", libxl_device_model_version),
-@@ -565,6 +568,7 @@ libxl_device_disk = Struct("device_disk"
+@@ -565,6 +568,7 @@ libxl_device_disk = Struct("device_disk", [
      ("is_cdrom", integer),
      ("direct_io_safe", bool),
      ("discard_enable", libxl_defbool),
@@ -121,26 +150,25 @@ Index: xen-4.6.6/tools/libxl/xl_cmdimpl.c
 ===================================================================
 --- xen-4.6.6.orig/tools/libxl/xl_cmdimpl.c
 +++ xen-4.6.6/tools/libxl/xl_cmdimpl.c
-@@ -1480,6 +1480,9 @@ static void parse_config_data(const char
+@@ -1480,6 +1480,7 @@ static void parse_config_data(const char *config_source,
      if (!xlu_cfg_get_long(config, "max_event_channels", &l, 0))
          b_info->event_channels = l;
  
-+	if (!xlu_cfg_get_string (config, "crypto_key_dir", &buf, 0))
-+		xlu_cfg_replace_string(config, "crypto_key_dir", &b_info->crypto_key_dir, 0);
-+
++    xlu_cfg_replace_string (config, "crypto_key_dir", &b_info->crypto_key_dir, 0);
      xlu_cfg_replace_string (config, "kernel", &b_info->kernel, 0);
      xlu_cfg_replace_string (config, "ramdisk", &b_info->ramdisk, 0);
      xlu_cfg_replace_string (config, "device_tree", &b_info->device_tree, 0);
-@@ -1789,6 +1792,12 @@ static void parse_config_data(const char
-                                              d_config->num_disks,
-                                              libxl_device_disk_init);
+@@ -1791,6 +1792,13 @@ static void parse_config_data(const char *config_source,
              parse_disk_config(&config, buf2, disk);
-+            if(d_config->b_info.crypto_key_dir && strcmp(d_config->b_info.crypto_key_dir, "")) {
-+                disk->crypto_key_dir = malloc(sizeof(char) * strlen(d_config->b_info.crypto_key_dir));
-+                strcpy(disk->crypto_key_dir, d_config->b_info.crypto_key_dir);
+ 
+             free(buf2);
++
++            if (d_config->b_info.crypto_key_dir) {
++                replace_string(&disk->crypto_key_dir,
++                               d_config->b_info.crypto_key_dir);
 +            } else {
 +                disk->crypto_key_dir = NULL;
 +            }
- 
-             free(buf2);
          }
+     }
+ 


### PR DESCRIPTION
Fixes toolstack memory corruption when parsing VM configuration data and during disk attach.

* Don't omit the string termination character in length calculations, especially when allocating a buffer to be immediately overwritten.
* Don't ignore the string handling functions already provided.
* Make the existing code that performs a deep struct copy also duplicate the new string that was added to the struct.
* Prefer the length-constrained string functions. eg. strncmp rather than strcmp.
* Respect the formatting conventions of the code being patched.
* Add notes relevant for upstreaming to the patch.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>