### PR TITLE
OXT-1322: v4v: Refresh the recipes.

### DIFF
--- a/recipes-openxt/xenclient/v4v-module-headers_git.bb
+++ b/recipes-openxt/xenclient/v4v-module-headers_git.bb
@@ -1,35 +1,22 @@
-DESCRIPTION = "v4v kernel module headers"
+SUMMARY = "V4V Linux module headers."
+DESCRIPTION = "V4V UAPI available to user-land programs to implement V4V \
+communications."
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://v4v.h;beginline=6;endline=32;md5=8054a75b345d2cd08e16f9dd0ad9283b"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
 PV = "git${SRCPV}"
 
-DEPENDS = ""
-
-SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/v4v.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git/v4v"
 
-INHIBIT_DEFAULT_DEPS = "1"
-EXCLUDE_FROM_SHLIBS = "1"
-INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-INHIBIT_PACKAGE_STRIP = "1"
-
-do_configure() {
-}
-
-do_compile() {
-}
+inherit allarch
 
 do_install() {
-    install -m 0755 -d ${D}/usr/include/linux
-    install -m 0755 -d ${STAGING_KERNEL_DIR}/include/xen
-    install -m 0755 -d ${STAGING_KERNEL_DIR}/include/linux
-    install -m 644 include/xen/v4v.h ${STAGING_KERNEL_DIR}/include/xen/v4v.h
-    install -m 644 linux/v4v_dev.h ${D}/usr/include/linux/v4v_dev.h
-    install -m 644 linux/v4v_dev.h ${STAGING_KERNEL_DIR}/include/linux/v4v_dev.h
+    oe_runmake INSTALL_HDR_PATH=${D}${prefix} headers_install
 }
 
-STAGING_KERNEL_DIR[vardepsexclude] = "MACHINE"
-do_install[vardepsexclude] = "MACHINE"
+# Skip build steps.
+do_compile[noexec] = "1"
+do_configure[noexec] = "1"

--- a/recipes-openxt/xenclient/v4v-module_git.bb
+++ b/recipes-openxt/xenclient/v4v-module_git.bb
@@ -1,37 +1,17 @@
-inherit module-compat
-inherit xenclient
-
-DESCRIPTION = "v4v kernel module"
+SUMMARY = "V4V Linux module."
+DESCRIPTION = "V4V implements inter-domain communication on Xen virtualization \
+platform relying on the hypervisor to broker all communications. Domains then \
+manage their own data rings and no memory is shared between them. V4V module \
+defines a stream and a datagram protocol."
+HOMEPAGE = "https://github.com/OpenXT/openxt/wiki/V4V"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://v4v.h;beginline=6;endline=32;md5=8054a75b345d2cd08e16f9dd0ad9283b"
-
-DEB_SUITE = "wheezy"
-DEB_ARCH = "i386"
-
-DEB_NAME = "v4v-module"
-DEB_DESC="The XenClient v4v kernel module"
-DEB_DESC_EXT="This package provides the XenClient v4v kernel module."
-DEB_SECTION="misc"
-DEB_PKG_MAINTAINER = "Citrix Systems <customerservice@citrix.com>"
-
-DEPENDS_append += " v4v-module-headers"
-DEPENDS_append_xenclient-nilfvm += " ${@deb_bootstrap_deps(d)} "
-
-inherit ${@"xenclient-simple-deb"if(d.getVar("MACHINE",1)=="xenclient-nilfvm")else("null")}
+LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
 PV = "git${SRCPV}"
 
+SRC_URI = "git://${OPENXT_GIT_MIRROR}/v4v.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/v4v.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
-	   file://DEBIAN_postinst \
-           "
 
 S = "${WORKDIR}/git/v4v"
 
-do_install_append_xenclient-nilfvm() {
-	## to generate deb package
-	sed -i "s|@KERNEL_VERSION@|${KERNEL_VERSION}|g" "${WORKDIR}/DEBIAN_postinst"
-	do_simple_deb_package
-}
-
-MAKE_TARGETS += "modules"
+inherit module


### PR DESCRIPTION
# Changes
- Use `module.bbclass` to build the out-of-tree V4V module.
- Use `headers_install` Makefile rules to deploy headers. Inherit `allarch.bbclass` since they are arch independent.
- Remove deprecated deb packaging statements, these are no longer used.
- Use `COPYING` file to check the license.

# Depends
- https://github.com/OpenXT/pv-linux-drivers/pull/44
- https://github.com/OpenXT/v4v/pull/37
- https://github.com/OpenXT/openxt/pull/304