### PR TITLE
uivm reboot fix : remove sleep(), instead perform xs_watch()

### DIFF
--- a/recipes-extended/xen/files/xl-uivm-reboot-fix.patch
+++ b/recipes-extended/xen/files/xl-uivm-reboot-fix.patch
@@ -1,0 +1,121 @@
+Index: xen-4.9.1/tools/xl/xl_vmcontrol.c
+===================================================================
+--- xen-4.9.1.orig/tools/xl/xl_vmcontrol.c
++++ xen-4.9.1/tools/xl/xl_vmcontrol.c
+@@ -1139,15 +1139,22 @@ start:
+                     d_config.c_info.name = strdup(common_domname);
+                 }
+ 
++                LOG("Done. Rebooting now");
++                libxl_update_state_direct(ctx, d_config.c_info.uuid, "shutdown");
++                if (libxl_watch_xenmgr_state(ctx, d_config.c_info.uuid, "shutdown")) {
++                    goto out; /* If xs_watch fails then there is an issue with xenstore, so shutdown */
++                }
++
++                libxl_update_state_direct(ctx, d_config.c_info.uuid, "rebooted");
++                if (libxl_watch_xenmgr_state(ctx, d_config.c_info.uuid, "rebooted")) {
++                    goto out; /* If xs_watch fails then there is an issue with xenstore, so shutdown */
++                }
++
+                 /*
+                  * XXX FIXME: If this sleep is not there then domain
+                  * re-creation fails sometimes.
+                  */
+-                LOG("Done. Rebooting now");
+-                libxl_update_state_direct(ctx, d_config.c_info.uuid, "shutdown"); //Sleep here because daemons with an xs_watch on this node
+-                sleep(2);                                                         //won't see the "shutdown" event, just the "rebooted" one.
+-                libxl_update_state_direct(ctx, d_config.c_info.uuid, "rebooted"); //Once this is fixed in xenstore libs, sleep can be removed.
+-                sleep(2);
++                sleep(8);
+                 goto start;
+ 
+             case DOMAIN_RESTART_NONE:
+Index: xen-4.9.1/tools/libxl/libxl_utils.c
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_utils.c
++++ xen-4.9.1/tools/libxl/libxl_utils.c
+@@ -1389,6 +1389,67 @@ int libxl_util_xs_read(libxl_ctx *ctx, c
+     return 0;
+ }
+ 
++int libxl_util_xs_watch(libxl_ctx *ctx, const char *path, const char *value)
++{
++  fd_set set;
++  unsigned int len;
++  struct timeval tv = { .tv_sec = 10, .tv_usec = 0 };
++  int ret = -1;
++  int fd;
++  char **watch_path;
++  char *buf;
++
++  if(!xs_watch(ctx->xsh, path, value))
++    goto out;
++  fd = xs_fileno(ctx->xsh);
++  while(1) {
++
++    FD_ZERO(&set);
++    FD_SET(fd, &set);
++
++    if (select(fd + 1, &set, NULL, NULL, &tv) < 0)
++      break;
++
++    if (!FD_ISSET(fd, &set))
++      continue;
++
++    /* Read the watch to drain the buffer */
++    watch_path = xs_read_watch(ctx->xsh, &len);
++    free(watch_path);
++
++    buf = xs_read(ctx->xsh, XBT_NULL, path, NULL);
++    if (buf == NULL) {
++      ret = 1;
++      break;
++    }
++    else {
++      if(!strcmp(buf, value)) {
++        ret = 0;
++        free(buf);
++        break;
++      }
++      else {
++        free(buf);
++        continue;
++      }
++    }
++  }
++  xs_unwatch(ctx->xsh, path, value);
++out:
++  return ret;
++}
++
++int libxl_watch_xenmgr_state(libxl_ctx *ctx, libxl_uuid xl_uuid, const char *value) {
++
++  char path[sizeof("/state/00000000-0000-0000-0000-000000000000/xenmgr-state")];
++  char uuid[37];
++
++  uuid_unparse(xl_uuid.uuid, uuid);
++  sprintf(path, "/state/%s/xenmgr-state", uuid);
++
++  return (libxl_util_xs_watch(ctx, path, value));
++}
++
+ /*
+  * Local variables:
+  * mode: C
+Index: xen-4.9.1/tools/libxl/libxl_utils.h
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_utils.h
++++ xen-4.9.1/tools/libxl/libxl_utils.h
+@@ -172,6 +172,12 @@ int libxl_cpumap_to_nodemap(libxl_ctx *c
+ 
+ int libxl_util_xs_read(libxl_ctx *ctx, char *path, char **out);
+ 
++/* Watch on xenstore node for a particular update */
++int libxl_util_xs_watch(libxl_ctx *ctx, const char *path, const char *value);
++
++/* Watch xenmgr-state for a particular update */
++int libxl_watch_xenmgr_state(libxl_ctx *ctx, libxl_uuid xl_uuid, const char *value);
++
+  static inline uint32_t libxl__sizekb_to_mb(uint32_t s) {
+     return (s + 1023) / 1024;
+ }

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -90,6 +90,7 @@ SRC_URI_append = " \
     file://libxl-fix-flr.patch \
     file://libxl-disable-vnc-query-when-disabled.patch \
     file://xl-shutdown-wait-for-domain-death.patch \
+    file://xl-uivm-reboot-fix.patch \
     ${BLKTAP_PATCHQUEUE} \
     file://xsa246-4.9.patch \
     file://xsa247-4.9/0001-p2m-Always-check-to-see-if-removing-a-p2m-entry-actu.patch \


### PR DESCRIPTION
OXT-1270

Instead of sleeping for random amount of time, watch on xenstore node
for xenmgr state update and proceed accordingly.

Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>