### PR TITLE
STABLE-7: [libxl] Fix flr for pci passthru device

### DIFF
--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -1,0 +1,118 @@
+Index: xen-4.9.0/tools/libxl/libxl_internal.h
+===================================================================
+--- xen-4.9.0.orig/tools/libxl/libxl_internal.h
++++ xen-4.9.0/tools/libxl/libxl_internal.h
+@@ -1392,6 +1392,14 @@ _hidden int libxl__domaindeathcheck_star
+ void libxl__domaindeathcheck_init(libxl__domaindeathcheck *dc);
+ void libxl__domaindeathcheck_stop(libxl__gc *gc, libxl__domaindeathcheck *dc);
+ 
++typedef struct libxl_pci_dev_wrap {
++    libxl_device_pci *pcidevs;
++    int num_devs;
++} libxl_pci_dev_wrap;
++
++int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
++                                   unsigned int dev, unsigned int func);
++
+ 
+ /*
+  * libxl__try_phy_backend - Check if there's support for the passed
+@@ -1415,7 +1423,7 @@ _hidden int libxl__pci_topology_init(lib
+ _hidden int libxl__device_pci_add(libxl__gc *gc, uint32_t domid, libxl_device_pci *pcidev, int starting);
+ _hidden int libxl__create_pci_backend(libxl__gc *gc, uint32_t domid,
+                                       libxl_device_pci *pcidev, int num);
+-_hidden int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid);
++_hidden libxl_pci_dev_wrap * libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid);
+ _hidden bool libxl__is_igd_vga_passthru(libxl__gc *gc,
+                                         const libxl_domain_config *d_config);
+ 
+@@ -3609,6 +3617,7 @@ struct libxl__destroy_domid_state {
+     /* private to implementation */
+     libxl__devices_remove_state drs;
+     libxl__ev_child destroyer;
++    libxl_pci_dev_wrap *pciw;
+     bool soft_reset;
+ };
+ 
+Index: xen-4.9.0/tools/libxl/libxl_pci.c
+===================================================================
+--- xen-4.9.0.orig/tools/libxl/libxl_pci.c
++++ xen-4.9.0/tools/libxl/libxl_pci.c
+@@ -212,7 +212,7 @@ static int libxl__device_pci_remove_xens
+         return ERROR_FAIL;
+ 
+     if (domtype == LIBXL_DOMAIN_TYPE_PV) {
+-        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
++        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateClosed)) < 0) {
+             LOGD(DEBUG, domid, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+         }
+@@ -235,13 +235,12 @@ static int libxl__device_pci_remove_xens
+ retry_transaction:
+     t = xs_transaction_start(ctx->xsh);
+     xs_write(ctx->xsh, t, GCSPRINTF("%s/state-%d", be_path, i), GCSPRINTF("%d", XenbusStateClosing), 1);
+-    xs_write(ctx->xsh, t, GCSPRINTF("%s/state", be_path), GCSPRINTF("%d", XenbusStateReconfiguring), 1);
+     if (!xs_transaction_end(ctx->xsh, t, 0))
+         if (errno == EAGAIN)
+             goto retry_transaction;
+ 
+     if (domtype == LIBXL_DOMAIN_TYPE_PV) {
+-        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
++        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateClosed)) < 0) {
+             LOGD(DEBUG, domid, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+         }
+@@ -1126,13 +1125,13 @@ out:
+     return rc;
+ }
+ 
+-static int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
++int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
+                                    unsigned int dev, unsigned int func)
+ {
+     char *reset;
+     int fd, rc;
+ 
+-    reset = GCSPRINTF("%s/do_flr", SYSFS_PCIBACK_DRIVER);
++    reset = GCSPRINTF("%s/reset_device", SYSFS_PCIBACK_DRIVER);
+     fd = open(reset, O_WRONLY);
+     if (fd >= 0) {
+         char *buf = GCSPRINTF(PCI_BDF, domain, bus, dev, func);
+@@ -1484,10 +1483,6 @@ skip1:
+         fclose(f);
+     }
+ out:
+-    /* don't do multiple resets while some functions are still passed through */
+-    if ( (pcidev->vdevfn & 0x7) == 0 ) {
+-        libxl__device_pci_reset(gc, pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func);
+-    }
+ 
+     if (!isstubdom) {
+         rc = xc_deassign_device(ctx->xch, domid, pcidev_encode_bdf(pcidev));
+@@ -1636,10 +1631,11 @@ out:
+     return pcidevs;
+ }
+ 
+-int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid)
++libxl_pci_dev_wrap * libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid)
+ {
+     libxl_ctx *ctx = libxl__gc_owner(gc);
+     libxl_device_pci *pcidevs;
++    libxl_pci_dev_wrap *pciw;
+     int num, i, rc = 0;
+ 
+     pcidevs = libxl_device_pci_list(ctx, domid, &num);
+@@ -1654,9 +1650,10 @@ int libxl__device_pci_destroy_all(libxl_
+         if (libxl__device_pci_remove_common(gc, domid, pcidevs + i, 1) < 0)
+             rc = ERROR_FAIL;
+     }
+-
+-    free(pcidevs);
+-    return rc;
++    pciw = malloc(sizeof(libxl_pci_dev_wrap));
++    pciw->pcidevs = pcidevs;
++    pciw->num_devs = num;
++    return pciw;
+ }
+ 
+ int libxl__grant_vga_iomem_permission(libxl__gc *gc, const uint32_t domid,

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -79,6 +79,7 @@ SRC_URI_append = " \
     file://libxl-vwif-support.patch \
     file://libxl-atapi-pt.patch \
     file://libxl-iso-hotswap.patch \
+    file://libxl-fix-flr.patch \
     file://tboot-xen-evtlog-support.patch \
     file://0001-gnttab-dont-use-possibly-unbounded-tail-calls.patch \
     file://0002-gnttab-fix-transitive-grant-handling.patch \


### PR DESCRIPTION
  Use correct sysfs node for the flr and perform it after the pci
  device is released from the domain and the domain has been
  destroyed.  This fixes the bug where certain AMD GPU passthru
  devices would crash the host without a proper flr on subsequent
  guest boots.

  Also fixes the expected xenbus state for pci to avoid a timeout
  on guest shutdown.

  OXT-1217

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>