### PR TITLE
installer-image: Add timeout to UEFI grub.cfg

### DIFF
--- a/recipes-core/images/xenclient-installer-image/grub.cfg
+++ b/recipes-core/images/xenclient-installer-image/grub.cfg
@@ -1,3 +1,5 @@
+set timeout=10
+
 menuentry --hotkey=i 'OpenXT Install' {
     set background_color=black
     multiboot2 /isolinux/xen.gz placeholder flask=disabled console=com1 com1=115200,8n1,pci mbi-video vga=current loglvl=debug guest_loglvl=debug sync_console


### PR DESCRIPTION
Right now, there is no timeout, so grub waits forever.  Add a default
timeout so we boot into the installer and wait there instead.  This
matches the legacy isolinux boot behaviour.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>