### PR TITLE
OXT-1216: xen: XSA-226 v7

### DIFF
--- a/recipes-extended/xen/files/xsa226-4.9/0001-gnttab-dont-use-possibly-unbounded-tail-calls.patch
+++ b/recipes-extended/xen/files/xsa226-4.9/0001-gnttab-dont-use-possibly-unbounded-tail-calls.patch
@@ -16,11 +16,28 @@ This is part of CVE-2017-12135 / XSA-226.
 
 Signed-off-by: Jan Beulich <jbeulich@suse.com>
 
+Index: xen-4.9.0/xen/common/compat/grant_table.c
+===================================================================
+--- xen-4.9.0.orig/xen/common/compat/grant_table.c
++++ xen-4.9.0/xen/common/compat/grant_table.c
+@@ -258,9 +258,9 @@ int compat_grant_table_op(unsigned int c
+                 rc = gnttab_copy(guest_handle_cast(nat.uop, gnttab_copy_t), n);
+             if ( rc > 0 )
+             {
+-                ASSERT(rc < n);
+-                i -= n - rc;
+-                n = rc;
++                ASSERT(rc <= n);
++                i -= rc;
++                n -= rc;
+             }
+             if ( rc >= 0 )
+             {
 Index: xen-4.9.0/xen/common/grant_table.c
 ===================================================================
---- xen-4.9.0.orig/xen/common/grant_table.c	2017-08-28 13:44:38.757885014 -0400
-+++ xen-4.9.0/xen/common/grant_table.c	2017-08-28 13:45:48.090238833 -0400
-@@ -2086,8 +2086,10 @@
+--- xen-4.9.0.orig/xen/common/grant_table.c
++++ xen-4.9.0/xen/common/grant_table.c
+@@ -2086,8 +2086,10 @@ __release_grant_for_copy(
  
      if ( td != rd )
      {
@@ -33,7 +50,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
          if ( released_write )
              __release_grant_for_copy(td, trans_gref, 0);
          else if ( released_read )
-@@ -2238,10 +2240,11 @@
+@@ -2238,10 +2240,11 @@ __acquire_grant_for_copy(
                  return rc;
              }
  
@@ -49,7 +66,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
              if ( act->pin != old_pin )
              {
                  __fixup_status_for_copy_pin(act, status);
-@@ -2249,9 +2252,8 @@
+@@ -2249,9 +2252,8 @@ __acquire_grant_for_copy(
                  active_entry_release(act);
                  grant_read_unlock(rgt);
                  put_page(*page);
@@ -61,7 +78,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
              }
  
              /* The actual remote remote grant may or may not be a
-@@ -2557,7 +2559,7 @@
+@@ -2557,7 +2559,7 @@ static int gnttab_copy_one(const struct
      {
          gnttab_copy_release_buf(src);
          rc = gnttab_copy_claim_buf(op, &op->source, src, GNTCOPY_source_gref);
@@ -70,7 +87,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
              goto out;
      }
  
-@@ -2567,7 +2569,7 @@
+@@ -2567,7 +2569,7 @@ static int gnttab_copy_one(const struct
      {
          gnttab_copy_release_buf(dest);
          rc = gnttab_copy_claim_buf(op, &op->dest, dest, GNTCOPY_dest_gref);
@@ -79,7 +96,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
              goto out;
      }
  
-@@ -2576,6 +2578,14 @@
+@@ -2576,6 +2578,14 @@ static int gnttab_copy_one(const struct
      return rc;
  }
  
@@ -94,7 +111,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
  static long gnttab_copy(
      XEN_GUEST_HANDLE_PARAM(gnttab_copy_t) uop, unsigned int count)
  {
-@@ -2589,7 +2599,7 @@
+@@ -2589,7 +2599,7 @@ static long gnttab_copy(
      {
          if ( i && hypercall_preempt_check() )
          {
@@ -103,7 +120,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
              break;
          }
  
-@@ -2599,13 +2609,20 @@
+@@ -2599,13 +2609,20 @@ static long gnttab_copy(
              break;
          }
  
@@ -126,7 +143,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
          if ( unlikely(__copy_field_to_guest(uop, &op, status)) )
          {
              rc = -EFAULT;
-@@ -3143,6 +3160,7 @@
+@@ -3143,6 +3160,7 @@ do_grant_table_op(
          rc = gnttab_copy(copy, count);
          if ( rc > 0 )
          {

--- a/recipes-extended/xen/files/xsa226-4.9/0002-gnttab-fix-transitive-grant-handling.patch
+++ b/recipes-extended/xen/files/xsa226-4.9/0002-gnttab-fix-transitive-grant-handling.patch
@@ -22,9 +22,9 @@ Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
 
 Index: xen-4.9.0/xen/common/grant_table.c
 ===================================================================
---- xen-4.9.0.orig/xen/common/grant_table.c	2017-08-28 13:45:48.090238833 -0400
-+++ xen-4.9.0/xen/common/grant_table.c	2017-08-28 13:45:52.580175407 -0400
-@@ -2033,13 +2033,8 @@
+--- xen-4.9.0.orig/xen/common/grant_table.c
++++ xen-4.9.0/xen/common/grant_table.c
+@@ -2033,13 +2033,8 @@ __release_grant_for_copy(
      unsigned long r_frame;
      uint16_t *status;
      grant_ref_t trans_gref;
@@ -38,7 +38,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
      grant_read_lock(rgt);
  
      act = active_entry_acquire(rgt, gref);
-@@ -2069,17 +2064,11 @@
+@@ -2069,17 +2064,11 @@ __release_grant_for_copy(
  
          act->pin -= GNTPIN_hstw_inc;
          if ( !(act->pin & (GNTPIN_devw_mask|GNTPIN_hstw_mask)) )
@@ -56,7 +56,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
  
      active_entry_release(act);
      grant_read_unlock(rgt);
-@@ -2087,13 +2076,10 @@
+@@ -2087,13 +2076,10 @@ __release_grant_for_copy(
      if ( td != rd )
      {
          /*
@@ -72,7 +72,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
  
          rcu_unlock_domain(td);
      }
-@@ -2167,8 +2153,108 @@
+@@ -2167,8 +2153,108 @@ __acquire_grant_for_copy(
                   act->domid, ldom, act->pin);
  
      old_pin = act->pin;
@@ -183,7 +183,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
      {
          if ( (rc = _set_status(rgt->gt_version, ldom,
                                 readonly, 0, shah, act,
-@@ -2189,79 +2275,6 @@
+@@ -2189,79 +2275,6 @@ __acquire_grant_for_copy(
              trans_page_off = 0;
              trans_length = PAGE_SIZE;
          }
@@ -263,7 +263,7 @@ Index: xen-4.9.0/xen/common/grant_table.c
          else if ( !(sha2->hdr.flags & GTF_sub_page) )
          {
              rc = __get_paged_frame(sha2->full_page.frame, &grant_frame, page, readonly, rd);
-@@ -2693,10 +2706,13 @@
+@@ -2693,10 +2706,13 @@ gnttab_set_version(XEN_GUEST_HANDLE_PARA
      case 2:
          for ( i = 0; i < GNTTAB_NR_RESERVED_ENTRIES; i++ )
          {


### PR DESCRIPTION
Update the XSA patch to include the latest fix.
https://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=b4660b4d4a35edac715c003c84326de2b0fa4f47

Alternative to https://github.com/OpenXT/xenclient-oe/pull/767. Uses the v7 of the XSA-226 advisory instead of back-porting another patch.
