### PR TITLE
Amend mirror.openxt.org layout changes and add new mirror.

### DIFF
--- a/recipes-core/ifplugd/ifplugd_0.28.bb
+++ b/recipes-core/ifplugd/ifplugd_0.28.bb
@@ -12,7 +12,11 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 PR = "r1"
 
-SRC_URI = "${OPENXT_MIRROR}/ifplugd-0.28.tar.gz \
+
+MIRRORS_append += " \
+    http://.*/.*      https://openxt.ainfosec.com/mirror/ \
+"
+SRC_URI = "${OPENXT_MIRROR}/openxt/ifplugd-0.28.tar.gz \
            file://kernel-types.patch \
            file://nobash.patch \
            file://ifplugd.conf"

--- a/recipes-openxt/acms/acms.bb
+++ b/recipes-openxt/acms/acms.bb
@@ -43,18 +43,21 @@ LIC_FILES_CHKSUM = "file://GM45_GS45_PM45-SINIT_51/license.txt;md5=60d123634e0b9
                     file://7th_gen_i5_i7-SINIT_74/license.txt;md5=4897766beede80773ddd162b2724a8bb \
 "
 
-SRC_URI = "${OPENXT_MIRROR}/GM45_GS45_PM45-SINIT_51.zip;name=gm45 \
-           ${OPENXT_MIRROR}/Q45_Q43-SINIT_51.zip;name=q45 \
-           ${OPENXT_MIRROR}/Q35-SINIT_51.zip;name=q35 \
-           ${OPENXT_MIRROR}/i5_i7_DUAL-SINIT_51.zip;name=i5 \
-           ${OPENXT_MIRROR}/i7_QUAD-SINIT_51.zip;name=i7 \
-           ${OPENXT_MIRROR}/Xeon-5600-3500-SINIT-v1.1.zip;name=xeon_5600 \
-           ${OPENXT_MIRROR}/Xeon-E7-8800-4800-2800-SINIT-v1.1.zip;name=xeon_e7 \
-           ${OPENXT_MIRROR}/3rd-gen-i5-i7-sinit-67.zip;name=ivb_snb \
-           ${OPENXT_MIRROR}/4th-gen-i5-i7-sinit-75.zip;name=hsw \
-           ${OPENXT_MIRROR}/5th_gen_i5_i7-SINIT_79.zip;name=bdw \
-           ${OPENXT_MIRROR}/6th_gen_i5_i7-SINIT_71.zip;name=skl \
-           ${OPENXT_MIRROR}/7th_gen_i5_i7-SINIT_74.zip;name=kbl \
+MIRRORS_append += " \
+    http://.*/.*    https://openxt.ainfosec.com/mirror/ \
+"
+SRC_URI = "${OPENXT_MIRROR}/openxt/GM45_GS45_PM45-SINIT_51.zip;name=gm45 \
+           ${OPENXT_MIRROR}/openxt/Q45_Q43-SINIT_51.zip;name=q45 \
+           ${OPENXT_MIRROR}/openxt/Q35-SINIT_51.zip;name=q35 \
+           ${OPENXT_MIRROR}/openxt/i5_i7_DUAL-SINIT_51.zip;name=i5 \
+           ${OPENXT_MIRROR}/openxt/i7_QUAD-SINIT_51.zip;name=i7 \
+           ${OPENXT_MIRROR}/openxt/Xeon-5600-3500-SINIT-v1.1.zip;name=xeon_5600 \
+           ${OPENXT_MIRROR}/openxt/Xeon-E7-8800-4800-2800-SINIT-v1.1.zip;name=xeon_e7 \
+           ${OPENXT_MIRROR}/openxt/3rd-gen-i5-i7-sinit-67.zip;name=ivb_snb \
+           ${OPENXT_MIRROR}/openxt/4th-gen-i5-i7-sinit-75.zip;name=hsw \
+           ${OPENXT_MIRROR}/openxt/5th_gen_i5_i7-SINIT_79.zip;name=bdw \
+           ${OPENXT_MIRROR}/openxt/6th_gen_i5_i7-SINIT_71.zip;name=skl \
+           ${OPENXT_MIRROR}/openxt/7th_gen_i5_i7-SINIT_74.zip;name=kbl \
 "
 
 FILES_${PN} = "/boot"

--- a/recipes-openxt/debootstrap/debootstrap.inc
+++ b/recipes-openxt/debootstrap/debootstrap.inc
@@ -4,7 +4,10 @@ XENCLIENT_BUILD_SRC_PACKAGES = "0"
 
 SSTATETASKS= ""
 
-SRC_URI = "${OPENXT_MIRROR}/debootstrap_${DEBOOTSTRAP_SUITE}_${DEBOOTSTRAP_ARCH}_${PV}.tar.gz"
+MIRRORS_append += " \
+    http://.*/.*    https://openxt.ainfosec.com/mirror/ \
+"
+SRC_URI = "${OPENXT_MIRROR}/openxt/debootstrap_${DEBOOTSTRAP_SUITE}_${DEBOOTSTRAP_ARCH}_${PV}.tar.gz"
 
 S = "${WORKDIR}/${DEBOOTSTRAP_SUITE}_${DEBOOTSTRAP_ARCH}"
 	

--- a/recipes-openxt/pmtools/pmtools_20100513.bb
+++ b/recipes-openxt/pmtools/pmtools_20100513.bb
@@ -1,11 +1,16 @@
-SRC_URI[md5sum] = "613d596275528a4c41e5dbf7a48f3ed2"
-SRC_URI[sha256sum] = "bffe9985f3079c01a534a408a3d0ccd38965b3e607fd2cc6a384648027a17f18"
-#SRC_URI="${KERNELORG_MIRROR}/pub/linux/kernel/people/lenb/acpi/utils/pmtools-${PV}.tar.bz2"
-SRC_URI="${OPENXT_MIRROR}/pmtools-${PV}.tar.bz2"
 LICENSE="GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-S="${WORKDIR}/pmtools"
+MIRRORS_append += " \
+    http://.*/.*      https://openxt.ainfosec.com/mirror/ \
+"
+SRC_URI = " \
+    ${OPENXT_MIRROR}/pmtools-${PV}.tar.bz2 \
+"
+SRC_URI[md5sum] = "613d596275528a4c41e5dbf7a48f3ed2"
+SRC_URI[sha256sum] = "bffe9985f3079c01a534a408a3d0ccd38965b3e607fd2cc6a384648027a17f18"
+
+S = "${WORKDIR}/pmtools"
 
 do_compile() {
         export CFLAGS="${CFLAGS} ${LDFLAGS}"
@@ -13,9 +18,9 @@ do_compile() {
 }
 
 do_install() {
-	install -d ${D}/usr/bin
-	install ${S}/acpidump/acpidump ${D}/usr/bin
-        install ${S}/acpixtract/acpixtract ${D}/usr/bin
-        install ${S}/turbostat/turbostat ${D}/usr/bin
-        install ${S}/pmtest/pmtest ${D}/usr/bin
+	install -d ${D}${bindir}
+	install ${S}/acpidump/acpidump ${D}${bindir}
+        install ${S}/acpixtract/acpixtract ${D}${bindir}
+        install ${S}/turbostat/turbostat ${D}${bindir}
+        install ${S}/pmtest/pmtest ${D}${bindir}
 }


### PR DESCRIPTION
~~- python-daemon still uses the deprecated http:// interfaces, switch to https as other recipes did.~~
- mirror.openxt.org changed its layout sometime recently. So attend for it. Since ainfosec.com also provide a mirror, add it for redundancy.