### PR TITLE
xen: remove patch-patching in libxl-xenmgr-support and libxl-domain-state

### DIFF
--- a/recipes-extended/xen/files/libxl-domain-state.patch
+++ b/recipes-extended/xen/files/libxl-domain-state.patch
@@ -38,15 +38,19 @@ Index: xen-4.9.0/tools/libxl/libxl_create.c
 ===================================================================
 --- xen-4.9.0.orig/tools/libxl/libxl_create.c
 +++ xen-4.9.0/tools/libxl/libxl_create.c
-@@ -918,6 +918,8 @@ static void initiate_domain_create(libxl
-         goto error_out;
-     }
- 
-+     libxl_update_state(ctx, domid, "creating-devices");
+@@ -954,6 +954,12 @@ static void initiate_domain_create(libxl__egc *egc,
+     dcs->sdss.dm.guest_domid = 0; /* means we haven't spawned */
+
+     /*
++     * OpenXT: XenMgr synchronizes with this state change to apply the v4v
++     * firewall rules and requires it to occur after libxl__domain_make(..).
++     */
++    libxl_update_state(ctx, domid, "creating-devices");
 +
-     ret = libxl__domain_build_info_setdefault(gc, &d_config->b_info);
-     if (ret) {
-         LOGD(ERROR, domid, "Unable to set domain build info defaults");
++    /*
+      * Set the dm version quite early so that libxl doesn't have to pass the
+      * build info around just to know if the domain has a device model or not.
+      */
 Index: xen-4.9.0/tools/libxl/libxl_dom_suspend.c
 ===================================================================
 --- xen-4.9.0.orig/tools/libxl/libxl_dom_suspend.c

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -111,28 +111,6 @@ Index: xen-4.9.0/tools/libxl/libxl_create.c
      xs_write(ctx->xsh, t, GCSPRINTF("%s/control/platform-feature-multiprocessor-suspend", dom_path), "1", 1);
      xs_write(ctx->xsh, t, GCSPRINTF("%s/control/platform-feature-xs_reset_watches", dom_path), "1", 1);
      if (!xs_transaction_end(ctx->xsh, t, 0)) {
-@@ -918,8 +942,6 @@ static void initiate_domain_create(libxl
-         goto error_out;
-     }
- 
--     libxl_update_state(ctx, domid, "creating-devices");
--
-     ret = libxl__domain_build_info_setdefault(gc, &d_config->b_info);
-     if (ret) {
-         LOGD(ERROR, domid, "Unable to set domain build info defaults");
-@@ -956,6 +978,12 @@ static void initiate_domain_create(libxl
-     dcs->sdss.dm.guest_domid = 0; /* means we haven't spawned */
- 
-     /*
-+     * OpenXT: XenMgr synchronizes with this state change to apply the v4v
-+     * firewall rules and requires it to occur after libxl__domain_make(..).
-+     */
-+    libxl_update_state(ctx, domid, "creating-devices");
-+
-+    /*
-      * Set the dm version quite early so that libxl doesn't have to pass the
-      * build info around just to know if the domain has a device model or not.
-      */
 @@ -1358,7 +1386,6 @@ static void domcreate_launch_dm(libxl__e
      {
          libxl__device_console console;


### PR DESCRIPTION
The most recent version of libxl-xenmgr-support.patch included hunks that
revised code introduced in libxl-domain-state.patch. This commit corrects that
by updating libxl-domain-state.patch with the intended final code and removing
the amend hunks from libxl-xenmgr-support.patch.

No code change to the end result of applying the patch queue,
just tidier patches.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>