### PR TITLE
OXT-1290: ipxe: Add back intel PXE rom to hvmloader.

### DIFF
--- a/recipes-extended/ipxe/ipxe_%.bbappend
+++ b/recipes-extended/ipxe/ipxe_%.bbappend
@@ -17,3 +17,7 @@ SRCREV = "827dd1bfee67daa683935ce65316f7e0f057fe1c"
 LIC_FILES_CHKSUM = "file://../COPYING;md5=92be9bced83819c46c5ab272173c4aa7"
 
 EXTRA_OEMAKE_append = " HOST_CFLAGS='${BUILD_CFLAGS} ${BUILD_LDFLAGS}'"
+
+do_compile_append() {
+    oe_runmake bin/intel.rom
+}

--- a/recipes-extended/xen/xen.bb
+++ b/recipes-extended/xen/xen.bb
@@ -71,7 +71,7 @@ INITSCRIPT_PARAMS_${PN}-console = "defaults 20"
 INITSCRIPT_NAME_${PN}-xenstored-c = "xenstored"
 INITSCRIPT_PARAMS_${PN}-xenstored-c = "defaults 05"
 
-EXTRA_OEMAKE += "ETHERBOOT_ROMS=${STAGING_DIR_HOST}/usr/share/firmware/e1000.rom"
+EXTRA_OEMAKE += "ETHERBOOT_ROMS=${STAGING_DIR_HOST}/usr/share/firmware/intel.rom"
 
 pkg_postinst_${PN}-xenstored-c () {
     update-alternatives --install ${sbindir}/xenstored xenstored xenstored.${PN}-xenstored-c 200
@@ -97,7 +97,7 @@ do_compile() {
     # tools/firmware/Rules.mk: override XEN_TARGET_ARCH = x86_32
     # With a 32bit host targeting a 64bit machine, this will break passing -m32
     # -m64 and using the 64bit sysroot.
-    if [ "${XEN_TARGET_ARCH}" = "${XEN_COMPILE_ARCH}"]; then
+    if [ "${XEN_TARGET_ARCH}" = "${XEN_COMPILE_ARCH}" ]; then
         oe_runmake -C tools subdir-all-firmware
     fi
 }


### PR DESCRIPTION
This was lost with xenclient-oe.git:
808a27be ipxe: Use meta-virt recipe.

The upstream ipxe intel driver got replaced:
945e4281 [intel] Replace driver for Intel Gigabit NICs
... Replace the e1000*.rom statement with the new intel.rom.

Sneak in a fix for a silly typo as well.