### PR TITLE
[linux] Adjust Hypercall id for txt evtlog

### DIFF
--- a/recipes-kernel/linux/4.9/patches/xen-txt-add-xen-txt-eventlog-module.patch
+++ b/recipes-kernel/linux/4.9/patches/xen-txt-add-xen-txt-eventlog-module.patch
@@ -268,15 +268,16 @@ Index: linux-4.9.76/include/xen/interface/xen.h
 ===================================================================
 --- linux-4.9.76.orig/include/xen/interface/xen.h
 +++ linux-4.9.76/include/xen/interface/xen.h
-@@ -81,6 +81,7 @@
+@@ -81,6 +81,8 @@
  #define __HYPERVISOR_tmem_op              38
  #define __HYPERVISOR_xc_reserved_op       39 /* reserved for XenClient */
  #define __HYPERVISOR_xenpmu_op            40
-+#define __HYPERVISOR_txt_op               41
++#define __HYPERVISOR_dm_op                41
++#define __HYPERVISOR_txt_op               42
  
  /* Architecture-specific hypercall definitions. */
  #define __HYPERVISOR_arch_0               48
-@@ -743,6 +744,13 @@ typedef uint64_t cpumap_t;
+@@ -743,6 +745,13 @@ typedef uint64_t cpumap_t;
  
  typedef uint8_t xen_domain_handle_t[16];
  


### PR DESCRIPTION
  Xen-4.9 added a new HYPERCALL_dm_op that uses the current id
  for the txt evtlog hypercall.  This commit adjusts the patch
  to account for that new hypercall.

Signed-off-by: Chris <rogersc@ainfosec.com>