### PR TITLE
layer: Add busybox to RDEPENDS (/bin/ash provider)

### DIFF
--- a/recipes-openxt/xenclient/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient/xenclient-installer_git.bb
@@ -1,9 +1,6 @@
 DESCRIPTION = "XenClient Installer"
-RDEPENDS_${PN} = "xenclient-eula xenclient-keyboard-list xenclient-repo-certs xenclient-caps"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
-
-inherit xenclient
 
 PV = "0+git${SRCPV}"
 
@@ -13,10 +10,21 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/installer.git;protocol=${OPENXT_GIT_PROTOC
 
 S = "${WORKDIR}/git"
 
+inherit xenclient
+
 PACKAGES += "${PN}-part2"
 
 FILES_${PN} = "/install/*"
 FILES_${PN}-part2 = "/*"
+
+RDEPENDS_${PN} = " \
+    busybox \
+    xenclient-eula \
+    xenclient-keyboard-list \
+    xenclient-repo-certs \
+    xenclient-caps \
+"
+RDEPENDS_${PN}-part2 += "busybox"
 
 do_install () {
     ${S}/install part1 ${D}/install


### PR DESCRIPTION
Scripts using /bin/ash rely on busybox to provide it.

Silence the following QA warnings:
WARNING: QA Issue: /install/part1/stages/Iscsi-confirm-repo_xenclient-installer contained in package xenclient-installer requires /bin/ash, but no providers found in its RDEPENDS [file-rdeps]
WARNING: QA Issue: /stages/TPM-BadSrk_xenclient-installer-part2 contained in package xenclient-installer-part2 requires /bin/ash, but no providers found in its RDEPENDS [file-rdeps]

Arrange the recipe to be more in compliance with:
https://www.openembedded.org/wiki/Styleguide
