### PR TITLE
service-vms: Remove getty on consoles.

### DIFF
--- a/recipes-core/images/xenclient-image-common.inc
+++ b/recipes-core/images/xenclient-image-common.inc
@@ -36,3 +36,8 @@ ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "read-only
 start_tty_on_hvc0() {
 	echo 'hvc0:12345:respawn:/bin/start_getty 115200 hvc0 vt102' >> ${IMAGE_ROOTFS}/etc/inittab;
 }
+
+# Remove default login shell on tty1 in inittab.
+remove_getty_on_tty() {
+    sed -i '/^#*.*getty.*tty[0-9]/d' ${IMAGE_ROOTFS}/etc/inittab ;
+}

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -84,13 +84,13 @@ post_rootfs_shell_commands() {
     # enable ctrlaltdel reboot because PV driver uses ctrl+alt+del to interpret reboot issued via xenstore
     echo 'ca:12345:ctrlaltdel:/sbin/shutdown -t1 -a -r now' >> ${IMAGE_ROOTFS}/etc/inittab;
 
-    # NDVM doesn't have a /dev/tty1, disable the login shell on it
-    sed -i 's/[^#].*getty.*tty1$/#&/' ${IMAGE_ROOTFS}/etc/inittab ;
-
     # Forcibly remove packages in PACKAGE_REMOVE variable.
     opkg -f ${IPKGCONF_TARGET} -o ${IMAGE_ROOTFS} ${OPKG_ARGS} -force-depends remove ${PACKAGE_REMOVE};
 }
 ROOTFS_POSTPROCESS_COMMAND += "post_rootfs_shell_commands; "
+
+# Remove getty on tty consoles, service-vms do not have a need for it.
+ROOTFS_POSTPROCESS_COMMAND += "remove_getty_on_tty; "
 
 # Get a tty on hvc0 when in debug mode.
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "debug-tweaks", "start_tty_on_hvc0; ", "",d)}'

--- a/recipes-core/images/xenclient-uivm-image.bb
+++ b/recipes-core/images/xenclient-uivm-image.bb
@@ -125,6 +125,9 @@ post_rootfs_shell_commands() {
 }
 ROOTFS_POSTPROCESS_COMMAND += "post_rootfs_shell_commands; "
 
+# Remove getty on tty consoles, service-vms do not have a need for it.
+ROOTFS_POSTPROCESS_COMMAND += "remove_getty_on_tty; "
+
 # Get a tty on hvc0 when in debug mode.
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "debug-tweaks", "start_tty_on_hvc0; ", "",d)}'
 


### PR DESCRIPTION
There is no need for it to start getty on tty[0-9] in service-vm.