### PR TITLE
base-passwd: use /bin/false instead of /bin/sh for system users

### DIFF
--- a/recipes-core/base-passwd/base-passwd_3.%.bbappend
+++ b/recipes-core/base-passwd/base-passwd_3.%.bbappend
@@ -1,0 +1,4 @@
+do_install_append() {
+	# Change the shell to false for everybody but root
+	sed -i '/^root:/b; s#^\(.*\):/bin/sh$#\1:/bin/false#' ${D}${datadir}/base-passwd/passwd.master
+}


### PR DESCRIPTION
OXT-836

Signed-off-by: Jed <lejosnej@ainfosec.com>