### PR TITLE
OXT-1212: Fix TPM2 active status check

### DIFF
--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -133,15 +133,19 @@ tpm_is_active() {
     local tpm="$(find /sys/class -name tpm0 2>/dev/null)/device"
     local active
     local msg
+    local val
 
     if is_tpm_2_0 ; then
-        msg=$(tpm2_dump_capability --capability=properties-fixed 2>&1) \
-            && return 0
+        msg=$(tpm2_dump_capability --capability=properties-variable 2>&1) || \
+            return 2
 
-        case "$msg" in
-            *Invalid) return 1 ;;
-            *) return 2 ;;
-        esac
+        # Ensure Hierarchies are enabled; otherwise the TPM2 is unusable.
+        for v in phEnable shEnable ehEnable phEnableNV; do
+            val="$( echo "${msg}" | awk "/${v}:/ { print \$2 }" )"
+            [ "${val}" = "set" ] || return 1
+        done
+
+        return 0
     fi
 
     active="$(cat ${tpm}/active)" || return 2

--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -131,30 +131,26 @@ tcsd_start() {
 #         2 if indeterminant
 tpm_is_active() {
     local tpm="$(find /sys/class -name tpm0 2>/dev/null)/device"
-    local state=""
+    local active
+    local msg
 
-    is_tpm_2_0
-    local tpm2=$?
-    if [ "${tpm2}" -eq 0 ];
-    then
-        msg=$(tpm2_dump_capability --capability=properties-fixed 2>&1)
-        if [ $? -ne 0 ]; then
-            case "$msg" in
-                *Invalid) state=1 ;;
-                *) state=0 ;;
-            esac
-        else
-            state=0
-        fi
-    else
-        state=$(cat ${tpm}/active)
-        if [ $? -ne 0 ]; then
-            return 2
-        fi
-        [ $state -eq 1 ] && state=0 || state=1
+    if is_tpm_2_0 ; then
+        msg=$(tpm2_dump_capability --capability=properties-fixed 2>&1) \
+            && return 0
+
+        case "$msg" in
+            *Invalid) return 1 ;;
+            *) return 2 ;;
+        esac
     fi
 
-    return $state
+    active="$(cat ${tpm}/active)" || return 2
+
+    if [ "${active}" -eq 1 ]; then
+        return 0
+    fi
+
+    return 1
 }
 # Function to determine whether or not the TPM is enabled
 # return 0 if TPM is enabled


### PR DESCRIPTION
Some BIOSes allow the TPM2 to be "on" but disabled.  In that case we need
to verify actual usability of the TPM2 to proceed with installation.  By returning inactive, the installer will allow the user to downgrade to a non-measured launch installation.

This needs testing on a machine that allows for an "on-but-disabled" TPM2.

OXT-1212