### PR TITLE
libxl-iso-hotswap: "physical-device" is hex, not dec

### DIFF
--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -184,7 +184,7 @@ Index: xen-4.9.0/tools/libxl/libxl_disk.c
 +        xs_set_permissions(ctx->xsh, t, be_path, roperm, ARRAY_SIZE(roperm));
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/params", be_path), "%s", devpath);
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/type", be_path), "%s", "phy");
-+        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/physical-device", be_path), "fe:%d", libxl__get_tap_minor(gc, LIBXL_DISK_FORMAT_EMPTY, iso));
++        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/physical-device", be_path), "fe:%x", libxl__get_tap_minor(gc, LIBXL_DISK_FORMAT_EMPTY, iso));
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/frontend", be_path), "%s", fe_path);
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/device-type", be_path), "%s", "cdrom");
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/online", be_path), "%s", "1");


### PR DESCRIPTION
OXT-1138

Signed-off-by: Jed <lejosnej@ainfosec.com>