### PR TITLE
STABLE-8: OXT-1297: linux-4.14: objtool for out-of-tree modules.

### DIFF
--- a/recipes-kernel/linux/4.14/linux-openxt_4.14.22.bb
+++ b/recipes-kernel/linux/4.14/linux-openxt_4.14.22.bb
@@ -5,8 +5,6 @@ require recipes-kernel/linux/linux.inc
 require recipes-kernel/linux/linux-openxt.inc
 
 PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
-INSANE_SKIP_kernel-module-txt = "arch"
-INSANE_SKIP_kernel-vmlinux = "arch"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:${THISDIR}/defconfigs:"
 SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;name=kernel \

--- a/recipes-kernel/linux/linux-openxt-copy-objtool.inc
+++ b/recipes-kernel/linux/linux-openxt-copy-objtool.inc
@@ -1,0 +1,11 @@
+# Backport from upstream commit to attend 4.14 and later kernels and
+# out-of-tree modules:
+# https://patchwork.openembedded.org/patch/148047/
+do_shared_workdir_append () {
+    # With CONFIG_UNWINDER_ORC (the default in 4.14), objtool is required for
+    # out-of-tree modules to be able to generate object files.
+    if [ -x tools/objtool/objtool ]; then
+        mkdir -p ${kerneldir}/tools/objtool
+        cp tools/objtool/objtool ${kerneldir}/tools/objtool/
+    fi
+}

--- a/recipes-kernel/linux/linux-openxt.inc
+++ b/recipes-kernel/linux/linux-openxt.inc
@@ -1,4 +1,4 @@
-inherit xenclient
+require recipes-kernel/linux/linux-openxt-copy-objtool.inc
 
 DEPENDS += "bc-native"
 


### PR DESCRIPTION
CONFIG_STACK_VALIDATION=y will require objtool available for out-of-tree
modules to generate object files.

Taken from commit:
https://patchwork.openembedded.org/patch/148047/