### PR TITLE
STABLE-8: OXT-1300: Use runlevels to control console login

### DIFF
--- a/recipes-core/sysvinit/sysvinit-inittab_%.bbappend
+++ b/recipes-core/sysvinit/sysvinit-inittab_%.bbappend
@@ -1,0 +1,5 @@
+
+do_install_append() {
+    sed -i '/getty 38400 tty/s/12345:respawn/3:respawn/' \
+        ${D}${sysconfdir}/inittab
+}

--- a/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
@@ -99,6 +99,8 @@ read_args() {
                 ;;
             break=*)
                 BREAK=$optarg ;;
+            [0123456Ss])
+                RUNLEVEL=$arg ;;
         esac
     done
 }
@@ -192,7 +194,7 @@ boot_root() {
     mount --move /sys /root/sys
 
     cd /root
-    exec switch_root -c /dev/console /root /sbin/selinux-load.sh ${INIT:-$DEFINIT}
+    exec switch_root -c /dev/console /root /sbin/selinux-load.sh ${INIT:-$DEFINIT} ${RUNLEVEL}
 }
 
 fatal() {

--- a/recipes-openxt/xenclient/surfman/surfman.initscript
+++ b/recipes-openxt/xenclient/surfman/surfman.initscript
@@ -27,7 +27,6 @@ SURFMAN_OPTS=""
 
 case "$1" in
   start)
-        grep -q no-graphics /proc/cmdline && SURFMAN_OPTS="${SURFMAN_OPTS} -c"
         grep -q safe-graphic /proc/cmdline && SURFMAN_OPTS="${SURFMAN_OPTS} -s"
 
         # Allow 55MB for core dumps

--- a/recipes-openxt/xenclient/surfman_git.bb
+++ b/recipes-openxt/xenclient/surfman_git.bb
@@ -21,7 +21,7 @@ ASNEEDED = ""
 inherit autotools xenclient update-rc.d pkgconfig
 
 INITSCRIPT_NAME = "surfman"
-INITSCRIPT_PARAMS = "defaults 72"
+INITSCRIPT_PARAMS = "start 72 5 . stop 72 0 1 2 3 4 6 ."
 
 pkg_postinst_${PN} () {
     if [ ! -f $D/etc/surfman.conf ]; then

--- a/recipes-openxt/xenclient/updatemgr_git.bb
+++ b/recipes-openxt/xenclient/updatemgr_git.bb
@@ -39,7 +39,7 @@ inherit update-rc.d haskell xc-rpcgen
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME_${PN} = "updatemgr"
-INITSCRIPT_PARAMS_${PN} = "start 80 5 . stop 01 0 1 6 ."
+INITSCRIPT_PARAMS_${PN} = "defaults 80"
 
 do_configure_append() {
 	# generate rpc stubs

--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
@@ -154,7 +154,7 @@ menuentry "XenClient Technical Support Option: console access" {
         set root=lvm/xenclient-root
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD com1=115200,8n1,pci
-        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 no-graphics fbcon
+        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon 3
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -177,7 +177,7 @@ menuentry "XenClient Technical Support Option: console access with AMT serial" {
         set root=lvm/xenclient-root
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1,vga com1=115200,8n1,amt
-        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 no-graphics fbcon
+        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon 3
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN

--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
@@ -3,35 +3,35 @@ default=openxt-normal
 
 [openxt-normal]
 options=console=com1 dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
-kernel=bzImage console=hvc0 autostart root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 autostart
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-safe-graphics]
 options=console=com1 dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
-kernel=bzImage console=hvc0 safe-graphic nomodeset root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 safe-graphic nomodeset
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
-kernel=bzImage console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-console]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
-kernel=bzImage console=hvc0,tty0 no-graphics fbcon root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 no-graphics fbcon
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-console-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
-kernel=bzImage console=hvc0,tty0 no-graphics fbcon root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 no-graphics fbcon
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin

--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
@@ -24,14 +24,14 @@ ucode=microcode_intel.bin
 
 [openxt-support-console]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 no-graphics fbcon
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-console-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 no-graphics fbcon
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin

--- a/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
@@ -477,4 +477,5 @@ fi
 
 unload_modules
 
-exec /sbin/init
+# We want to pass the runlevel specifically, but just pass along all arguments.
+exec /sbin/init "$@"

--- a/recipes-openxt/xenclient/xenmgr/xenmgr_git.bb
+++ b/recipes-openxt/xenclient/xenmgr/xenmgr_git.bb
@@ -45,7 +45,7 @@ S = "${WORKDIR}/git/xenmgr"
 inherit haskell update-rc.d xc-rpcgen
 
 INITSCRIPT_NAME = "xenmgr"
-INITSCRIPT_PARAMS = "start 80 5 . stop 01 0 1 6 ."
+INITSCRIPT_PARAMS = "defaults 80"
 
 FILES_${PN} += " \
     ${datadir}/xenmgr-1.0/templates/default/* \


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/xenclient-oe/pull/858

We only want to run a getty on tty1 in console mode, and suppress the getty for graphical boots. Use init runlevels to differentiate between text console (runlevel 3) and graphical (5) boots.

More discussion is here https://github.com/OpenXT/xenclient-oe/pull/858