### PR TITLE
seabios: Change URL to avoid HTTP 308.

### DIFF
--- a/recipes-openxt/seabios/seabios.inc
+++ b/recipes-openxt/seabios/seabios.inc
@@ -3,8 +3,9 @@ HOMEPAGE = "http://www.coreboot.org/SeaBIOS"
 LICENSE = "LGPLv3"
 SECTION = "firmware"
 
-SRC_URI = "http://code.coreboot.org/p/seabios/downloads/get/${PN}-${PV}.tar.gz;name=tarball \
-           "
+SRC_URI = " \
+    https://code.coreboot.org/p/seabios/downloads/get/${PN}-${PV}.tar.gz;name=tarball \
+"
 
 S = "${WORKDIR}/${PN}-${PV}"
 


### PR DESCRIPTION
Wget will fail to fetch from the http URL after receiving a 308. Use the
https source instead.

This seems to fail when building a new tree without cache.