### PR TITLE
STABLE-7: [libxl] Fix flr for pci passthru devices

### DIFF
--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -1,0 +1,207 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Fix device reset for pci devices in libxl
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+This patch fixes the logic and the control flow path for pci device reset in
+libxl.  Additionally, it addresses an issue with Xenbus state synchronization
+during domain teardown.  More detailed information about the patch follows:
+
+The changes to Xenbus state are to prevent hitting a timeout when domains are
+shutdown or destroyed. Xl is waiting for "XenbusStateConnected" (state 4), while
+the state machine has already moved the device to Closing (state 5) and Closed
+(state 6) by the time we reach this point tearing down the domain.
+
+The reset logic introduced in this patch is delayed until the domain has fully
+been destroyed. The reason for this has to do with the
+thorough-reset-interface-to-pciback-s-sysfs.patch in the linux patchqueue.
+__pcistub_raw_device_reset tries multiple approaches for resetting the device,
+flr, slot-level, and bus-level. If we encounter a device that, for example,
+doesn't support flr but does support a slot-level reset, we want to make sure
+all the functions on that device (GPUS are a good example, they often have 2
+functions, video and HDMI audio, and are the only device in the slot) are
+released from the domain before attempting the reset or it will fail. This
+approach seems to be taken in an attempt to support a wide variety of PCI
+devices.
+
+################################################################################
+CHANGELOG
+################################################################################
+Authors:
+Chris Rogers <rogersc@ainfosec.com>
+
+################################################################################
+REMOVAL
+################################################################################
+N/A
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Depends on the feasibility of upstreaming thorough-reset-interface-to-pciback...
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+
+################################################################################
+PATCHES
+################################################################################
+Index: xen-4.6.6/tools/libxl/libxl.c
+===================================================================
+--- xen-4.6.6.orig/tools/libxl/libxl.c
++++ xen-4.6.6/tools/libxl/libxl.c
+@@ -1604,7 +1604,14 @@ static void domain_destroy_callback(libx
+         LOG(ERROR, "unable to destroy guest with domid %u", dis->domid);
+         dds->rc = rc;
+     }
+-
++    if(dis->pciw) {
++        for (int i = 0; i < dis->pciw->num_devs; i++) {
++            libxl_device_pci *pcidev = &dis->pciw->pcidevs[i];
++            libxl__device_pci_reset(gc, pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func); 
++        } 
++        free(dis->pciw->pcidevs);
++        free(dis->pciw);
++    }
+     dds->domain_finished = 1;
+     destroy_finish_check(egc, dds);
+ }
+@@ -1672,8 +1679,10 @@ void libxl__destroy_domid(libxl__egc *eg
+         goto out;
+     }
+ 
+-    if (libxl__device_pci_destroy_all(gc, domid) < 0)
+-        LIBXL__LOG(ctx, LIBXL__LOG_ERROR, "pci shutdown failed for domid %d", domid);
++    rc = libxl__device_pci_destroy_all(gc, domid, &(dis->pciw));
++    if( rc < 0) {
++        LIBXL__LOG_ERRNOVAL(ctx, LIBXL__LOG_ERROR, rc, "Pci shutdown failed for %d", domid);
++    }
+     rc = xc_domain_pause(ctx->xch, domid);
+     if (rc < 0) {
+         LIBXL__LOG_ERRNOVAL(ctx, LIBXL__LOG_ERROR, rc, "xc_domain_pause failed for %d", domid);
+Index: xen-4.6.6/tools/libxl/libxl_internal.h
+===================================================================
+--- xen-4.6.6.orig/tools/libxl/libxl_internal.h
++++ xen-4.6.6/tools/libxl/libxl_internal.h
+@@ -1351,16 +1351,22 @@ _hidden int libxl__pci_topology_init(lib
+ 
+ /* from libxl_pci */
+ 
++typedef struct libxl_pci_dev_wrap {
++    libxl_device_pci *pcidevs;
++    int num_devs;
++} libxl_pci_dev_wrap;
++
+ _hidden int libxl__device_pci_add(libxl__gc *gc, uint32_t domid, libxl_device_pci *pcidev, int starting);
+ _hidden int libxl__create_pci_backend(libxl__gc *gc, uint32_t domid,
+                                       libxl_device_pci *pcidev, int num);
+-_hidden int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid);
++_hidden int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid, libxl_pci_dev_wrap **pciw);
++_hidden int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain,
++                                    unsigned int bus, unsigned int dev, unsigned int func);
+ 
+ /* from libxl_dtdev */
+ 
+ _hidden int libxl__device_dt_add(libxl__gc *gc, uint32_t domid,
+                                  const libxl_device_dtdev *dtdev);
+-
+ /*
+  *----- spawn -----
+  *
+@@ -3250,6 +3256,7 @@ struct libxl__destroy_domid_state {
+     /* private to implementation */
+     libxl__devices_remove_state drs;
+     libxl__ev_child destroyer;
++    libxl_pci_dev_wrap *pciw;
+ };
+ 
+ struct libxl__domain_destroy_state {
+Index: xen-4.6.6/tools/libxl/libxl_pci.c
+===================================================================
+--- xen-4.6.6.orig/tools/libxl/libxl_pci.c
++++ xen-4.6.6/tools/libxl/libxl_pci.c
+@@ -219,7 +219,7 @@ static int libxl__device_pci_remove_xens
+         return ERROR_FAIL;
+ 
+     if (domtype == LIBXL_DOMAIN_TYPE_PV) {
+-        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
++        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateClosed)) < 0) {
+             LIBXL__LOG(ctx, LIBXL__LOG_DEBUG, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+         }
+@@ -242,13 +242,12 @@ static int libxl__device_pci_remove_xens
+ retry_transaction:
+     t = xs_transaction_start(ctx->xsh);
+     xs_write(ctx->xsh, t, libxl__sprintf(gc, "%s/state-%d", be_path, i), GCSPRINTF("%d", XenbusStateClosing), 1);
+-    xs_write(ctx->xsh, t, libxl__sprintf(gc, "%s/state", be_path), GCSPRINTF("%d", XenbusStateReconfiguring), 1);
+     if (!xs_transaction_end(ctx->xsh, t, 0))
+         if (errno == EAGAIN)
+             goto retry_transaction;
+ 
+     if (domtype == LIBXL_DOMAIN_TYPE_PV) {
+-        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
++        if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateClosed)) < 0) {
+             LIBXL__LOG(ctx, LIBXL__LOG_DEBUG, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+         }
+@@ -1014,20 +1013,20 @@ out:
+     return rc;
+ }
+ 
+-static int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
++int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, unsigned int bus,
+                                    unsigned int dev, unsigned int func)
+ {
+     libxl_ctx *ctx = libxl__gc_owner(gc);
+     char *reset;
+     int fd, rc;
+ 
+-    reset = libxl__sprintf(gc, "%s/do_flr", SYSFS_PCIBACK_DRIVER);
++    reset = libxl__sprintf(gc, "%s/reset_device", SYSFS_PCIBACK_DRIVER);
+     fd = open(reset, O_WRONLY);
+     if (fd >= 0) {
+         char *buf = libxl__sprintf(gc, PCI_BDF, domain, bus, dev, func);
+         rc = write(fd, buf, strlen(buf));
+         if (rc < 0)
+-            LIBXL__LOG(ctx, LIBXL__LOG_ERROR, "write to %s returned %d", reset, rc);
++            LIBXL__LOG(ctx, LIBXL__LOG_ERROR, "write %s to fd %d, file %s returned %d, errno %d", buf, fd, reset, rc, errno);
+         close(fd);
+         return rc < 0 ? rc : 0;
+     }
+@@ -1331,10 +1330,6 @@ skip1:
+         fclose(f);
+     }
+ out:
+-    /* don't do multiple resets while some functions are still passed through */
+-    if ( (pcidev->vdevfn & 0x7) == 0 ) {
+-        libxl__device_pci_reset(gc, pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func);
+-    }
+ 
+     if (!libxl_is_stubdom(ctx, domid, NULL)) {
+         rc = xc_deassign_device(ctx->xch, domid, pcidev_encode_bdf(pcidev));
+@@ -1483,7 +1478,7 @@ out:
+     return pcidevs;
+ }
+ 
+-int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid)
++int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid, libxl_pci_dev_wrap **pciw)
+ {
+     libxl_ctx *ctx = libxl__gc_owner(gc);
+     libxl_device_pci *pcidevs;
+@@ -1502,8 +1497,10 @@ int libxl__device_pci_destroy_all(libxl_
+             rc = ERROR_FAIL;
+     }
+ 
+-    free(pcidevs);
+-    return 0;
++    *pciw = malloc(sizeof(libxl_pci_dev_wrap));
++    (*pciw)->pcidevs = pcidevs;
++    (*pciw)->num_devs = num;
++    return rc;
+ }
+ 
+ int libxl__grant_vga_iomem_permission(libxl__gc *gc, const uint32_t domid,

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -79,6 +79,7 @@ SRC_URI_append = " \
     file://libxl-vwif-support.patch \
     file://libxl-atapi-pt.patch \
     file://libxl-iso-hotswap.patch \
+    file://libxl-fix-flr.patch \
     file://tboot-xen-evtlog-support.patch \
     file://0001-gnttab-dont-use-possibly-unbounded-tail-calls.patch \
     file://0002-gnttab-fix-transitive-grant-handling.patch \


### PR DESCRIPTION
  Use correct sysfs node for the flr and perform it after the pci
  device is released from the domain and the domain has been
  destroyed.  This fixes the bug where certain AMD GPU passthru
  devices would crash the host without a proper flr on subsequent
  guest boots.

  Also fixes the expected xenbus state for pci to avoid a timeout
  on guest shutdown.

  OXT-1217

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>