### PR TITLE
OXT-1253: toolstack: Use the ocamlincdir from the bbclass.

### DIFF
--- a/recipes-openxt/xenclient/xenclient-toolstack_git.bb
+++ b/recipes-openxt/xenclient/xenclient-toolstack_git.bb
@@ -60,9 +60,9 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 S = "${WORKDIR}/git"
 
 # TODO: ocamlc can figure it out in the build-system.
-CFLAGS_append = " -I${OCAML_HEADERS}"
+CFLAGS_append = " -I${ocamlincdir}"
 do_compile() {
-        make V=1 XEN_DIST_ROOT="${STAGING_DIR}"
+        make V=1 XEN_DIST_ROOT="${STAGING_DIR_HOST}"
 }
 
 OCAML_INSTALL_LIBS = " \


### PR DESCRIPTION
This should have been part of the original commit as it was defined in
the local.conf which got move to the bbclass.

Also use the correct variable to find xen headers.
