### PR TITLE
OXT-1313: tpm2-tools: backport fixes for tpm2_listpcrs.

### DIFF
--- a/recipes-openxt/tss/tpm2-tools/0001-tpm2_listpcrs-use-TPM2_GetCapability-to-determine-PC.patch
+++ b/recipes-openxt/tss/tpm2-tools/0001-tpm2_listpcrs-use-TPM2_GetCapability-to-determine-PC.patch
@@ -1,0 +1,122 @@
+From d1152ca70eab47fbbabcd65122898ededb338c67 Mon Sep 17 00:00:00 2001
+From: Jerry Snitselaar <jsnitsel@redhat.com>
+Date: Mon, 15 May 2017 14:01:24 -0700
+Subject: [PATCH 1/3] tpm2_listpcrs: use TPM2_GetCapability to determine PCRs
+ to read
+
+Allow TPM to tell us PCRs that are available to be read in a bank
+instead of assuming there will be 24. This resolves an issue on
+a system where in the bios you can choose between hash functions
+(sha1 and sha256 in this case). Both will show up as supported,
+but when it tries reading the bank that isn't selected in the bios
+it makes no progress, and then fails saying that there are too many
+PCRs to read.
+
+This consolidates the pcr_selections init code into one function.
+
+Also a minor change to show_pcr_values to use sizeofSelect to
+determine loop iteration instead of hardcoding 24.
+
+Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>
+(cherry picked from commit c2586d4116b29436baa6608c5c3a222aae8bf193)
+Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>
+---
+ tools/tpm2_listpcrs.c | 55 +++++++++++++++++++++++++--------------------------
+ 1 file changed, 27 insertions(+), 28 deletions(-)
+
+diff --git a/tools/tpm2_listpcrs.c b/tools/tpm2_listpcrs.c
+index f50c200..42bb8c6 100644
+--- a/tools/tpm2_listpcrs.c
++++ b/tools/tpm2_listpcrs.c
+@@ -173,38 +173,35 @@ static bool read_pcr_values(listpcr_context *context) {
+     return true;
+ }
+ 
+-static void init_pcr_selection_from_algorithm(TPMI_ALG_HASH alg_id,
+-        TPML_PCR_SELECTION *pcr_selections) {
++static bool init_pcr_selection(TPMI_ALG_HASH alg_id, listpcr_context *context) {
+ 
+-    pcr_selections->count = 1;
+-    pcr_selections->pcrSelections[0].hash = alg_id;
+-    set_pcr_select_size(&pcr_selections->pcrSelections[0], 3);
+-    clear_pcr_select_bits(&pcr_selections->pcrSelections[0]);
++    TPMI_YES_NO moreData;
++    TPMS_CAPABILITY_DATA cap_data;
++    TPML_PCR_SELECTION *pcr_sel = &context->pcr_selections;
++    UINT32 rval, i, j;
+ 
+-    UINT32 pcr_id;
+-    for (pcr_id = 0; pcr_id < 24; pcr_id++) {
+-        set_pcr_select_bit(&pcr_selections->pcrSelections[0], pcr_id);
++    rval = Tss2_Sys_GetCapability(context->sapi_context, 0, TPM_CAP_PCRS, 0, 1, &moreData, &cap_data, 0);
++    if (rval != TPM_RC_SUCCESS) {
++        LOG_ERR("GetCapability: Get PCR allocation status Error. TPM Error:0x%x......\n", rval);
++        return false;
+     }
+-}
+ 
+-/* XXX Could this internally call init_pcr_selection_from_algorithm to reduce duplicate code? */
+-static void init_pcr_selection_all(tpm2_algorithm *algorithm,
+-        TPML_PCR_SELECTION *pcr_selections) {
++    pcr_sel->count = 0;
+ 
+-    pcr_selections->count = 0;
++    for (i = 0; i < cap_data.data.assignedPCR.count; i++) {
++        if (alg_id && (cap_data.data.assignedPCR.pcrSelections[i].hash != alg_id))
++            continue;
++        pcr_sel->pcrSelections[pcr_sel->count].hash = cap_data.data.assignedPCR.pcrSelections[i].hash;
++        set_pcr_select_size(&pcr_sel->pcrSelections[pcr_sel->count], cap_data.data.assignedPCR.pcrSelections[i].sizeofSelect);
++        for (j = 0; j < pcr_sel->pcrSelections[pcr_sel->count].sizeofSelect; j++)
++            pcr_sel->pcrSelections[pcr_sel->count].pcrSelect[j] = cap_data.data.assignedPCR.pcrSelections[i].pcrSelect[j];
++        pcr_sel->count++;
++    }
+ 
+-    int i;
+-    for (i = 0; i < algorithm->count; i++) {
+-        pcr_selections->pcrSelections[i].hash = algorithm->alg[i];
+-        set_pcr_select_size(&pcr_selections->pcrSelections[i], 3);
+-        clear_pcr_select_bits(&pcr_selections->pcrSelections[i]);
++    if (pcr_sel->count == 0)
++        return false;
+ 
+-        UINT32 pcr_id;
+-        for (pcr_id = 0; pcr_id < 24; pcr_id++) {
+-            set_pcr_select_bit(&pcr_selections->pcrSelections[i], pcr_id);
+-        }
+-        pcr_selections->count++;
+-    }
++    return true;
+ }
+ 
+ // show all PCR banks according to g_pcrSelection & g_pcrs->
+@@ -220,7 +217,7 @@ static bool show_pcr_values(listpcr_context *context) {
+                 context->pcr_selections.pcrSelections[i].hash);
+ 
+         UINT32 pcr_id;
+-        for (pcr_id = 0; pcr_id < 24; pcr_id++) {
++        for (pcr_id = 0; pcr_id < context->pcr_selections.pcrSelections[i].sizeofSelect * 8; pcr_id++) {
+             if (!is_pcr_select_bit_set(&context->pcr_selections.pcrSelections[i],
+                     pcr_id)) {
+                 continue;
+@@ -271,14 +268,16 @@ static bool show_selected_pcr_values(listpcr_context *context) {
+ 
+ static bool show_all_pcr_values(listpcr_context *context) {
+ 
+-    init_pcr_selection_all(&context->algs, &context->pcr_selections);
++    if (!init_pcr_selection(0, context))
++        return false;
+ 
+     return show_selected_pcr_values(context);
+ }
+ 
+ static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id) {
+ 
+-    init_pcr_selection_from_algorithm(alg_id, &context->pcr_selections);
++    if (!init_pcr_selection(alg_id, context))
++        return false;
+ 
+     return show_selected_pcr_values(context);
+ }
+-- 
+2.16.1
+

--- a/recipes-openxt/tss/tpm2-tools/0002-listpcrs-remove-one-redundant-call-to-tpm-get-cap.patch
+++ b/recipes-openxt/tss/tpm2-tools/0002-listpcrs-remove-one-redundant-call-to-tpm-get-cap.patch
@@ -1,0 +1,90 @@
+From b48c7fa5acd274105730f33f0da591cc6c26e74f Mon Sep 17 00:00:00 2001
+From: Gang Wei <gang.wei@intel.com>
+Date: Thu, 8 Jun 2017 11:52:32 +0800
+Subject: [PATCH 2/3] listpcrs: remove one redundant call to tpm get cap
+
+Signed-of-by: Gang Wei <gang.wei@intel.com>
+(cherry picked from commit 433a1e44f362fbeb4fd01d9de119dbabd4829ad5)
+Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>
+---
+ tools/tpm2_listpcrs.c | 32 +++++++++++++-------------------
+ 1 file changed, 13 insertions(+), 19 deletions(-)
+
+diff --git a/tools/tpm2_listpcrs.c b/tools/tpm2_listpcrs.c
+index 42bb8c6..fa1197c 100644
+--- a/tools/tpm2_listpcrs.c
++++ b/tools/tpm2_listpcrs.c
+@@ -63,6 +63,7 @@ struct listpcr_context {
+     tpm2_algorithm algs;
+     tpm2_pcrs pcrs;
+     TPML_PCR_SELECTION pcr_selections;
++    TPMS_CAPABILITY_DATA cap_data;
+ };
+ 
+ static inline void set_pcr_select_bit(TPMS_PCR_SELECTION *pcr_selection,
+@@ -175,26 +176,19 @@ static bool read_pcr_values(listpcr_context *context) {
+ 
+ static bool init_pcr_selection(TPMI_ALG_HASH alg_id, listpcr_context *context) {
+ 
+-    TPMI_YES_NO moreData;
+-    TPMS_CAPABILITY_DATA cap_data;
++    TPMS_CAPABILITY_DATA *cap_data = &context->cap_data;
+     TPML_PCR_SELECTION *pcr_sel = &context->pcr_selections;
+-    UINT32 rval, i, j;
+-
+-    rval = Tss2_Sys_GetCapability(context->sapi_context, 0, TPM_CAP_PCRS, 0, 1, &moreData, &cap_data, 0);
+-    if (rval != TPM_RC_SUCCESS) {
+-        LOG_ERR("GetCapability: Get PCR allocation status Error. TPM Error:0x%x......\n", rval);
+-        return false;
+-    }
++    UINT32 i, j;
+ 
+     pcr_sel->count = 0;
+ 
+-    for (i = 0; i < cap_data.data.assignedPCR.count; i++) {
+-        if (alg_id && (cap_data.data.assignedPCR.pcrSelections[i].hash != alg_id))
++    for (i = 0; i < cap_data->data.assignedPCR.count; i++) {
++        if (alg_id && (cap_data->data.assignedPCR.pcrSelections[i].hash != alg_id))
+             continue;
+-        pcr_sel->pcrSelections[pcr_sel->count].hash = cap_data.data.assignedPCR.pcrSelections[i].hash;
+-        set_pcr_select_size(&pcr_sel->pcrSelections[pcr_sel->count], cap_data.data.assignedPCR.pcrSelections[i].sizeofSelect);
++        pcr_sel->pcrSelections[pcr_sel->count].hash = cap_data->data.assignedPCR.pcrSelections[i].hash;
++        set_pcr_select_size(&pcr_sel->pcrSelections[pcr_sel->count], cap_data->data.assignedPCR.pcrSelections[i].sizeofSelect);
+         for (j = 0; j < pcr_sel->pcrSelections[pcr_sel->count].sizeofSelect; j++)
+-            pcr_sel->pcrSelections[pcr_sel->count].pcrSelect[j] = cap_data.data.assignedPCR.pcrSelections[i].pcrSelect[j];
++            pcr_sel->pcrSelections[pcr_sel->count].pcrSelect[j] = cap_data->data.assignedPCR.pcrSelections[i].pcrSelect[j];
+         pcr_sel->count++;
+     }
+ 
+@@ -285,11 +279,11 @@ static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id)
+ static bool get_banks(listpcr_context *context) {
+ 
+     TPMI_YES_NO more_data;
+-    TPMS_CAPABILITY_DATA capability_data;
++    TPMS_CAPABILITY_DATA *capability_data = &context->cap_data;
+     UINT32 rval;
+ 
+     rval = Tss2_Sys_GetCapability(context->sapi_context, 0, TPM_CAP_PCRS, 0, 1,
+-            &more_data, &capability_data, 0);
++            &more_data, capability_data, 0);
+     if (rval != TPM_RC_SUCCESS) {
+         LOG_ERR(
+                 "GetCapability: Get PCR allocation status Error. TPM Error:0x%x......\n",
+@@ -298,11 +292,11 @@ static bool get_banks(listpcr_context *context) {
+     }
+ 
+     unsigned i;
+-    for (i = 0; i < capability_data.data.assignedPCR.count; i++) {
++    for (i = 0; i < capability_data->data.assignedPCR.count; i++) {
+         context->algs.alg[i] =
+-                capability_data.data.assignedPCR.pcrSelections[i].hash;
++                capability_data->data.assignedPCR.pcrSelections[i].hash;
+     }
+-    context->algs.count = capability_data.data.assignedPCR.count;
++    context->algs.count = capability_data->data.assignedPCR.count;
+ 
+     return true;
+ }
+-- 
+2.16.1
+

--- a/recipes-openxt/tss/tpm2-tools/0003-listpcrs-fix-for-unsupported-disabled-alg-in-L.patch
+++ b/recipes-openxt/tss/tpm2-tools/0003-listpcrs-fix-for-unsupported-disabled-alg-in-L.patch
@@ -1,0 +1,121 @@
+From 6c471458c0231a5eb8a74cd9ee24ae758336b641 Mon Sep 17 00:00:00 2001
+From: Gang Wei <gang.wei@intel.com>
+Date: Thu, 8 Jun 2017 16:19:12 +0800
+Subject: [PATCH 3/3] listpcrs: fix for unsupported/disabled alg in -L
+
+Sign-off-by: Gang Wei <gang.wei@intel.com>
+(cherry picked from commit ada4c20d23d99b4b489c6c793e4132c1d5234b66)
+Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>
+---
+ tools/tpm2_listpcrs.c | 67 ++++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 63 insertions(+), 4 deletions(-)
+
+diff --git a/tools/tpm2_listpcrs.c b/tools/tpm2_listpcrs.c
+index fa1197c..767ca37 100644
+--- a/tools/tpm2_listpcrs.c
++++ b/tools/tpm2_listpcrs.c
+@@ -198,6 +198,62 @@ static bool init_pcr_selection(TPMI_ALG_HASH alg_id, listpcr_context *context) {
+     return true;
+ }
+ 
++static void shrink_pcr_selection(TPML_PCR_SELECTION *s) {
++
++    UINT32 i, j;
++
++    //seek for the first empty item
++    for (i = 0; i < s->count; i++)
++        if (!s->pcrSelections[i].hash)
++            break;
++    j = i + 1;
++
++    for (; i < s->count; i++) {
++        if (!s->pcrSelections[i].hash) {
++            for (; j < s->count; j++)
++                if (s->pcrSelections[j].hash)
++                    break;
++            if (j >= s->count)
++                break;
++
++            memcpy(&s->pcrSelections[i], &s->pcrSelections[j], sizeof(s->pcrSelections[i]));
++            s->pcrSelections[j].hash = 0;
++            j++;
++        }
++    }
++
++    s->count = i;
++}
++
++static bool check_pcr_selection(listpcr_context *context) {
++
++    TPMS_CAPABILITY_DATA *cap_data = &context->cap_data;
++    TPML_PCR_SELECTION *pcr_sel = &context->pcr_selections;
++    UINT32 i, j, k;
++
++    for (i = 0; i < pcr_sel->count; i++) {
++        for (j = 0; j < cap_data->data.assignedPCR.count; j++) {
++            if (pcr_sel->pcrSelections[i].hash == cap_data->data.assignedPCR.pcrSelections[j].hash) {
++                for (k = 0; k < pcr_sel->pcrSelections[i].sizeofSelect; k++)
++                    pcr_sel->pcrSelections[i].pcrSelect[k] &= cap_data->data.assignedPCR.pcrSelections[j].pcrSelect[k];
++                break;
++            }
++        }
++
++        if (j >= cap_data->data.assignedPCR.count) {
++            const char *alg_name = get_algorithm_name(pcr_sel->pcrSelections[i].hash);
++            LOG_WARN("Ignore unsupported bank/algorithm: %s(0x%04x)\n", alg_name, pcr_sel->pcrSelections[i].hash);
++            pcr_sel->pcrSelections[i].hash = 0; //mark it as to be removed
++        }
++    }
++
++    shrink_pcr_selection(pcr_sel);
++    if (pcr_sel->count == 0)
++        return false;
++
++    return true;
++}
++
+ // show all PCR banks according to g_pcrSelection & g_pcrs->
+ static bool show_pcr_values(listpcr_context *context) {
+ 
+@@ -249,7 +305,10 @@ static bool show_pcr_values(listpcr_context *context) {
+     return true;
+ }
+ 
+-static bool show_selected_pcr_values(listpcr_context *context) {
++static bool show_selected_pcr_values(listpcr_context *context, bool check) {
++
++    if (check && !check_pcr_selection(context))
++        return false;
+ 
+     if (!read_pcr_values(context))
+         return false;
+@@ -265,7 +324,7 @@ static bool show_all_pcr_values(listpcr_context *context) {
+     if (!init_pcr_selection(0, context))
+         return false;
+ 
+-    return show_selected_pcr_values(context);
++    return show_selected_pcr_values(context, false);
+ }
+ 
+ static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id) {
+@@ -273,7 +332,7 @@ static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id)
+     if (!init_pcr_selection(alg_id, context))
+         return false;
+ 
+-    return show_selected_pcr_values(context);
++    return show_selected_pcr_values(context, false);
+ }
+ 
+ static bool get_banks(listpcr_context *context) {
+@@ -398,7 +457,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
+     } else if (g_flag) {
+         success = show_alg_pcr_values(&context, selected_algorithm);
+     } else if (L_flag) {
+-        success = show_selected_pcr_values(&context);
++        success = show_selected_pcr_values(&context, true);
+     } else {
+         success = show_all_pcr_values(&context);
+     }
+-- 
+2.16.1
+

--- a/recipes-openxt/tss/tpm2-tools_git.bb
+++ b/recipes-openxt/tss/tpm2-tools_git.bb
@@ -6,6 +6,9 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=91b7c548d73ea16537799e8060cea819"
 DEPENDS = "tpm2-tss openssl curl autoconf-archive pkgconfig"
 SRC_URI = "git://github.com/01org/tpm2-tools.git;protocol=git;branch=master;name=tpm2-tools;destsuffix=tpm2-tools \
+    file://0001-tpm2_listpcrs-use-TPM2_GetCapability-to-determine-PC.patch \
+    file://0002-listpcrs-remove-one-redundant-call-to-tpm-get-cap.patch \
+    file://0003-listpcrs-fix-for-unsupported-disabled-alg-in-L.patch \
     file://tpm2-tools-lib-support.patch \
     file://tpm2-sealing-support.patch \
     file://tpm2-unsealing-support.patch \


### PR DESCRIPTION
As suggested on:
- https://github.com/tpm2-software/tpm2-tools/pull/294
- https://github.com/tpm2-software/tpm2-tools/pull/295

Backport the following fixes:
tpm2_listpcrs: use TPM2_GetCapability to determine PCRs
listpcrs: remove one redundant call to tpm get cap
listpcrs: fix for unsupported/disabled alg in -L