### PR TITLE
python-daemon: Fetch from https source.

### DIFF
--- a/recipes-devtools/python/python-daemon_1.5.5.bb
+++ b/recipes-devtools/python/python-daemon_1.5.5.bb
@@ -8,7 +8,7 @@ RDEPENDS_${PN} += "python-io \
 
 S = "${WORKDIR}/python-daemon-${PV}" 
 
-SRC_URI = "http://pypi.python.org/packages/source/p/python-daemon/python-daemon-${PV}.tar.gz;name=tarball"
+SRC_URI = "https://pypi.python.org/packages/source/p/python-daemon/python-daemon-${PV}.tar.gz;name=tarball"
 SRC_URI[tarball.md5sum] = "1f6cd41473c2e201021a0aeef395b2b1"
 SRC_URI[tarball.sha256sum] = "1406962e48ce03642c6057f40f9ffd49493792a7b34357fe9e264708748c83c0"
 


### PR DESCRIPTION
Fix builds without cache, python-daemon still uses the deprecated http:// interfaces, switch to https as other recipes did.