### PR TITLE
STABLE-8: OXT-1311: tpm: Detect TPM version from sysfs caps entry.

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
@@ -28,7 +28,20 @@ DEFINIT=/sbin/init
 FIRSTBOOT_FLAG=/boot/system/firstboot
 
 is_tpm_2_0 () {
-    [ -e /sys/class/tpm/tpm0/device/description ] && cat /sys/class/tpm/tpm0/device/description | grep "2.0" &>/dev/null
+    # See the TPM chardev driver implementation:
+    # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/char/tpm/tpm-sysfs.c?h=v4.14.34#n296
+    # Assuming a TPM has already been detected, absence of the sysfs entry
+    # means TPM 2.0.
+    # This is still valid on Linux 4.16.
+    if [ ! -e /sys/class/tpm/tpm0/device/caps ]; then
+        return 0
+    fi
+
+    # Sysfs caps entry contains TPM manufacturer and version info.
+    # https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-tpm
+    local tpm_ver="$(awk '/TCG version:/ { print $3 }' /sys/class/tpm/tpm0/device/caps)"
+
+    [ "${tpm_ver}" = "2.0" ]
 }
 
 #listpcrs sample output:

--- a/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient/xenclient-tpm-scripts/tpm-functions
@@ -30,7 +30,20 @@ clean_old_tpm_files () {
 }
 
 is_tpm_2_0 () {
-   [ -e /sys/class/tpm/tpm0/device/description ] && cat /sys/class/tpm/tpm0/device/description | grep "2.0" &>/dev/null
+    # See the TPM chardev driver implementation:
+    # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/char/tpm/tpm-sysfs.c?h=v4.14.34#n296
+    # Assuming a TPM has already been detected, absence of the sysfs entry
+    # means TPM 2.0.
+    # This is still valid on Linux 4.16.
+    if [ ! -e /sys/class/tpm/tpm0/device/caps ]; then
+        return 0
+    fi
+
+    # Sysfs caps entry contains TPM manufacturer and version info.
+    # https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-tpm
+    local tpm_ver="$(awk '/TCG version:/ { print $3 }' /sys/class/tpm/tpm0/device/caps)"
+
+    [ "${tpm_ver}" = "2.0" ]
 }
 
 pcr_bank_exists () {


### PR DESCRIPTION
Using /sys/class/tpm/tpm0/device/description is unreliable as the entry
might not be populated by the driver.

From:
https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-tpm
It is recommended to use /sys/class/tpm/tpmX/device/caps instead. One
caveat though is documented in the TPM module sources:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/char/tpm/tpm-sysfs.c?h=v4.14.34#n296

TPM 2.0 devices will not expose /sys/class/tpm/tpmX/device/caps (this is
still the case to this day in Linux 4.16 line). So assuming a
TPM is detected, the absence of this file reveals a TPM 2.0 version.

(cherry picked from commit 4a1b0c75031099eab155f3c241cf5d963d2dcb91)
