### PR TITLE
STABLE-8: OXT-1321: fbcon: The module is now builtin.

### DIFF
--- a/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
+++ b/recipes-openxt/initrdscripts/initramfs-xenclient/init.sh
@@ -107,7 +107,6 @@ read_args() {
             debug)
                 set -x ;;
             fbcon)
-                modprobe fbcon
                 FBCON=true
                 ;;
             break=*)

--- a/recipes-openxt/xenclient/xenclient-config-access/config-access.initscript
+++ b/recipes-openxt/xenclient/xenclient-config-access/config-access.initscript
@@ -35,7 +35,6 @@ LUKS)
 	eval $keycmd | cryptsetup -q -d - luksOpen \
 	    "/dev/mapper/${CONFIG_LV}" config >/dev/null 2>&1 || {
 	    {
-                modprobe fbcon
 		clear
 		echo '** ERROR: Unauthorized system modification detected! **'
 		echo ""

--- a/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
@@ -387,7 +387,6 @@ load_modules()
     modprobe xhci-pci
     modprobe hid
     modprobe hid-generic
-    modprobe fbcon
 
     # A few temp. hacks to get TPM measurement back on track
     modprobe tpm
@@ -412,7 +411,6 @@ unload_modules()
     exec 2>&-
 
     echo -n 0 > /sys/class/vtconsole/vtcon1/bind 2>/dev/null
-    rmmod fbcon >/dev/null 2>&1
 }
 
 #


### PR DESCRIPTION
Silence warning:
modprobe: FATAL: Module fbcon not found in directory /lib/modules/4.14.34

(cherry picked from commit 09917750cd3f614ba7f77fda2da7e6a39e872bc7)

Relates to: https://github.com/OpenXT/installer/pull/75
