### PR TITLE
STABLE-8: OXT-1325, OXT-1326: rsyslog fix for logrorate and other backports.

### DIFF
--- a/recipes-extended/rsyslog/patches/0001-core-bugfix-segfault-after-configuration-errors.patch
+++ b/recipes-extended/rsyslog/patches/0001-core-bugfix-segfault-after-configuration-errors.patch
@@ -1,0 +1,90 @@
+From 6d258339802cb9f13d8a4a157a4b74eccb902d8f Mon Sep 17 00:00:00 2001
+From: Rainer Gerhards <rgerhards@adiscon.com>
+Date: Mon, 17 Jul 2017 15:36:32 +0200
+Subject: [PATCH] core bugfix: segfault after configuration errors
+
+rsyslog will segfault on startup if
+a) the local machine's hostname is set to a non-FQDN name
+b) the getaddrinfo() system call fails
+This scenario is higly unlikely, but may exist especially with
+provisioned VMs which may not properly be able to do name queries
+on startup (seen for example on AWS).
+
+This patch fixes the situation and also provides more robustness
+for very early startup error messages when some of the error-reporting
+subsystem is not yet properly initialized. Note that under these
+circumstances, errors may only show up on stderr.
+
+Upstream status: Backport
+
+closes https://github.com/rsyslog/rsyslog/issues/1573
+
+Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
+---
+ runtime/prop.c   |  6 ++++++
+ tools/rsyslogd.c | 17 +++++++++--------
+ 2 files changed, 15 insertions(+), 8 deletions(-)
+
+diff --git a/runtime/prop.c b/runtime/prop.c
+index e5b4693..cb93285 100644
+--- a/runtime/prop.c
++++ b/runtime/prop.c
+@@ -133,7 +133,13 @@ propConstructFinalize(prop_t __attribute__((unused)) *pThis)
+  */
+ static rsRetVal AddRef(prop_t *pThis)
+ {
++	if(pThis == NULL)  {
++		DBGPRINTF("prop/AddRef is passed a NULL ptr - ignoring it "
++			"- further problems may occur\n");
++		FINALIZE;
++	}
+ 	ATOMIC_INC(&pThis->iRefCount, &pThis->mutRefCount);
++finalize_it:
+ 	return RS_RET_OK;
+ }
+ 
+diff --git a/tools/rsyslogd.c b/tools/rsyslogd.c
+index 759d293..6aa1487 100644
+--- a/tools/rsyslogd.c
++++ b/tools/rsyslogd.c
+@@ -808,9 +808,11 @@ logmsgInternal(int iErr, const syslog_pri_t pri, const uchar *const msg, int fla
+ 	 * permits us to process unmodified config files which otherwise contain a
+ 	 * supressor statement.
+ 	 */
+-	if(((Debug == DEBUG_FULL || !doFork) && ourConf->globals.bErrMsgToStderr) || iConfigVerify) {
++	int emit_to_stderr = (ourConf == NULL) ? 1 : ourConf->globals.bErrMsgToStderr;
++	if(((Debug == DEBUG_FULL || !doFork) && emit_to_stderr) || iConfigVerify) {
+ 		if(pri2sev(pri) == LOG_ERR)
+-			fprintf(stderr, "rsyslogd: %s\n", (bufModMsg == NULL) ? (char*)msg : bufModMsg);
++			fprintf(stderr, "rsyslogd: %s\n",
++				(bufModMsg == NULL) ? (char*)msg : bufModMsg);
+ 	}
+ 
+ finalize_it:
+@@ -1115,18 +1117,17 @@ initAll(int argc, char **argv)
+ 
+ 	/* doing some core initializations */
+ 
+-	/* get our host and domain names - we need to do this early as we may emit
+-	 * error log messages, which need the correct hostname. -- rgerhards, 2008-04-04
+-	 */
+-	queryLocalHostname();
+-
+-	/* initialize the objects */
+ 	if((iRet = modInitIminternal()) != RS_RET_OK) {
+ 		fprintf(stderr, "fatal error: could not initialize errbuf object (error code %d).\n",
+ 			iRet);
+ 		exit(1); /* "good" exit, leaving at init for fatal error */
+ 	}
+ 
++	/* get our host and domain names - we need to do this early as we may emit
++	 * error log messages, which need the correct hostname. -- rgerhards, 2008-04-04
++	 * But we need to have imInternal up first!
++	 */
++	queryLocalHostname();
+ 
+ 	/* END core initializations - we now come back to carrying out command line options*/
+ 
+-- 
+2.10.2
+

--- a/recipes-extended/rsyslog/patches/CVE-2017-12588.patch
+++ b/recipes-extended/rsyslog/patches/CVE-2017-12588.patch
@@ -1,0 +1,40 @@
+From 6bc4aa975a83abed43d734299ce76cd9e1a14aec Mon Sep 17 00:00:00 2001
+From: Thomas Deutschmann <whissi@whissi.de>
+Date: Wed, 17 May 2017 23:05:24 +0200
+Subject: [PATCH] imzmq3: Fix building with -Werror=format-security
+
+Reference: https://nvd.nist.gov/vuln/detail/CVE-2017-12588
+
+CVE: 2017-12588
+
+Upstream-Status: Backport
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ contrib/imzmq3/imzmq3.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/contrib/imzmq3/imzmq3.c b/contrib/imzmq3/imzmq3.c
+index 9ca17871..d32dcbc2 100644
+--- a/contrib/imzmq3/imzmq3.c
++++ b/contrib/imzmq3/imzmq3.c
+@@ -403,7 +403,7 @@ static rsRetVal createSocket(instanceConf_t* info, void** sock) {
+ 
+     /* Do the bind/connect... */
+     if (info->action==ACTION_CONNECT) {
+-        rv = zsocket_connect(*sock, info->description);
++        rv = zsocket_connect(*sock, "%s", info->description);
+         if (rv == -1) {
+             errmsg.LogError(0,
+                             RS_RET_INVALID_PARAMS,
+@@ -413,7 +413,7 @@ static rsRetVal createSocket(instanceConf_t* info, void** sock) {
+         }
+         DBGPRINTF("imzmq3: connect for %s successful\n",info->description);
+     } else {
+-        rv = zsocket_bind(*sock, info->description);
++        rv = zsocket_bind(*sock, "%s", info->description);
+         if (rv == -1) {
+             errmsg.LogError(0,
+                             RS_RET_INVALID_PARAMS,
+-- 
+2.13.0
+

--- a/recipes-extended/rsyslog/rsyslog_%.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/patches:"
 
 SRC_URI += " \
     file://CVE-2017-12588.patch \
+    file://0001-core-bugfix-segfault-after-configuration-errors.patch \
 "
 
 # Hack until upstream fix is backported on Pyro upstream:

--- a/recipes-extended/rsyslog/rsyslog_%.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_%.bbappend
@@ -1,2 +1,10 @@
 # Fetch our configuration files.
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+# Hack until upstream fix is backported on Pyro upstream:
+# 32a93e0d5 rsyslog: install logrotate configuration file into correct location
+do_install_append() {
+    rm -f ${D}${sysconfdir}/logrotate.d/logrotate.rsyslog
+    install -d "${D}${sysconfdir}/logrotate.d"
+    install -m 644 ${WORKDIR}/rsyslog.logrotate ${D}${sysconfdir}/logrotate.d/rsyslog
+}

--- a/recipes-extended/rsyslog/rsyslog_%.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_%.bbappend
@@ -1,5 +1,9 @@
 # Fetch our configuration files.
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/patches:"
+
+SRC_URI += " \
+    file://CVE-2017-12588.patch \
+"
 
 # Hack until upstream fix is backported on Pyro upstream:
 # 32a93e0d5 rsyslog: install logrotate configuration file into correct location


### PR DESCRIPTION
- Fix logrorate configuration not installed in the correct `/etc/logrorate.d` directory;
- Backport CVE-2017-12588;
- Backport fix for segfault after configuration errors.

Until sent upstream for `pyro-next`.