### PR TITLE
service-vms: Remove getty on consoles.

### DIFF
--- a/conf/machine/xenclient-ndvm.conf
+++ b/conf/machine/xenclient-ndvm.conf
@@ -7,3 +7,5 @@
 require xenclient-common.conf
 
 MACHINE_FEATURES = "kernel26 ethernet pci ext2 x86"
+
+USE_VT = "0"

--- a/conf/machine/xenclient-stubdomain.conf
+++ b/conf/machine/xenclient-stubdomain.conf
@@ -7,3 +7,5 @@
 require xenclient-common.conf
 
 MACHINE_FEATURES = "kernel26 screen keyboard ethernet pci acpi ext2 x86"
+
+USE_VT = "0"

--- a/conf/machine/xenclient-uivm.conf
+++ b/conf/machine/xenclient-uivm.conf
@@ -16,3 +16,5 @@ XSERVER = "xserver-xorg \
 MACHINE_FEATURES = "kernel26 screen keyboard ethernet pci acpi ext2 x86"
 
 DISTRO_FEATURES_append += "opengl"
+
+USE_VT = "0"


### PR DESCRIPTION
Following https://github.com/OpenXT/xenclient-oe/pull/839, add `USE_VT = "0"`, as recommended by @jandryuk, to UIVM, NDVM and stub-domains (not required but seems consistent).