### PR TITLE
layer: Attend left-over QA warnings (pass 3)

### DIFF
--- a/recipes-devtools/rsync/rsync_%.bbappend
+++ b/recipes-devtools/rsync/rsync_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG_append = " xattr"
+PACKAGECONFIG_append += "attr"

--- a/recipes-graphics/xorg-driver/xorg-driver-video.inc
+++ b/recipes-graphics/xorg-driver/xorg-driver-video.inc
@@ -2,3 +2,6 @@ include xorg-driver-common.inc
 
 DEPENDS =+ "renderproto videoproto xextproto fontsproto"
 
+# xorg-driver-abi was introduced in later versions of the recipe.
+# This should be removed when xserver & relevant gets upgraded.
+INSANE_SKIP_${PN} = "xorg-driver-abi"

--- a/recipes-graphics/xorg-lib/libxi_1.4.5.bb
+++ b/recipes-graphics/xorg-lib/libxi_1.4.5.bb
@@ -18,7 +18,7 @@ PR = "r0"
 
 XORG_PN = "libXi"
 
-EXTRA_OECONF_append = " --enable-specs=no"
+EXTRA_OECONF_append += "--with-fop=no --without-xmlto --enable-specs=no"
 
 SRC_URI[md5sum] = "82dcdc76388116800a2c3ad969f510a4"
 SRC_URI[sha256sum] = "22a99123229d22e6e1567c4cda0224a744475f427625d61b23d965157a86f1b5"

--- a/recipes-graphics/xorg-lib/xorg-lib-common.inc
+++ b/recipes-graphics/xorg-lib/xorg-lib-common.inc
@@ -13,7 +13,7 @@ S = "${WORKDIR}/${XORG_PN}-${PV}"
 
 inherit autotools pkgconfig
 
-EXTRA_OECONF = "--enable-malloc0returnsnull --with-fop=no --without-xmlto"
+EXTRA_OECONF = "--enable-malloc0returnsnull"
 
 python () {
         whitelist = [ "pixman" ]


### PR DESCRIPTION
More low priority warnings:
```
WARNING: rsync-3.1.2-r0 do_configure: QA Issue: rsync: invalid PACKAGECONFIG: xattr [invalid-packageconfig]
WARNING: libxrandr-1_1.3.2-r0 do_configure: QA Issue: libxrandr: configure was passed unrecognised options: --with-fop --without-xmlto [unknown-configure-option]
WARNING: xf86-video-fbdev-2_0.4.2-r17.0.1 do_package_qa: QA Issue: Package xf86-video-fbdev contains Xorg driver (fbdev_drv.so) but no xorg-abi- dependencies [xorg-driver-abi]
```