### PR TITLE
STABLE-8: OXT-1258:  xen: Ammend PGC_pinned_by_tools declaration

### DIFF
--- a/recipes-extended/xen/files/xen-translate.patch
+++ b/recipes-extended/xen/files/xen-translate.patch
@@ -488,21 +488,20 @@ PATCHES
          break;
 --- a/xen/include/asm-x86/mm.h
 +++ b/xen/include/asm-x86/mm.h
-@@ -212,9 +212,13 @@ struct page_info
- #define PGT_locked        PG_mask(1, 9)
- 
-  /* Count of uses of this frame as its current type. */
--#define PGT_count_width   PG_shift(9)
-+#define PGT_count_width   PG_shift(10)
- #define PGT_count_mask    ((1UL<<PGT_count_width)-1)
- 
+@@ -240,9 +240,12 @@ struct page_info
+ #define PGC_state_offlined PG_mask(2, 9)
+ #define PGC_state_free    PG_mask(3, 9)
+ #define page_state_is(pg, st) (((pg)->count_info&PGC_state) == PGC_state_##st)
 + /* Pinned by dom0 tools */
 +#define _PGC_pinned_by_tools	PG_shift(10)
 +#define PGC_pinned_by_tools	PG_mask(1, 10)
-+
- /* Are the 'type mask' bits identical? */
- #define PGT_type_equal(x, y) (!(((x) ^ (y)) & PGT_type_mask))
  
+  /* Count of references to this frame. */
+-#define PGC_count_width   PG_shift(9)
++#define PGC_count_width   PG_shift(10)
+ #define PGC_count_mask    ((1UL<<PGC_count_width)-1)
+ 
+ struct spage_info
 --- a/xen/include/public/memory.h
 +++ b/xen/include/public/memory.h
 @@ -310,8 +310,30 @@ struct xen_remove_from_physmap {


### PR DESCRIPTION
PGC_pinned_by_tools is a flag in page->count_info field, hence
PGC_count_width should be incremented to accomodate for it. Ref-count
has to be quite high to make this fail, which is why no misbehavior was
seen until now.

XenServer maintains an equivalent hunk in one patch:
https://github.com/xenserver/xen-4.7.pg/blob/1b778262c1b4a3c7c8e504d50e0149fe5909d670/master/nvidia-hypercalls.patch#L487

Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>

OXT-1258