### PR TITLE
Reneable the bmdma_cancel function when using atapi pass through

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/atapi-pass-through.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/atapi-pass-through.patch
@@ -4209,7 +4209,7 @@ Index: qemu-2.6.2/hw/ide/pci.c
 +             */
 +#ifdef CONFIG_ATAPI_PT
 +            /* TODO: Why? Are we sure this is safe? */
-+            /*dma_cancel(bm);*/
++            bmdma_cancel(bm);
 +#endif
              ide_cancel_dma_sync(idebus_active_if(bm->bus));
              bm->status &= ~BM_STATUS_DMAING;


### PR DESCRIPTION
OXT-1055