### PR TITLE
tpm-functions: use dmesg instead of not-always-there sys node to detect TPM 2.0

### DIFF
--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -30,7 +30,15 @@ clean_old_tpm_files () {
 }
 
 is_tpm_2_0 () {
-   [ -e /sys/class/tpm/tpm0/device/description ] && cat /sys/class/tpm/tpm0/device/description | grep "2.0" &>/dev/null
+    # Grab the tpm_tis line from dmesg
+    isit1=`dmesg | grep -m 1 tpm_tis`
+    # Remove the timestamp
+    isit2=${isit1#\[*\]}
+    # Remove the module name and version
+    isit3=${isit2#*: }
+    # Keep only the first word (the TPM version)
+    isit4=${isit3%% *}
+    [[ $isit4 = "2.0" ]]
 }
 
 pcr_bank_exists () {


### PR DESCRIPTION
Signed-off-by: Jed <lejosnej@ainfosec.com>