### PR TITLE
OXT-1199: SELinux AVCs during OTA upgrade.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.system.mount.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.system.mount.diff
@@ -2,11 +2,12 @@ Index: refpolicy/policy/modules/system/mount.te
 ===================================================================
 --- refpolicy.orig/policy/modules/system/mount.te
 +++ refpolicy/policy/modules/system/mount.te
-@@ -83,6 +83,12 @@ dev_dontaudit_getattr_memory_dev(mount_t
+@@ -83,6 +83,13 @@ dev_dontaudit_getattr_memory_dev(mount_t
  dev_getattr_sound_dev(mount_t)
  # Early devtmpfs, before udev relabel
  dev_dontaudit_rw_generic_chr_files(mount_t)
 +dev_getattr_generic_blk_files(mount_t)
++dev_getattr_fs(mount_t)
 +
 +xen_dontaudit_rw_unix_stream_sockets(mount_t)
 +files_read_mnt_symlinks(mount_t)
@@ -15,7 +16,7 @@ Index: refpolicy/policy/modules/system/mount.te
  
  domain_use_interactive_fds(mount_t)
  
-@@ -103,6 +109,7 @@ files_dontaudit_write_all_mountpoints(mo
+@@ -103,6 +110,7 @@ files_dontaudit_write_all_mountpoints(mo
  files_dontaudit_setattr_all_mountpoints(mount_t)
  
  fs_getattr_xattr_fs(mount_t)
@@ -23,7 +24,7 @@ Index: refpolicy/policy/modules/system/mount.te
  fs_getattr_cifs(mount_t)
  fs_mount_all_fs(mount_t)
  fs_unmount_all_fs(mount_t)
-@@ -112,10 +119,14 @@ fs_rw_tmpfs_chr_files(mount_t)
+@@ -112,10 +120,14 @@ fs_rw_tmpfs_chr_files(mount_t)
  fs_read_tmpfs_symlinks(mount_t)
  fs_dontaudit_write_tmpfs_dirs(mount_t)
  
@@ -38,7 +39,7 @@ Index: refpolicy/policy/modules/system/mount.te
  
  storage_raw_read_fixed_disk(mount_t)
  storage_raw_write_fixed_disk(mount_t)
-@@ -142,6 +153,11 @@ seutil_read_config(mount_t)
+@@ -142,6 +154,11 @@ seutil_read_config(mount_t)
  
  userdom_use_all_users_fds(mount_t)
  
@@ -50,7 +51,7 @@ Index: refpolicy/policy/modules/system/mount.te
  ifdef(`distro_redhat',`
  	optional_policy(`
  		auth_read_pam_console_data(mount_t)
-@@ -219,7 +235,6 @@ optional_policy(`
+@@ -219,7 +236,6 @@ optional_policy(`
  optional_policy(`
  	samba_run_smbmount(mount_t, mount_roles)
  ')
@@ -58,7 +59,7 @@ Index: refpolicy/policy/modules/system/mount.te
  ########################################
  #
  # Unconfined mount local policy
-@@ -228,4 +243,11 @@ optional_policy(`
+@@ -228,4 +244,11 @@ optional_policy(`
  optional_policy(`
  	files_etc_filetrans_etc_runtime(unconfined_mount_t, file)
  	unconfined_domain(unconfined_mount_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.system.mount.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/policy.modules.system.mount.diff
@@ -15,7 +15,15 @@ Index: refpolicy/policy/modules/system/mount.te
  
  domain_use_interactive_fds(mount_t)
  
-@@ -112,10 +118,14 @@ fs_rw_tmpfs_chr_files(mount_t)
+@@ -103,6 +109,7 @@ files_dontaudit_write_all_mountpoints(mo
+ files_dontaudit_setattr_all_mountpoints(mount_t)
+ 
+ fs_getattr_xattr_fs(mount_t)
++fs_getattr_tmpfs(mount_t)
+ fs_getattr_cifs(mount_t)
+ fs_mount_all_fs(mount_t)
+ fs_unmount_all_fs(mount_t)
+@@ -112,10 +119,14 @@ fs_rw_tmpfs_chr_files(mount_t)
  fs_read_tmpfs_symlinks(mount_t)
  fs_dontaudit_write_tmpfs_dirs(mount_t)
  
@@ -30,7 +38,7 @@ Index: refpolicy/policy/modules/system/mount.te
  
  storage_raw_read_fixed_disk(mount_t)
  storage_raw_write_fixed_disk(mount_t)
-@@ -142,6 +152,11 @@ seutil_read_config(mount_t)
+@@ -142,6 +153,11 @@ seutil_read_config(mount_t)
  
  userdom_use_all_users_fds(mount_t)
  
@@ -42,7 +50,7 @@ Index: refpolicy/policy/modules/system/mount.te
  ifdef(`distro_redhat',`
  	optional_policy(`
  		auth_read_pam_console_data(mount_t)
-@@ -219,7 +234,6 @@ optional_policy(`
+@@ -219,7 +235,6 @@ optional_policy(`
  optional_policy(`
  	samba_run_smbmount(mount_t, mount_roles)
  ')
@@ -50,7 +58,7 @@ Index: refpolicy/policy/modules/system/mount.te
  ########################################
  #
  # Unconfined mount local policy
-@@ -228,4 +242,11 @@ optional_policy(`
+@@ -228,4 +243,11 @@ optional_policy(`
  optional_policy(`
  	files_etc_filetrans_etc_runtime(unconfined_mount_t, file)
  	unconfined_domain(unconfined_mount_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/updatemgr-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/updatemgr-interfaces.diff
@@ -45,7 +45,7 @@ Index: refpolicy/policy/modules/system/lvm.te
 ===================================================================
 --- refpolicy.orig/policy/modules/system/lvm.te
 +++ refpolicy/policy/modules/system/lvm.te
-@@ -405,3 +405,9 @@ optional_policy(`
+@@ -405,3 +405,10 @@ optional_policy(`
  	xc_read_vhd_key_files(lvm_t)
  	xc_search_vhd_key_dirs(lvm_t)
  ')
@@ -54,6 +54,7 @@ Index: refpolicy/policy/modules/system/lvm.te
 +	updatemgr_dontaudit_use_fd(lvm_t)
 +	updatemgr_dontaudit_rw_fifo_files(lvm_t)
 +	updatemgr_dontaudit_rw_stream_sockets(lvm_t)
++	updatemgr_dontaudit_search_storage(lvm_t)
 +')
 Index: refpolicy/policy/modules/system/mount.te
 ===================================================================

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/xc-installer-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/patches/xc-installer-interfaces.diff
@@ -2,9 +2,9 @@ Index: refpolicy/policy/modules/system/lvm.te
 ===================================================================
 --- refpolicy.orig/policy/modules/system/lvm.te
 +++ refpolicy/policy/modules/system/lvm.te
-@@ -413,4 +413,5 @@ optional_policy(`
- 	updatemgr_dontaudit_use_fd(lvm_t)
+@@ -414,4 +414,5 @@ optional_policy(`
  	updatemgr_dontaudit_rw_fifo_files(lvm_t)
  	updatemgr_dontaudit_rw_stream_sockets(lvm_t)
+ 	updatemgr_dontaudit_search_storage(lvm_t)
 +	xc_installer_read_tmp_files(lvm_t)
  ')

--- a/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/updatemgr.if
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.20141203/policy/modules/services/updatemgr.if
@@ -110,6 +110,23 @@ interface(`updatemgr_search_storage',`
 ')
 ########################################
 ## <summary>
+##	Dontaudit search through the updatemgr storage directory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`updatemgr_dontaudit_search_storage',`
+	gen_require(`
+		type updatemgr_storage_t;
+	')
+
+	dontaudit $1 updatemgr_storage_t:dir search_dir_perms;
+')
+########################################
+## <summary>
 ##	Create an object in the XC updatemgr directory with a private type.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
- Allow mount to stat tmpfs,
- don't audit lvcreate search in updatemgr storage,
- allow mount to getattr on filesystem devices.