### PR TITLE
Change the tpm2.0 identification method

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
@@ -28,7 +28,14 @@ DEFINIT=/sbin/init
 FIRSTBOOT_FLAG=/boot/system/firstboot
 
 is_tpm_2_0 () {
-    [ -e /sys/class/tpm/tpm0/device/description ] && cat /sys/class/tpm/tpm0/device/description | grep "2.0" &>/dev/null
+   files=$(find /sys/ | grep "description$")
+   for file in $files; do
+      tpm=$(cat ${file})
+      if [ "${tpm}" == "TPM 2.0 Device" ]; then
+         return 0
+      fi
+   done
+   return 1
 }
 
 #listpcrs sample output:

--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -30,7 +30,14 @@ clean_old_tpm_files () {
 }
 
 is_tpm_2_0 () {
-   [ -e /sys/class/tpm/tpm0/device/description ] && cat /sys/class/tpm/tpm0/device/description | grep "2.0" &>/dev/null
+   files=$(find /sys/ | grep "description$")
+   for file in $files; do
+      tpm=$(cat ${file})
+      if [ "${tpm}" == "TPM 2.0 Device" ]; then
+         return 0
+      fi
+   done
+   return 1
 }
 
 pcr_bank_exists () {


### PR DESCRIPTION
Linux Kernel 4.11 changed the location yet again on where to find the TPM description. Make the function for finding the TPM version more robust for any future changes.