### PR TITLE
Use correct ESP path during forward-sealing

### DIFF
--- a/recipes-openxt/openxt/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt/openxt-measuredlaunch/seal-system
@@ -146,27 +146,27 @@ forward)
 
         pcr4=$(hash_extend 0 $ev_separator $hashalg)
 
-        hash=$(pesign -h -d ${hashalg} -i /tmp/esp/EFI/BOOT/BOOTX64.EFI | awk '{ print $2 }')
+        hash=$(pesign -h -d ${hashalg} -i /tmp/esp/EFI/OpenXT/shimx64.efi | awk '{ print $2 }')
         pcr4=$(hash_extend $pcr4 $hash $hashalg) ||
             err "failed to calculate pcr4"
 
-        hash=$(${hashalg}sum /tmp/esp/EFI/BOOT/xen.efi | awk '{ print $1 }')
+        hash=$(${hashalg}sum /tmp/esp/EFI/OpenXT/xen.efi | awk '{ print $1 }')
         pcr4=$(hash_extend $pcr4 $hash $hashalg) ||
             err "failed to calculate pcr4"
 
-        hash=$(${hashalg}sum /tmp/esp/EFI/BOOT/bzImage | awk '{ print $1 }')
+        hash=$(${hashalg}sum /tmp/esp/EFI/OpenXT/bzImage | awk '{ print $1 }')
         pcr4=$(hash_extend $pcr4 $hash $hashalg) ||
             err "failed to calculate pcr4"
 
-        hash=$(${hashalg}sum /tmp/esp/EFI/BOOT/openxt.cfg | awk '{ print $1 }')
+        hash=$(${hashalg}sum /tmp/esp/EFI/OpenXT/openxt.cfg | awk '{ print $1 }')
         pcr8=$(hash_extend 0 $hash $hashalg) ||
             err "failed to calculate pcr8"
 
-        hash=$(${hashalg}sum /tmp/esp/EFI/BOOT/initramfs.gz | awk '{ print $1 }')
+        hash=$(${hashalg}sum /tmp/esp/EFI/OpenXT/initramfs.gz | awk '{ print $1 }')
         pcr8=$(hash_extend $pcr8 $hash $hashalg) ||
             err "failed to calculate pcr8"
 
-        hash=$(${hashalg}sum /tmp/esp/EFI/BOOT/policy.24 | awk '{ print $1 }')
+        hash=$(${hashalg}sum /tmp/esp/EFI/OpenXT/policy.24 | awk '{ print $1 }')
         pcr8=$(hash_extend $pcr8 $hash $hashalg) ||
             err "failed to calculate pcr8"
 


### PR DESCRIPTION
  The correct ESP path is \EFI\OpenXT after commit 99adcb9f1aeec3940b9ad0eb42b74a0f7570b0f7

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>