### PR TITLE
OXT-1191: glibc: CVE-2017-1000366

### DIFF
--- a/recipes-core/glibc/glibc_2.22.bbappend
+++ b/recipes-core/glibc/glibc_2.22.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+SRC_URI += " \
+    file://CVE-2017-1000366.patch \
+"

--- a/recipes-core/glibc/patches/CVE-2017-1000366.patch
+++ b/recipes-core/glibc/patches/CVE-2017-1000366.patch
@@ -1,0 +1,45 @@
+From f6110a8fee2ca36f8e2d2abecf3cba9fa7b8ea7d Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Mon, 19 Jun 2017 17:09:55 +0200
+Subject: [PATCH] CVE-2017-1000366: Ignore LD_LIBRARY_PATH for AT_SECURE=1
+ programs [BZ #21624]
+
+LD_LIBRARY_PATH can only be used to reorder system search paths, which
+is not useful functionality.
+
+This makes an exploitable unbounded alloca in _dl_init_paths unreachable
+for AT_SECURE=1 programs.
+---
+ ChangeLog  | 7 +++++++
+ elf/rtld.c | 3 ++-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+Index: git/ChangeLog
+===================================================================
+--- git.orig/ChangeLog
++++ git/ChangeLog
+@@ -1,3 +1,10 @@
++2017-06-19  Florian Weimer  <fweimer@redhat.com>
++
++	[BZ #21624]
++	CVE-2017-1000366
++	* elf/rtld.c (process_envvars): Ignore LD_LIBRARY_PATH for
++	__libc_enable_secure.
++
+ 2016-05-23  Florian Weimer  <fweimer@redhat.com>
+ 
+    CVE-2016-4429
+Index: git/elf/rtld.c
+===================================================================
+--- git.orig/elf/rtld.c
++++ git/elf/rtld.c
+@@ -2443,7 +2443,8 @@ process_envvars (enum mode *modep)
+ 
+ 	case 12:
+ 	  /* The library search path.  */
+-	  if (memcmp (envline, "LIBRARY_PATH", 12) == 0)
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "LIBRARY_PATH", 12) == 0)
+ 	    {
+ 	      library_path = &envline[13];
+ 	      break;


### PR DESCRIPTION
Backport upstream patch:
f6110a8fee CVE-2017-1000366: Ignore LD_LIBRARY_PATH for AT_SECURE=1 programs [BZ #21624]