### PR TITLE
OXT-1236: xen: do not register hpet mmio during s3 cycle

### DIFF
--- a/recipes-extended/xen/files/x86-hvm-do-not-register-hpet-mmio-during-s3-cycle.patch
+++ b/recipes-extended/xen/files/x86-hvm-do-not-register-hpet-mmio-during-s3-cycle.patch
@@ -1,0 +1,81 @@
+From 0f766e1573a45acb79642272b7b5c003a5f260a0 Mon Sep 17 00:00:00 2001
+From: Eric Chanudet <chanudete@ainfosec.com>
+Date: Mon, 30 Oct 2017 12:45:18 -0400
+Subject: [PATCH v3] x86/hvm: do not register hpet mmio during s3 cycle
+
+Do it once at domain creation (hpet_init).
+
+Sleep -> Resume cycles will end up crashing an HVM guest with hpet as
+the sequence during resume takes the path:
+-> hvm_s3_suspend
+  -> hpet_reset
+    -> hpet_deinit
+    -> hpet_init
+      -> register_mmio_handler
+        -> hvm_next_io_handler
+
+register_mmio_handler will use a new io handler each time, until
+eventually it reaches NR_IO_HANDLERS, then hvm_next_io_handler calls
+domain_crash.
+
+Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>
+
+---
+v2:
+  * make hpet_reinit static inline (one call site in this file)
+  * remove single use local variable.
+---
+v3:
+  * remove single use of hpet_reinit.
+---
+ xen/arch/x86/hvm/hpet.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/xen/arch/x86/hvm/hpet.c b/xen/arch/x86/hvm/hpet.c
+index 3ea895a0fb..f98ae7b123 100644
+--- a/xen/arch/x86/hvm/hpet.c
++++ b/xen/arch/x86/hvm/hpet.c
+@@ -635,14 +635,10 @@ static int hpet_load(struct domain *d, hvm_domain_context_t *h)
+ 
+ HVM_REGISTER_SAVE_RESTORE(HPET, hpet_save, hpet_load, 1, HVMSR_PER_DOM);
+ 
+-void hpet_init(struct domain *d)
++static void hpet_set(HPETState *h)
+ {
+-    HPETState *h = domain_vhpet(d);
+     int i;
+ 
+-    if ( !has_vhpet(d) )
+-        return;
+-
+     memset(h, 0, sizeof(HPETState));
+ 
+     rwlock_init(&h->lock);
+@@ -668,7 +664,14 @@ void hpet_init(struct domain *d)
+         h->hpet.comparator64[i] = ~0ULL;
+         h->pt[i].source = PTSRC_isa;
+     }
++}
++
++void hpet_init(struct domain *d)
++{
++    if ( !has_vhpet(d) )
++        return;
+ 
++    hpet_set(domain_vhpet(d));
+     register_mmio_handler(d, &hpet_mmio_ops);
+     d->arch.hvm_domain.params[HVM_PARAM_HPET_ENABLED] = 1;
+ }
+@@ -698,7 +701,8 @@ void hpet_deinit(struct domain *d)
+ void hpet_reset(struct domain *d)
+ {
+     hpet_deinit(d);
+-    hpet_init(d);
++    if ( has_vhpet(d) )
++        hpet_set(domain_vhpet(d));
+ }
+ 
+ /*
+-- 
+2.14.1
+

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -122,6 +122,7 @@ SRC_URI_append = " \
     file://xsa242-4.9.patch \
     file://xsa243.patch \
     file://xsa244.patch \
+    file://x86-hvm-do-not-register-hpet-mmio-during-s3-cycle.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'


### PR DESCRIPTION
mmio handler exhaustion will have Xen destroy the domain instead of
letting it suspend.
