### PR TITLE
remove useless cdrom VBD nodes from xenstore

### DIFF
--- a/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
+++ b/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
@@ -1,0 +1,86 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Don't create useless CDROM VBD nodes in xenstore
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+blkfront doesn't support CDROMs in HVMs. However, XL creates guest CDROM VBD
+nodes for the virtual CD, when it only makes sense for their stubdoms. XL also
+creates stubdom and guest nodes for atapi-pt drives, which doesn't make sense.
+To summarize, the creation of guest virtual cd nodes and all atapi-pt nodes
+should be removed from XL.
+
+################################################################################
+CHANGELOG
+################################################################################
+Authors:
+Mahantesh Salimath<salimathm@ainfosec.com>
+
+################################################################################
+Index: xen-4.9.1/tools/libxl/libxl_create.c
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_create.c
++++ xen-4.9.1/tools/libxl/libxl_create.c
+@@ -1265,7 +1265,7 @@ static void domcreate_rebuild_done(libxl
+ 
+     /* convenience aliases */
+     const uint32_t domid = dcs->guest_domid;
+-    libxl_domain_config *const d_config = dcs->guest_config;
++    libxl_domain_config *d_config = dcs->guest_config;
+ 
+     if (ret) {
+         LOGD(ERROR, domid, "cannot (re-)build domain: %d", ret);
+@@ -1275,11 +1275,51 @@ static void domcreate_rebuild_done(libxl
+ 
+     store_libxl_entry(gc, domid, &d_config->b_info);
+ 
++    /* Below quirk is to prevent the creation of useless vbd nodes
++     * in xenstore.
++     */
++    if(d_config->c_info.type == LIBXL_DOMAIN_TYPE_HVM) {
++        libxl_domain_config domain_config;
++        int i = 0;
++        int j = 0;
++        bool has_stub;
++
++        has_stub = libxl_defbool_val(d_config->b_info.device_model_stubdomain);
++        libxl_domain_config_copy(CTX, &domain_config, dcs->guest_config);
++        d_config = &domain_config;
++
++        for( ; i < d_config->num_disks; i++) {
++            if(d_config->disks[i].is_cdrom) {
++
++                /* No atapi-pt vbd nodes */
++                if(!strncmp(d_config->disks[i].vdev, "atapi-pt", 9))
++                    continue;
++
++                /* No emulated cdroms for guests that have stubdom */
++                if(has_stub)
++                    continue;
++
++            }
++            if(j != i)
++                    libxl_device_disk_copy(CTX,
++                                           &d_config->disks[j],
++                                           &d_config->disks[i]);
++            j++;
++        }
++        d_config->num_disks = j;
++        d_config->disks = libxl__realloc(NOGC,
++                                         d_config->disks,
++                                         sizeof(*(d_config->disks)) * j);
++    }
++
+     libxl__multidev_begin(ao, &dcs->multidev);
+     dcs->multidev.callback = domcreate_launch_dm;
+     libxl__add_disks(egc, ao, domid, d_config, &dcs->multidev);
+     libxl__multidev_prepared(egc, &dcs->multidev, 0);
+ 
++    if(d_config != dcs->guest_config)
++        libxl_domain_config_dispose(d_config);
++
+     return;
+ 
+  error_out:

--- a/recipes-extended/xen/files/libxl-disable-json-updates.patch
+++ b/recipes-extended/xen/files/libxl-disable-json-updates.patch
@@ -64,7 +64,7 @@ Index: xen-4.9.1/tools/libxl/libxl_create.c
 ===================================================================
 --- xen-4.9.1.orig/tools/libxl/libxl_create.c
 +++ xen-4.9.1/tools/libxl/libxl_create.c
-@@ -1586,25 +1586,6 @@ static void domcreate_complete(libxl__eg
+@@ -1626,25 +1626,6 @@ static void domcreate_complete(libxl__eg
  
      bool retain_domain = !rc || rc == ERROR_ABORTED;
  

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -10,9 +10,8 @@ LONG DESCRIPTION:
 ################################################################################
 CHANGELOG
 ################################################################################
-Author: Chris Rogers <rogersc@ainfosec.com>
-Date:   Tue Apr 18 14:43:21 2017 -0400
-
+Authors: Chris Rogers <rogersc@ainfosec.com>
+         Mahantesh Salimath <salimathm@ainfosec.com>
 ################################################################################
 REMOVAL
 ################################################################################
@@ -125,9 +124,9 @@ Index: xen-4.9.1/tools/libxl/libxl_disk.c
 +    disk_empty.vdev = libxl__strdup(NOGC, olddisk->vdev);
 +    disk_empty.pdev_path = libxl__strdup(NOGC, "");
 +    disk_empty.is_cdrom = 1;
-+    libxl__device_disk_setdefault(gc, &disk_empty, domid);
++    libxl__device_disk_setdefault(gc, &disk_empty, stubdomid);
 +
-+    lock = libxl__lock_domain_userdata(gc, domid);
++    lock = libxl__lock_domain_userdata(gc, stubdomid);
 +    if (!lock) {
 +        rc = ERROR_LOCK_FAIL;
 +        goto out;
@@ -516,10 +515,10 @@ Index: xen-4.9.1/tools/xl/xl_cdrom.c
 +     * send qmp message to stubdom to change cdrom medium using blkfront
 +     * target */
 +    if (stubdomid > 0) {
-+        disks = libxl_device_disk_list(ctx, domid, &nb);
++        disks = libxl_device_disk_list(ctx, stubdomid, &nb);
 +        if (disks) {
 +            for (i=0; i<nb; i++) {
-+                if (!libxl_device_disk_getinfo(ctx, domid, &disks[i], &diskinfo)) {
++                if (!libxl_device_disk_getinfo(ctx, stubdomid, &disks[i], &diskinfo)) {
 +                    xasprintf(&xspath, "%s/dev", diskinfo.backend);
 +                    if (!xspath) {
 +                        r = 0;
@@ -540,7 +539,7 @@ Index: xen-4.9.1/tools/xl/xl_cdrom.c
 +        }
 +        xasprintf(&strdevid, "%d", devid);
 +
-+        libxl_vdev_to_device_disk(ctx, domid, strdevid, &olddisk);
++        libxl_vdev_to_device_disk(ctx, stubdomid, strdevid, &olddisk);
 +
 +        libxl_cdrom_change(ctx, domid, phys, &olddisk, strdevid, NULL);
 +

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -84,6 +84,7 @@ SRC_URI_append = " \
     file://libxl-vwif-support.patch \
     file://libxl-atapi-pt.patch \
     file://libxl-iso-hotswap.patch \
+    file://libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch \
     file://libxl-disable-json-updates.patch \
     file://libxl-allow-non-qdisk-cdrom.patch \
     file://libxl-fix-flr.patch \


### PR DESCRIPTION
blkfront doesn't support CDROMs in HVMs. However, XL creates guest CDROM VBD
nodes for the virtual CD, when it only makes sense for their stubdoms. XL also
creates stubdom and guest nodes for atapi-pt drives, which doesn't make sense.
To summarize, the creation of guest virtual cd nodes and all atapi-pt nodes
should be removed from XL.

OXT-1259

Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>