### PR TITLE
STABLE-8: OXT-1304: v4v: Fix SMAP & HVM guest use

### DIFF
--- a/recipes-extended/xen/files/v4v.patch
+++ b/recipes-extended/xen/files/v4v.patch
@@ -130,7 +130,7 @@ PATCHES
      int port;
 --- /dev/null
 +++ b/xen/common/v4v.c
-@@ -0,0 +1,1964 @@
+@@ -0,0 +1,1980 @@
 +/******************************************************************************
 + * v4v.c
 + *
@@ -419,7 +419,24 @@ PATCHES
 +  return 0;
 +}
 +
++static int
++v4v_copy_from_guest (uint8_t *dst,
++                     XEN_GUEST_HANDLE (uint8_t) src_hnd,
++                     uint32_t len)
++{
++  struct guest_memory_policy policy = { .smap_policy = SMAP_CHECK_DISABLED,
++                                        .nested_guest_mode = false };
++  struct vcpu *v = current;
++  int ret = 0;
 +
++  update_guest_memory_policy(v, &policy);
++  if (copy_from_guest (dst, src_hnd, len))
++      ret = -EFAULT;
++
++  update_guest_memory_policy(v, &policy);
++
++  return ret;
++}
 +
 +/*called must have L3*/
 +static int
@@ -445,9 +462,8 @@ PATCHES
 +              MY_FILE, __LINE__, dst, offset, (void *) src_hnd.p,
 +              (int) (PAGE_SIZE - offset));
 +#endif
-+      if (copy_from_guest ((dst + offset), src_hnd, PAGE_SIZE - offset))
++      if (v4v_copy_from_guest ((dst + offset), src_hnd, PAGE_SIZE - offset))
 +          return -EFAULT;
-+
 +
 +      page++;
 +      len -= PAGE_SIZE - offset;
@@ -464,7 +480,7 @@ PATCHES
 +  printk (KERN_ERR "%s:%d copy_from_guest(%p+%d,%p,%d)\n",
 +          MY_FILE, __LINE__, dst, offset, (void *) src_hnd.p, len);
 +#endif
-+  if (copy_from_guest ((dst + offset), src_hnd, len))
++  if (v4v_copy_from_guest ((dst + offset), src_hnd, len))
 +      return -EFAULT;
 +
 +  return 0;


### PR DESCRIPTION
When SMAP is enabled, v4v_send fails from an HVM domain. The guest page table walk fails with an emulated SMAP violation. SMAP emulation needs to be disabled to allow the send.

This is a forward port of a stable-6 patch implementing the same functionality. It required changing the Xen function used to disable SMAP. Integrating this into a normal build tests fine with the PV domains. I haven't actually tested with HVM on a master build at this time. This is needed for the HVM NDVM, which is still on my to-do list.