### PR TITLE
STABLE-8: Revert "v4v: Fix SMAP & HVM guest use"

### DIFF
--- a/recipes-extended/xen/files/v4v.patch
+++ b/recipes-extended/xen/files/v4v.patch
@@ -130,7 +130,7 @@ PATCHES
      int port;
 --- /dev/null
 +++ b/xen/common/v4v.c
-@@ -0,0 +1,1980 @@
+@@ -0,0 +1,1964 @@
 +/******************************************************************************
 + * v4v.c
 + *
@@ -419,24 +419,7 @@ PATCHES
 +  return 0;
 +}
 +
-+static int
-+v4v_copy_from_guest (uint8_t *dst,
-+                     XEN_GUEST_HANDLE (uint8_t) src_hnd,
-+                     uint32_t len)
-+{
-+  struct guest_memory_policy policy = { .smap_policy = SMAP_CHECK_DISABLED,
-+                                        .nested_guest_mode = false };
-+  struct vcpu *v = current;
-+  int ret = 0;
 +
-+  update_guest_memory_policy(v, &policy);
-+  if (copy_from_guest (dst, src_hnd, len))
-+      ret = -EFAULT;
-+
-+  update_guest_memory_policy(v, &policy);
-+
-+  return ret;
-+}
 +
 +/*called must have L3*/
 +static int
@@ -462,8 +445,9 @@ PATCHES
 +              MY_FILE, __LINE__, dst, offset, (void *) src_hnd.p,
 +              (int) (PAGE_SIZE - offset));
 +#endif
-+      if (v4v_copy_from_guest ((dst + offset), src_hnd, PAGE_SIZE - offset))
++      if (copy_from_guest ((dst + offset), src_hnd, PAGE_SIZE - offset))
 +          return -EFAULT;
++
 +
 +      page++;
 +      len -= PAGE_SIZE - offset;
@@ -480,7 +464,7 @@ PATCHES
 +  printk (KERN_ERR "%s:%d copy_from_guest(%p+%d,%p,%d)\n",
 +          MY_FILE, __LINE__, dst, offset, (void *) src_hnd.p, len);
 +#endif
-+  if (v4v_copy_from_guest ((dst + offset), src_hnd, len))
++  if (copy_from_guest ((dst + offset), src_hnd, len))
 +      return -EFAULT;
 +
 +  return 0;


### PR DESCRIPTION
The original change didn't fix v4v for HVMs with SMAP on Xen 4.9.  It
relied on smap_check_policy in guest_walk_tables to skip the SMAP check,
but that was removed between Xen 4.6 and 4.9.  Upstream NACK-ed
re-introducing support in guest_walk_tables and suggested wrapping the
v4v hypercall in the guest kernel with stac/clac.  We'll do that in the
v4v module: https://github.com/OpenXT/v4v/pull/36

This reverts commit 816157744a05a32e206ddf2eddd504bc0cb09587.

OXT-1304

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit bfd1cf097cc55504cc2c68513ad940e46cae8bbd)