### PR TITLE
STABLE-8: OXT-1314: Update Xen patches: support for SecureBoot and minor fixes

### DIFF
--- a/recipes-extended/xen/files/efi-load-option-support.patch
+++ b/recipes-extended/xen/files/efi-load-option-support.patch
@@ -1,7 +1,7 @@
-From d51e22b3876c0a392aad2ef58bba62a334e61b28 Mon Sep 17 00:00:00 2001
+From 3def7c280f64dbb6a9646d94fbbed6f97fa58293 Mon Sep 17 00:00:00 2001
 From: Tamas K Lengyel <tamas@tklengyel.com>
 Date: Thu, 28 Dec 2017 18:50:29 +0100
-Subject: [PATCH 2/3] xen: Add EFI_LOAD_OPTION support
+Subject: [PATCH] xen: Add EFI_LOAD_OPTION support
 
 When booting Xen via UEFI the Xen config file can contain multiple sections
 each describing different boot options. It is currently only possible to choose
@@ -19,9 +19,11 @@ v3: simplify sanity checking logic
 v2: move EFI_LOAD_OPTION definition into file that uses it
     add more sanity checks to validate the buffer
 ---
- xen/common/efi/boot.c | 47 ++++++++++++++++++++++++++++++++++++++++++-----
- 1 file changed, 42 insertions(+), 5 deletions(-)
+ xen/common/efi/boot.c | 49 +++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 43 insertions(+), 6 deletions(-)
 
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index daf0c80ef8..0772ba1c93 100644
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
 @@ -88,6 +88,16 @@ typedef struct _EFI_APPLE_PROPERTIES {
@@ -41,7 +43,7 @@ v2: move EFI_LOAD_OPTION definition into file that uses it
  union string {
      CHAR16 *w;
      char *s;
-@@ -375,12 +385,39 @@ static void __init PrintErrMesg(const CH
+@@ -375,12 +385,39 @@ static void __init PrintErrMesg(const CHAR16 *mesg, EFI_STATUS ErrCode)
  
  static unsigned int __init get_argv(unsigned int argc, CHAR16 **argv,
                                      CHAR16 *cmdline, UINTN cmdsize,
@@ -83,7 +85,16 @@ v2: move EFI_LOAD_OPTION definition into file that uses it
              cmdsize -= sizeof(*cmdline), ++cmdline )
      {
          bool_t cur_sep = *cmdline == L' ' || *cmdline == L'\t';
-@@ -1096,17 +1133,17 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1073,7 +1110,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+     union string section = { NULL }, name;
+     bool_t base_video = 0;
+     char *option_str;
+-    bool_t use_cfg_file;
++    bool_t use_cfg_file, elo_active = 0;
+ 
+     __set_bit(EFI_BOOT, &efi_flags);
+     __set_bit(EFI_LOADER, &efi_flags);
+@@ -1096,17 +1133,17 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
      if ( use_cfg_file )
      {
          argc = get_argv(0, NULL, loaded_image->LoadOptions,
@@ -104,3 +115,6 @@ v2: move EFI_LOAD_OPTION definition into file that uses it
          {
              CHAR16 *ptr = argv[i];
  
+-- 
+2.11.0
+

--- a/recipes-extended/xen/files/shim-support-for-shim-lock-measure.patch
+++ b/recipes-extended/xen/files/shim-support-for-shim-lock-measure.patch
@@ -1,12 +1,17 @@
-From 20e21fcb462c3e480b95f16b411200ee62774ea4 Mon Sep 17 00:00:00 2001
+From 89bb42087d83f1817245083da19331dd03efc727 Mon Sep 17 00:00:00 2001
 From: Tamas K Lengyel <tamas@tklengyel.com>
 Date: Fri, 2 Feb 2018 17:39:56 -0700
-Subject: [PATCH 3/3] Shim lock measure
+Subject: [PATCH] Shim lock measure
 
+Support measuring critical components into the TPM using shim_lock->Measure
+
+Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
 ---
- xen/common/efi/boot.c | 37 +++++++++++++++++++++++++++++++------
- 1 file changed, 31 insertions(+), 6 deletions(-)
+ xen/common/efi/boot.c | 75 +++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 70 insertions(+), 5 deletions(-)
 
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index 0772ba1c93..6a0951568c 100644
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
 @@ -46,8 +46,17 @@ typedef EFI_STATUS
@@ -27,7 +32,40 @@ Subject: [PATCH 3/3] Shim lock measure
  } EFI_SHIM_LOCK_PROTOCOL;
  
  struct _EFI_APPLE_PROPERTIES;
-@@ -1105,12 +1114,12 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1095,6 +1104,32 @@ static int __init __maybe_unused set_color(u32 mask, int bpp, u8 *pos, u8 *sz)
+    return max(*pos + *sz, bpp);
+ }
+ 
++static bool secureboot_enabled(void)
++{
++    EFI_GUID efi_gv = EFI_GLOBAL_VARIABLE;
++    UINT8 SecureBoot = 0, SetupMode = 0;
++    UINTN DataSize = sizeof(SecureBoot);
++    EFI_STATUS efi_status;
++
++    efi_status = efi_rs->GetVariable(L"SecureBoot", &efi_gv, NULL,
++                                     &DataSize, &SecureBoot);
++    if ( EFI_ERROR(efi_status) )
++        return false;
++
++    if ( !SecureBoot )
++        return false;
++
++    efi_status = efi_rs->GetVariable(L"SetupMode", &efi_gv, NULL,
++                                     &DataSize, &SetupMode);
++    if ( EFI_ERROR(efi_status) )
++        return false;
++
++    if ( SetupMode )
++        return false;
++
++    return true;
++}
++
+ void EFIAPI __init noreturn
+ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+ {
+@@ -1105,7 +1140,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
      unsigned int i, argc;
      CHAR16 **argv, *file_name, *cfg_file_name = L"openxt.cfg", *options = NULL;
      UINTN gop_mode = ~0;
@@ -36,13 +74,7 @@ Subject: [PATCH 3/3] Shim lock measure
      EFI_GRAPHICS_OUTPUT_PROTOCOL *gop = NULL;
      union string section = { NULL }, name;
      bool_t base_video = 0;
-     char *option_str;
--    bool_t use_cfg_file;
-+    bool_t use_cfg_file, elo_active;
- 
-     __set_bit(EFI_BOOT, &efi_flags);
-     __set_bit(EFI_LOADER, &efi_flags);
-@@ -1225,6 +1234,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1225,6 +1260,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
          }
          else if ( !read_file(dir_handle, cfg_file_name, &cfg, NULL) )
              blexit(L"Configuration file not found.");
@@ -56,7 +88,7 @@ Subject: [PATCH 3/3] Shim lock measure
          pre_parse(&cfg);
  
          if ( section.w )
-@@ -1262,16 +1278,20 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1262,16 +1304,34 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
          read_file(dir_handle, s2w(&name), &kernel, option_str);
          efi_bs->FreePool(name.w);
  
@@ -64,9 +96,23 @@ Subject: [PATCH 3/3] Shim lock measure
 -                        (void **)&shim_lock)) &&
 -             (status = shim_lock->Verify(kernel.ptr, kernel.size)) != EFI_SUCCESS )
 -            PrintErrMesg(L"Dom0 kernel image could not be verified", status);
-+        if ( shim_lock &&
-+            (status = shim_lock->Measure(kernel.ptr, kernel.size, 4)) != EFI_SUCCESS )
-+            PrintErrMesg(L"Dom0 kernel image could not be measured", status);
++        if ( shim_lock )
++        {
++            if ( secureboot_enabled() )
++            {
++                if ( (status = shim_lock->Verify(kernel.ptr, kernel.size))
++                    != EFI_SUCCESS )
++                    PrintErrMesg(L"Dom0 kernel image could not be verified",
++                                 status);
++            }
++            else
++            {
++                if ( (status = shim_lock->Measure(kernel.ptr, kernel.size, 4))
++                    != EFI_SUCCESS )
++                    PrintErrMesg(L"Dom0 kernel image could not be measured",
++                                 status);
++            }
++        }
  
          name.s = get_value(&cfg, section.s, "ramdisk");
          if ( name.s )
@@ -81,7 +127,7 @@ Subject: [PATCH 3/3] Shim lock measure
          }
  
          name.s = get_value(&cfg, section.s, "xsm");
-@@ -1279,6 +1299,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1279,6 +1339,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
          {
              read_file(dir_handle, s2w(&name), &xsm, NULL);
              efi_bs->FreePool(name.w);
@@ -93,3 +139,6 @@ Subject: [PATCH 3/3] Shim lock measure
          }
  
          name.s = get_value(&cfg, section.s, "options");
+-- 
+2.11.0
+


### PR DESCRIPTION
Make Xen query the firmware for the status of SecureBoot to determine whether to use shim_lock->Measure or shim_lock->Verify on the dom0 kernel.

Move definition of elo_active to the efi-load-option-support.patch where it belongs.

Siged-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>