### PR TITLE
STABLE-8: OXT-1301: xl: fix network detach

### DIFF
--- a/recipes-extended/xen/files/libxl-atapi-pt.patch
+++ b/recipes-extended/xen/files/libxl-atapi-pt.patch
@@ -33,10 +33,10 @@ INTERNAL DEPENDENCIES
 ################################################################################
 PATCHES
 ################################################################################
-Index: xen-4.9.0/tools/libxl/libxl_device.c
+Index: xen-4.9.1/tools/libxl/libxl_device.c
 ===================================================================
---- xen-4.9.0.orig/tools/libxl/libxl_device.c
-+++ xen-4.9.0/tools/libxl/libxl_device.c
+--- xen-4.9.1.orig/tools/libxl/libxl_device.c
++++ xen-4.9.1/tools/libxl/libxl_device.c
 @@ -271,6 +271,11 @@ static int disk_try_backend(disk_try_bac
              return backend;
          }
@@ -72,11 +72,11 @@ Index: xen-4.9.0/tools/libxl/libxl_device.c
  
      chrused = -1;
      if ((sscanf(virtpath, "d%ip%i%n", &disk, &partition, &chrused)  >= 2
-Index: xen-4.9.0/tools/libxl/libxl_dm.c
+Index: xen-4.9.1/tools/libxl/libxl_dm.c
 ===================================================================
---- xen-4.9.0.orig/tools/libxl/libxl_dm.c
-+++ xen-4.9.0/tools/libxl/libxl_dm.c
-@@ -1532,13 +1532,20 @@ static int libxl__build_device_model_arg
+--- xen-4.9.1.orig/tools/libxl/libxl_dm.c
++++ xen-4.9.1/tools/libxl/libxl_dm.c
+@@ -1531,13 +1531,20 @@ static int libxl__build_device_model_arg
              }
  
              if (disks[i].is_cdrom) {
@@ -104,7 +104,7 @@ Index: xen-4.9.0/tools/libxl/libxl_dm.c
              } else {
                  /*
                   * Explicit sd disks are passed through as is.
-@@ -1694,6 +1701,34 @@ static int libxl__build_device_model_arg
+@@ -1693,6 +1700,34 @@ static int libxl__build_device_model_arg
      }
  }
  
@@ -139,7 +139,7 @@ Index: xen-4.9.0/tools/libxl/libxl_dm.c
  static void libxl__dm_vifs_from_hvm_guest_config(libxl__gc *gc,
                                      libxl_domain_config * const guest_config,
                                      libxl_domain_config *dm_config)
-@@ -1896,9 +1931,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1895,9 +1930,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.extra_hvm = guest_config->b_info.extra_hvm;
      dm_config->b_info.stubdom_cmdline = guest_config->b_info.stubdom_cmdline;
  
@@ -150,10 +150,10 @@ Index: xen-4.9.0/tools/libxl/libxl_dm.c
      libxl__dm_vifs_from_hvm_guest_config(gc, guest_config, dm_config);
  
      dm_config->c_info.run_hotplug_scripts =
-Index: xen-4.9.0/tools/libxl/libxlu_disk.c
+Index: xen-4.9.1/tools/libxl/libxlu_disk.c
 ===================================================================
---- xen-4.9.0.orig/tools/libxl/libxlu_disk.c
-+++ xen-4.9.0/tools/libxl/libxlu_disk.c
+--- xen-4.9.1.orig/tools/libxl/libxlu_disk.c
++++ xen-4.9.1/tools/libxl/libxlu_disk.c
 @@ -75,7 +75,9 @@ int xlu_disk_parse(XLU_Config *cfg,
      }
      if (disk->is_cdrom) {

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -28,8 +28,10 @@ INTERNAL DEPENDENCIES
 ################################################################################
 PATCHES
 ################################################################################
---- a/tools/libxl/libxl_device.c
-+++ b/tools/libxl/libxl_device.c
+Index: xen-4.9.1/tools/libxl/libxl_device.c
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_device.c
++++ xen-4.9.1/tools/libxl/libxl_device.c
 @@ -737,7 +737,8 @@ int libxl__device_destroy(libxl__gc *gc,
              libxl__xs_path_cleanup(gc, t, be_path);
          }
@@ -95,8 +97,10 @@ PATCHES
  
          GCNEW(aodev);
          libxl__prepare_ao_device(ao, aodev);
---- a/tools/libxl/libxl_dm.c
-+++ b/tools/libxl/libxl_dm.c
+Index: xen-4.9.1/tools/libxl/libxl_dm.c
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_dm.c
++++ xen-4.9.1/tools/libxl/libxl_dm.c
 @@ -1230,9 +1230,12 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
@@ -113,7 +117,7 @@ PATCHES
                  flexarray_append(dm_args, "-netdev");
                  flexarray_append(dm_args,
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
-@@ -1704,6 +1707,8 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1703,6 +1706,8 @@ static void libxl__dm_vifs_from_hvm_gues
          libxl_device_nic_init(&dm_config->nics[i]);
          libxl_device_nic_copy(ctx, &dm_config->nics[i], &guest_config->nics[i]);
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;
@@ -122,8 +126,10 @@ PATCHES
          if (dm_config->nics[i].ifname)
              dm_config->nics[i].ifname = GCSPRINTF("%s" TAP_DEVICE_SUFFIX,
                                                    dm_config->nics[i].ifname);
---- a/tools/libxl/libxl_linux.c
-+++ b/tools/libxl/libxl_linux.c
+Index: xen-4.9.1/tools/libxl/libxl_linux.c
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_linux.c
++++ xen-4.9.1/tools/libxl/libxl_linux.c
 @@ -51,7 +51,8 @@ static char **get_hotplug_env(libxl__gc
      env[nr++] = GCSPRINTF("backend/%s/%u/%d", type, dev->domid, dev->devid);
      env[nr++] = "XENBUS_BASE_PATH";
@@ -142,8 +148,10 @@ PATCHES
          /*
           * If domain has a stubdom we don't have to execute hotplug scripts
           * for emulated interfaces
---- a/tools/libxl/libxl_nic.c
-+++ b/tools/libxl/libxl_nic.c
+Index: xen-4.9.1/tools/libxl/libxl_nic.c
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_nic.c
++++ xen-4.9.1/tools/libxl/libxl_nic.c
 @@ -57,6 +57,7 @@ int libxl__device_nic_setdefault(libxl__
  {
      int rc;
@@ -179,7 +187,15 @@ PATCHES
          if ((nic->devid = libxl__device_nextid(gc, domid, "vif")) < 0) {
              rc = ERROR_FAIL;
              goto out;
-@@ -385,6 +393,10 @@ static int libxl__device_nic_from_xensto
+@@ -367,6 +375,7 @@ static int libxl__device_nic_from_xensto
+     int rc;
+ 
+     libxl_device_nic_init(nic);
++    libxl_defbool_setdefault(&nic->wireless, false);
+ 
+     rc = libxl__xs_read_checked(gc, XBT_NULL,
+                                 GCSPRINTF("%s/handle", libxl_path), &tmp);
+@@ -385,6 +394,10 @@ static int libxl__device_nic_from_xensto
          rc = ERROR_FAIL;
          goto out;
      }
@@ -190,7 +206,7 @@ PATCHES
      rc = libxl__backendpath_parse_domid(gc, tmp, &nic->backend_domid);
      if (rc) goto out;
  
-@@ -508,6 +520,10 @@ int libxl_devid_to_device_nic(libxl_ctx
+@@ -508,6 +521,10 @@ int libxl_devid_to_device_nic(libxl_ctx
      libxl_path = GCSPRINTF("%s/device/vif/%d", libxl_dom_path, devid);
  
      rc = libxl__device_nic_from_xenstore(gc, libxl_path, nic);
@@ -201,7 +217,7 @@ PATCHES
      if (rc) goto out;
  
      rc = 0;
-@@ -519,13 +535,14 @@ out:
+@@ -519,13 +536,14 @@ out:
  static int libxl__append_nic_list(libxl__gc *gc,
                                             uint32_t domid,
                                             libxl_device_nic **nics,
@@ -218,7 +234,7 @@ PATCHES
  
      libxl_dir_path = GCSPRINTF("%s/device/vif",
                                 libxl__xs_libxl_path(gc, domid));
-@@ -546,9 +563,14 @@ static int libxl__append_nic_list(libxl_
+@@ -546,9 +564,14 @@ static int libxl__append_nic_list(libxl_
          }
          *nnics += n;
      }
@@ -234,7 +250,7 @@ PATCHES
      return rc;
  }
  
-@@ -560,7 +582,7 @@ libxl_device_nic *libxl_device_nic_list(
+@@ -560,7 +583,7 @@ libxl_device_nic *libxl_device_nic_list(
  
      *num = 0;
  
@@ -243,7 +259,7 @@ PATCHES
      if (rc) goto out_err;
  
      GC_FREE;
-@@ -587,9 +609,15 @@ int libxl_device_nic_getinfo(libxl_ctx *
+@@ -587,9 +610,15 @@ int libxl_device_nic_getinfo(libxl_ctx *
      dompath = libxl__xs_get_dompath(gc, domid);
      nicinfo->devid = nic->devid;
  
@@ -262,9 +278,11 @@ PATCHES
      nicinfo->backend = xs_read(ctx->xsh, XBT_NULL,
                                  GCSPRINTF("%s/backend", libxl_path), NULL);
      if (!nicinfo->backend) {
---- a/tools/libxl/libxl_types.idl
-+++ b/tools/libxl/libxl_types.idl
-@@ -677,6 +677,7 @@ libxl_device_nic = Struct("device_nic",
+Index: xen-4.9.1/tools/libxl/libxl_types.idl
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_types.idl
++++ xen-4.9.1/tools/libxl/libxl_types.idl
+@@ -673,6 +673,7 @@ libxl_device_nic = Struct("device_nic",
      ("rate_bytes_per_interval", uint64),
      ("rate_interval_usecs", uint32),
      ("gatewaydev", string),
@@ -272,8 +290,10 @@ PATCHES
      # Note that the COLO configuration settings should be considered unstable.
      # They may change incompatibly in future versions of Xen.
      ("coloft_forwarddev", string),
---- a/tools/libxl/libxl_types_internal.idl
-+++ b/tools/libxl/libxl_types_internal.idl
+Index: xen-4.9.1/tools/libxl/libxl_types_internal.idl
+===================================================================
+--- xen-4.9.1.orig/tools/libxl/libxl_types_internal.idl
++++ xen-4.9.1/tools/libxl/libxl_types_internal.idl
 @@ -26,6 +26,7 @@ libxl__device_kind = Enumeration("device
      (9, "VUSB"),
      (10, "QUSB"),
@@ -282,8 +302,10 @@ PATCHES
      ])
  
  libxl__console_backend = Enumeration("console_backend", [
---- a/tools/xl/xl_parse.c
-+++ b/tools/xl/xl_parse.c
+Index: xen-4.9.1/tools/xl/xl_parse.c
+===================================================================
+--- xen-4.9.1.orig/tools/xl/xl_parse.c
++++ xen-4.9.1/tools/xl/xl_parse.c
 @@ -576,6 +576,8 @@ int parse_nic_config(libxl_device_nic *n
          replace_string(&nic->colo_checkpoint_port, oparg);
      } else if (MATCH_OPTION("accel", token, oparg)) {


### PR DESCRIPTION
xl network-detach is currently broken, seems like changes were missed
while porting to xen-4.9

OXT-1301

Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>
(cherry picked from commit bf22feff03a04e80f186a52fdbe8e183699d4c0c)
Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>