### PR TITLE
STABLE-8: OXT-1306: dbus: Fix recipe DEPENDS statement.

### DIFF
--- a/recipes-core/dbus/dbus_1.%.bbappend
+++ b/recipes-core/dbus/dbus_1.%.bbappend
@@ -1,7 +1,14 @@
-DEPENDS_${PN} += " \
+# LibSELinux does not extend nativesdk.
+DEPENDS_append_class-native += " \
+    libselinux \
+"
+# DBus will not link with libv4v in the native case.
+# The v4v kernel headers cannot be expected in the native environment since
+# libv4v depends on Xen, and the hypervisor headers are not separated from the
+# main recipe.
+DEPENDS_append_class-target += " \
     libselinux \
     libv4v \
-    xen \
 "
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 


### PR DESCRIPTION
DEPENDS applies for the whole recipe, giving it an "_<PACKAGE>" will
have Bitbake ignore it.

DBus does not require xen as depend (libv4v does).
Since libv4v is optional for that recipe, depend on it only for the
target build. DBus recipe provides native tools, and libv4v is not
needed for that.