### PR TITLE
[libxl] Fix flr for pci passthru devices

### DIFF
--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -1,0 +1,194 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Fix device reset for pci devices in libxl
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+This patch fixes the logic and the control flow path for pci device reset in
+libxl.  Additionally, it addresses an issue with Xenbus state synchronization
+during domain teardown.  More detailed information about the patch follows:
+
+The changes to Xenbus state are to prevent hitting a timeout when domains are 
+shutdown or destroyed. Xl is waiting for "XenbusStateConnected" (state 4), while 
+the state machine has already moved the device to Closing (state 5) and Closed 
+(state 6) by the time we reach this point tearing down the domain.
+
+The reset logic introduced in this patch is delayed until the domain has fully 
+been destroyed. The reason for this has to do with the 
+thorough-reset-interface-to-pciback-s-sysfs.patch in the linux patchqueue. 
+__pcistub_raw_device_reset tries multiple approaches for resetting the device, 
+flr, slot-level, and bus-level. If we encounter a device that, for example, 
+doesn't support flr but does support a slot-level reset, we want to make sure 
+all the functions on that device (GPUS are a good example, they often have 2 
+functions, video and HDMI audio, and are the only device in the slot) are 
+released from the domain before attempting the reset or it will fail. This 
+approach seems to be taken in an attempt to support a wide variety of PCI 
+devices.
+
+################################################################################
+CHANGELOG
+################################################################################
+Authors:
+Chris Rogers <rogersc@ainfosec.com>
+
+################################################################################
+REMOVAL
+################################################################################
+N/A
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Depends on the feasibility of upstreaming thorough-reset-interface-to-pciback...
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+
+################################################################################
+PATCHES
+################################################################################
+Index: xen-4.9.0/tools/libxl/libxl_internal.h
+===================================================================
+--- xen-4.9.0.orig/tools/libxl/libxl_internal.h
++++ xen-4.9.0/tools/libxl/libxl_internal.h
+@@ -1412,12 +1412,19 @@ _hidden int libxl__pci_topology_init(lib
+ 
+ /* from libxl_pci */
+ 
++typedef struct libxl_pci_dev_wrap {
++    libxl_device_pci *pcidevs;
++    int num_devs;
++} libxl_pci_dev_wrap;
++
+ _hidden int libxl__device_pci_add(libxl__gc *gc, uint32_t domid, libxl_device_pci *pcidev, int starting);
+ _hidden int libxl__create_pci_backend(libxl__gc *gc, uint32_t domid,
+                                       libxl_device_pci *pcidev, int num);
+-_hidden int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid);
++_hidden int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid, libxl_pci_dev_wrap **pciw);
+ _hidden bool libxl__is_igd_vga_passthru(libxl__gc *gc,
+                                         const libxl_domain_config *d_config);
++_hidden int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, 
++                                    unsigned int bus, unsigned int dev, unsigned int func);
+ 
+ /* from libxl_dtdev */
+ 
+@@ -3609,6 +3616,7 @@ struct libxl__destroy_domid_state {
+     /* private to implementation */
+     libxl__devices_remove_state drs;
+     libxl__ev_child destroyer;
++    libxl_pci_dev_wrap *pciw;
+     bool soft_reset;
+ };
+ 
+Index: xen-4.9.0/tools/libxl/libxl_pci.c
+===================================================================
+--- xen-4.9.0.orig/tools/libxl/libxl_pci.c
++++ xen-4.9.0/tools/libxl/libxl_pci.c
+@@ -212,7 +212,7 @@ static int libxl__device_pci_remove_xens
+         return ERROR_FAIL;
+ 
+     if (domtype == LIBXL_DOMAIN_TYPE_PV) {
+-        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
++        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateClosed)) < 0) {
+             LOGD(DEBUG, domid, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+         }
+@@ -235,13 +235,12 @@ static int libxl__device_pci_remove_xens
+ retry_transaction:
+     t = xs_transaction_start(ctx->xsh);
+     xs_write(ctx->xsh, t, GCSPRINTF("%s/state-%d", be_path, i), GCSPRINTF("%d", XenbusStateClosing), 1);
+-    xs_write(ctx->xsh, t, GCSPRINTF("%s/state", be_path), GCSPRINTF("%d", XenbusStateReconfiguring), 1);
+     if (!xs_transaction_end(ctx->xsh, t, 0))
+         if (errno == EAGAIN)
+             goto retry_transaction;
+ 
+     if (domtype == LIBXL_DOMAIN_TYPE_PV) {
+-        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
++        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateClosed)) < 0) {
+             LOGD(DEBUG, domid, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+         }
+@@ -1126,13 +1125,13 @@ out:
+     return rc;
+ }
+ 
+-static int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
++int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
+                                    unsigned int dev, unsigned int func)
+ {
+     char *reset;
+     int fd, rc;
+ 
+-    reset = GCSPRINTF("%s/do_flr", SYSFS_PCIBACK_DRIVER);
++    reset = GCSPRINTF("%s/reset_device", SYSFS_PCIBACK_DRIVER);
+     fd = open(reset, O_WRONLY);
+     if (fd >= 0) {
+         char *buf = GCSPRINTF(PCI_BDF, domain, bus, dev, func);
+@@ -1484,10 +1483,6 @@ skip1:
+         fclose(f);
+     }
+ out:
+-    /* don't do multiple resets while some functions are still passed through */
+-    if ( (pcidev->vdevfn & 0x7) == 0 ) {
+-        libxl__device_pci_reset(gc, pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func);
+-    }
+ 
+     if (!isstubdom) {
+         rc = xc_deassign_device(ctx->xch, domid, pcidev_encode_bdf(pcidev));
+@@ -1636,7 +1631,7 @@ out:
+     return pcidevs;
+ }
+ 
+-int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid)
++int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid, libxl_pci_dev_wrap **pciw)
+ {
+     libxl_ctx *ctx = libxl__gc_owner(gc);
+     libxl_device_pci *pcidevs;
+@@ -1654,8 +1649,9 @@ int libxl__device_pci_destroy_all(libxl_
+         if (libxl__device_pci_remove_common(gc, domid, pcidevs + i, 1) < 0)
+             rc = ERROR_FAIL;
+     }
+-
+-    free(pcidevs);
++    *pciw = malloc(sizeof(libxl_pci_dev_wrap));
++    (*pciw)->pcidevs = pcidevs;
++    (*pciw)->num_devs = num;
+     return rc;
+ }
+ 
+Index: xen-4.9.0/tools/libxl/libxl_domain.c
+===================================================================
+--- xen-4.9.0.orig/tools/libxl/libxl_domain.c
++++ xen-4.9.0/tools/libxl/libxl_domain.c
+@@ -999,6 +999,15 @@ static void domain_destroy_callback(libx
+         dds->rc = rc;
+     }
+ 
++    if(dis->pciw) {
++        for (int i = 0; i < dis->pciw->num_devs; i++) {
++            libxl_device_pci *pcidev = &dis->pciw->pcidevs[i];
++            libxl__device_pci_reset(gc, pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func);
++        } 
++        free(dis->pciw->pcidevs);
++        free(dis->pciw);
++    }
++
+     dds->domain_finished = 1;
+     destroy_finish_check(egc, dds);
+ }
+@@ -1065,8 +1074,11 @@ void libxl__destroy_domid(libxl__egc *eg
+         goto out;
+     }
+ 
+-    if (libxl__device_pci_destroy_all(gc, domid) < 0)
++    rc = libxl__device_pci_destroy_all(gc, domid, &(dis->pciw));
++    if (rc < 0) {
+         LOGD(ERROR, domid, "Pci shutdown failed");
++    }
++
+     rc = xc_domain_pause(ctx->xch, domid);
+     if (rc < 0) {
+         LOGEVD(ERROR, rc, domid, "xc_domain_pause failed");

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -97,6 +97,7 @@ SRC_URI_append = " \
     file://libxl-disable-json-updates.patch \
     file://libxl-allow-non-qdisk-cdrom.patch \
     file://libxl-domain-build-fix-array-size-bug.patch \
+    file://libxl-fix-flr.patch \
     file://xsa226-4.9/0001-gnttab-dont-use-possibly-unbounded-tail-calls.patch \
     file://xsa226-4.9/0002-gnttab-fix-transitive-grant-handling.patch \
     file://xsa226-4.9/0003-gnttab-fix-don-t-use-possibly-unbounded-tail-calls.patch \


### PR DESCRIPTION
  Use correct sysfs node for the flr and perform it after the pci
  device is released from the domain and the domain has been
  destroyed.  This fixes the bug where certain AMD GPU passthru
  devices would crash the host without a proper flr on subsequent
  guest boots.

  Also fixes the expected xenbus state for pci to avoid a timeout
  on guest shutdown.

  OXT-1217

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>