### PR TITLE
STABLE-8: OXT-1333, OXT-1346: Xen stable branch and latest XSA.

### DIFF
--- a/recipes-extended/xen/files/Dell-980-txt-shutdown-acpi-access-width.patch
+++ b/recipes-extended/xen/files/Dell-980-txt-shutdown-acpi-access-width.patch
@@ -48,7 +48,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/acpi/power.c
 +++ b/xen/arch/x86/acpi/power.c
-@@ -362,8 +362,10 @@ static void tboot_sleep(u8 sleep_state)
+@@ -376,8 +376,10 @@ static void tboot_sleep(u8 sleep_state)
      /* sizes are not same (due to packing) so copy each one */
      TB_COPY_GAS(g_tboot_shared->acpi_sinfo.pm1a_cnt_blk,
                  acpi_sinfo.pm1a_cnt_blk);

--- a/recipes-extended/xen/files/allow-mwait-cstate.patch
+++ b/recipes-extended/xen/files/allow-mwait-cstate.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/cpuid.c
 +++ b/xen/arch/x86/cpuid.c
-@@ -881,33 +881,36 @@ void guest_cpuid(const struct vcpu *v, u
+@@ -900,33 +900,36 @@ void guest_cpuid(const struct vcpu *v, u
               *
               * These leaks are retained for backwards compatibility, but
               * restricted to the hardware domains kernel only.

--- a/recipes-extended/xen/files/config.patch
+++ b/recipes-extended/xen/files/config.patch
@@ -34,7 +34,7 @@ PATCHES
 ################################################################################
 --- a/tools/configure
 +++ b/tools/configure
-@@ -7407,63 +7407,6 @@
+@@ -7407,63 +7407,6 @@ else
  
  fi
  
@@ -98,7 +98,7 @@ PATCHES
  CPPFLAGS=$ac_previous_cppflags
  LDFLAGS=$ac_previous_ldflags
  
-@@ -8716,53 +8659,6 @@
+@@ -8716,53 +8659,6 @@ $as_echo "$ax_cv_ptyfuncs_libs" >&6; }
      PTYFUNCS_LIBS="$ax_cv_ptyfuncs_libs"
  
  

--- a/recipes-extended/xen/files/cores-per-socket.patch
+++ b/recipes-extended/xen/files/cores-per-socket.patch
@@ -87,7 +87,7 @@ PATCHES
      long rc = do_memory_op(xch, XENMEM_maximum_gpfn, &domid, sizeof(domid));
 --- a/xen/arch/x86/cpuid.c
 +++ b/xen/arch/x86/cpuid.c
-@@ -665,6 +665,7 @@ void guest_cpuid(const struct vcpu *v, u
+@@ -684,6 +684,7 @@ void guest_cpuid(const struct vcpu *v, u
  {
      const struct domain *d = v->domain;
      const struct cpuid_policy *p = d->arch.cpuid;
@@ -95,7 +95,7 @@ PATCHES
  
      *res = EMPTY_LEAF;
  
-@@ -690,6 +691,14 @@ void guest_cpuid(const struct vcpu *v, u
+@@ -709,6 +710,14 @@ void guest_cpuid(const struct vcpu *v, u
                  return;
  
              *res = p->cache.raw[subleaf];
@@ -110,7 +110,7 @@ PATCHES
              break;
  
          case 0x7:
-@@ -760,10 +769,31 @@ void guest_cpuid(const struct vcpu *v, u
+@@ -779,10 +788,31 @@ void guest_cpuid(const struct vcpu *v, u
          const struct cpu_user_regs *regs;
  
      case 0x1:
@@ -146,7 +146,7 @@ PATCHES
  
          /* TODO: Rework vPMU control in terms of toolstack choices. */
          if ( vpmu_available(v) &&
-@@ -1019,6 +1049,25 @@ void guest_cpuid(const struct vcpu *v, u
+@@ -1038,6 +1068,25 @@ void guest_cpuid(const struct vcpu *v, u
          }
          break;
  

--- a/recipes-extended/xen/files/domain-reboot.patch
+++ b/recipes-extended/xen/files/domain-reboot.patch
@@ -47,7 +47,7 @@
  
  start:
      restoring = (restore_file || (migrate_fd >= 0));
-@@ -1149,15 +1168,16 @@ start:
+@@ -1139,15 +1158,16 @@ start:
                      d_config.c_info.name = strdup(common_domname);
                  }
  

--- a/recipes-extended/xen/files/efi-load-option-support.patch
+++ b/recipes-extended/xen/files/efi-load-option-support.patch
@@ -22,8 +22,6 @@ v2: move EFI_LOAD_OPTION definition into file that uses it
  xen/common/efi/boot.c | 49 +++++++++++++++++++++++++++++++++++++++++++------
  1 file changed, 43 insertions(+), 6 deletions(-)
 
-diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
-index daf0c80ef8..0772ba1c93 100644
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
 @@ -88,6 +88,16 @@ typedef struct _EFI_APPLE_PROPERTIES {
@@ -43,7 +41,7 @@ index daf0c80ef8..0772ba1c93 100644
  union string {
      CHAR16 *w;
      char *s;
-@@ -375,12 +385,39 @@ static void __init PrintErrMesg(const CHAR16 *mesg, EFI_STATUS ErrCode)
+@@ -375,12 +385,39 @@ static void __init PrintErrMesg(const CH
  
  static unsigned int __init get_argv(unsigned int argc, CHAR16 **argv,
                                      CHAR16 *cmdline, UINTN cmdsize,
@@ -85,7 +83,7 @@ index daf0c80ef8..0772ba1c93 100644
              cmdsize -= sizeof(*cmdline), ++cmdline )
      {
          bool_t cur_sep = *cmdline == L' ' || *cmdline == L'\t';
-@@ -1073,7 +1110,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+@@ -1073,7 +1110,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      union string section = { NULL }, name;
      bool_t base_video = 0;
      char *option_str;
@@ -94,7 +92,7 @@ index daf0c80ef8..0772ba1c93 100644
  
      __set_bit(EFI_BOOT, &efi_flags);
      __set_bit(EFI_LOADER, &efi_flags);
-@@ -1096,17 +1133,17 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+@@ -1096,17 +1133,17 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      if ( use_cfg_file )
      {
          argc = get_argv(0, NULL, loaded_image->LoadOptions,
@@ -115,6 +113,3 @@ index daf0c80ef8..0772ba1c93 100644
          {
              CHAR16 *ptr = argv[i];
  
--- 
-2.11.0
-

--- a/recipes-extended/xen/files/efi-require-shim.patch
+++ b/recipes-extended/xen/files/efi-require-shim.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Require the presence of the shim to boot under UEFI
 
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
-@@ -1237,6 +1237,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1263,6 +1263,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
  
          efi_bs->LocateProtocol(&shim_lock_guid, NULL, (void **)&shim_lock);
  

--- a/recipes-extended/xen/files/gpt-s3-resume-reason.patch
+++ b/recipes-extended/xen/files/gpt-s3-resume-reason.patch
@@ -33,7 +33,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/hvm/hvm.c
 +++ b/xen/arch/x86/hvm/hvm.c
-@@ -3975,6 +3975,9 @@ static void hvm_s3_suspend(struct domain
+@@ -3974,6 +3974,9 @@ static void hvm_s3_suspend(struct domain
      domain_unlock(d);
  }
  
@@ -43,7 +43,7 @@ PATCHES
  static void hvm_s3_resume(struct domain *d)
  {
      if ( test_and_clear_bool(d->arch.hvm_domain.is_s3_suspended) )
-@@ -3983,6 +3986,10 @@ static void hvm_s3_resume(struct domain
+@@ -3982,6 +3985,10 @@ static void hvm_s3_resume(struct domain
  
          for_each_vcpu( d, v )
              hvm_set_guest_tsc(v, 0);

--- a/recipes-extended/xen/files/hvm-rtc.patch
+++ b/recipes-extended/xen/files/hvm-rtc.patch
@@ -44,7 +44,7 @@ PATCHES
 
 --- a/xen/arch/x86/acpi/power.c
 +++ b/xen/arch/x86/acpi/power.c
-@@ -131,6 +131,8 @@ static void thaw_domains(void)
+@@ -132,6 +132,8 @@ static void thaw_domains(void)
      for_each_domain ( d )
      {
          restore_vcpu_affinity(d);

--- a/recipes-extended/xen/files/increase-ap-startup-time.patch
+++ b/recipes-extended/xen/files/increase-ap-startup-time.patch
@@ -41,7 +41,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/smpboot.c
 +++ b/xen/arch/x86/smpboot.c
-@@ -439,7 +439,14 @@ static int wakeup_secondary_cpu(int phys
+@@ -447,7 +447,14 @@ static int wakeup_secondary_cpu(int phys
           * While AP is in root mode handling the INIT the CPU will drop
           * any SIPIs
           */

--- a/recipes-extended/xen/files/libxl-RFC-5of7-Handle-Linux-stubdomain-specific-QEMUoptions.patch
+++ b/recipes-extended/xen/files/libxl-RFC-5of7-Handle-Linux-stubdomain-specific-QEMUoptions.patch
@@ -64,16 +64,7 @@ PATCHES
                                    NULL);
                  ioemu_nics++;
              }
-@@ -657,6 +660,8 @@ static const char *qemu_disk_format_stri
-     case LIBXL_DISK_FORMAT_RAW: return "raw";
-     case LIBXL_DISK_FORMAT_EMPTY: return NULL;
-     case LIBXL_DISK_FORMAT_QED: return "qed";
-+    case LIBXL_DISK_FORMAT_HOST_CDROM: return "host_cdrom";
-+    case LIBXL_DISK_FORMAT_HOST_DEVICE: return "host_device";
-     default: return NULL;
-     }
- }
-@@ -911,6 +916,7 @@ static int libxl__build_device_model_arg
+@@ -898,6 +901,7 @@ static int libxl__build_device_model_arg
      uint64_t ram_size;
      const char *path, *chardev;
      char *user = NULL;
@@ -81,7 +72,7 @@ PATCHES
  
      dm_args = flexarray_make(gc, 16, 1);
      dm_envs = flexarray_make(gc, 16, 1);
-@@ -921,24 +927,18 @@ static int libxl__build_device_model_arg
+@@ -908,24 +912,18 @@ static int libxl__build_device_model_arg
                        "-xen-domid",
                        GCSPRINTF("%d", guest_domid), NULL);
  
@@ -118,7 +109,7 @@ PATCHES
  
      for (i = 0; i < guest_config->num_channels; i++) {
          connection = guest_config->channels[i].connection;
-@@ -982,7 +982,7 @@ static int libxl__build_device_model_arg
+@@ -969,7 +967,7 @@ static int libxl__build_device_model_arg
          flexarray_vappend(dm_args, "-name", c_info->name, NULL);
      }
  
@@ -127,7 +118,7 @@ PATCHES
          char *vncarg = NULL;
  
          flexarray_append(dm_args, "-vnc");
-@@ -1033,7 +1033,7 @@ static int libxl__build_device_model_arg
+@@ -1020,7 +1018,7 @@ static int libxl__build_device_model_arg
       */
      flexarray_append_pair(dm_args, "-display", "none");
  
@@ -136,7 +127,7 @@ PATCHES
          flexarray_append(dm_args, "-sdl");
          if (sdl->display)
              flexarray_append_pair(dm_envs, "DISPLAY", sdl->display);
-@@ -1064,10 +1064,19 @@ static int libxl__build_device_model_arg
+@@ -1051,10 +1049,19 @@ static int libxl__build_device_model_arg
                  return ERROR_INVAL;
              }
              if (b_info->u.hvm.serial) {
@@ -158,7 +149,7 @@ PATCHES
                  for (p = b_info->u.hvm.serial_list;
                       *p;
                       p++) {
-@@ -1082,7 +1091,7 @@ static int libxl__build_device_model_arg
+@@ -1069,7 +1076,7 @@ static int libxl__build_device_model_arg
              flexarray_append(dm_args, "-nographic");
          }
  
@@ -167,7 +158,7 @@ PATCHES
              const libxl_spice_info *spice = &b_info->u.hvm.spice;
              char *spiceoptions = dm_spice_options(gc, spice);
              if (!spiceoptions)
-@@ -1221,8 +1230,8 @@ static int libxl__build_device_model_arg
+@@ -1208,8 +1215,8 @@ static int libxl__build_device_model_arg
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
                                             "script=%s,downscript=%s",
                                             nics[i].devid, ifname,
@@ -178,19 +169,19 @@ PATCHES
  
                  /* Userspace COLO Proxy need this */
  #define APPEND_COLO_SOCK_SERVER(sock_id, sock_ip, sock_port) ({             \
-@@ -1475,6 +1484,11 @@ static int libxl__build_device_model_arg
+@@ -1462,6 +1469,11 @@ static int libxl__build_device_model_arg
                           disks[i].vdev);
                      continue;
                  }
 +            } else if ((disks[i].is_cdrom) && (b_info->stubdomain_version ==
 +                                               LIBXL_STUBDOMAIN_VERSION_LINUX))
 +            {
-+                format = qemu_disk_format_string(LIBXL_DISK_FORMAT_HOST_CDROM);
++                format = libxl__qemu_disk_format_string(LIBXL_DISK_FORMAT_HOST_CDROM);
 +                target_path = "/dev/xvdc";
              } else {
                  if (format == NULL) {
                      LOGD(WARN, guest_domid,
-@@ -1565,6 +1579,10 @@ static int libxl__build_device_model_arg
+@@ -1552,6 +1564,10 @@ static int libxl__build_device_model_arg
                               "qemu-xen doesn't support read-only IDE disk drivers");
                          return ERROR_INVAL;
                      }
@@ -201,7 +192,7 @@ PATCHES
                      if (colo_mode == LIBXL__COLO_SECONDARY) {
                          drive = libxl__sprintf
                              (gc, "if=none,driver=%s,file=%s,id=%s",
-@@ -1644,7 +1662,7 @@ static int libxl__build_device_model_arg
+@@ -1631,7 +1647,7 @@ static int libxl__build_device_model_arg
                                          char ***args, char ***envs,
                                          const libxl__domain_build_state *state,
                                          int *dm_state_fd)
@@ -210,7 +201,7 @@ PATCHES
   * and therefore will be passing a filename rather than a fd. */
  {
      switch (guest_config->b_info.device_model_version) {
-@@ -1654,8 +1672,10 @@ static int libxl__build_device_model_arg
+@@ -1641,8 +1657,10 @@ static int libxl__build_device_model_arg
                                                    args, envs,
                                                    state);
      case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN:
@@ -223,7 +214,7 @@ PATCHES
          return libxl__build_device_model_args_new(gc, dm,
                                                    guest_domid, guest_config,
                                                    args, envs,
-@@ -1712,7 +1732,7 @@ static int libxl__vfb_and_vkb_from_hvm_g
+@@ -1699,7 +1717,7 @@ static int libxl__vfb_and_vkb_from_hvm_g
  
  static int libxl__write_stub_dmargs(libxl__gc *gc,
                                      int dm_domid, int guest_domid,
@@ -232,7 +223,7 @@ PATCHES
  {
      libxl_ctx *ctx = libxl__gc_owner(gc);
      int i;
-@@ -1740,7 +1760,9 @@ static int libxl__write_stub_dmargs(libx
+@@ -1727,7 +1745,9 @@ static int libxl__write_stub_dmargs(libx
      i = 1;
      dmargs[0] = '\0';
      while (args[i] != NULL) {
@@ -243,7 +234,7 @@ PATCHES
              strcat(dmargs, " ");
              strcat(dmargs, args[i]);
          }
-@@ -1878,7 +1900,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1865,7 +1885,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          goto out;
      }
  
@@ -264,3 +255,14 @@ PATCHES
      ])
  
  libxl_disk_backend = Enumeration("disk_backend", [
+--- a/tools/libxl/libxl_device.c
++++ b/tools/libxl/libxl_device.c
+@@ -435,6 +435,8 @@ const char *libxl__qemu_disk_format_stri
+     case LIBXL_DISK_FORMAT_RAW: return "raw";
+     case LIBXL_DISK_FORMAT_EMPTY: return NULL;
+     case LIBXL_DISK_FORMAT_QED: return "qed";
++    case LIBXL_DISK_FORMAT_HOST_CDROM: return "host_cdrom";
++    case LIBXL_DISK_FORMAT_HOST_DEVICE: return "host_device";
+     default: return NULL;
+     }
+ }

--- a/recipes-extended/xen/files/libxl-RFC-6of7-Build-the-domain-with-a-Linux-based-stubdomain.patch
+++ b/recipes-extended/xen/files/libxl-RFC-6of7-Build-the-domain-with-a-Linux-based-stubdomain.patch
@@ -93,7 +93,7 @@ PATCHES
  
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1781,6 +1781,16 @@ retry_transaction:
+@@ -1766,6 +1766,16 @@ retry_transaction:
      return 0;
  }
  
@@ -110,7 +110,7 @@ PATCHES
  static void spawn_stubdom_pvqemu_cb(libxl__egc *egc,
                                  libxl__dm_spawn_state *stubdom_dmss,
                                  int rc);
-@@ -1810,6 +1820,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1795,6 +1805,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      char **args;
      struct xs_permissions perm[2];
      xs_transaction_t t;
@@ -118,7 +118,7 @@ PATCHES
  
      /* convenience aliases */
      libxl_domain_config *const dm_config = &sdss->dm_config;
-@@ -1818,10 +1829,14 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1803,10 +1814,14 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      libxl__domain_build_state *const d_state = sdss->dm.build_state;
      libxl__domain_build_state *const stubdom_state = &sdss->dm_state;
  
@@ -137,7 +137,7 @@ PATCHES
      }
  
      sdss->pvqemu.guest_domid = 0;
-@@ -1842,8 +1857,17 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1827,8 +1842,17 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      libxl_domain_build_info_init_type(&dm_config->b_info, LIBXL_DOMAIN_TYPE_PV);
  
      dm_config->b_info.max_vcpus = 1;
@@ -157,7 +157,7 @@ PATCHES
      dm_config->b_info.target_memkb = dm_config->b_info.max_memkb;
  
      dm_config->b_info.u.pv.features = "";
-@@ -1877,10 +1901,33 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1862,10 +1886,33 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->vkbs = vkb;
      dm_config->num_vkbs = 1;
  
@@ -195,7 +195,7 @@ PATCHES
  
      /* fixme: this function can leak the stubdom if it fails */
      ret = libxl__domain_make(gc, dm_config, &sdss->pvqemu.guest_domid,
-@@ -1900,6 +1947,10 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1885,6 +1932,10 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          goto out;
      }
  
@@ -206,7 +206,7 @@ PATCHES
      libxl__write_stub_dmargs(gc, dm_domid, guest_domid, args,
           guest_config->b_info.stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX);
      libxl__xs_printf(gc, XBT_NULL,
-@@ -1910,6 +1961,15 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1895,6 +1946,15 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                       GCSPRINTF("%s/target",
                                 libxl__xs_get_dompath(gc, dm_domid)),
                       "%d", guest_domid);
@@ -222,7 +222,7 @@ PATCHES
      ret = xc_domain_set_target(ctx->xch, dm_domid, guest_domid);
      if (ret<0) {
          LOGED(ERROR, guest_domid, "setting target domain %d -> %d",
-@@ -1935,6 +1995,10 @@ retry_transaction:
+@@ -1920,6 +1980,10 @@ retry_transaction:
  
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
@@ -233,7 +233,7 @@ PATCHES
      libxl__add_disks(egc, ao, dm_domid, dm_config, &sdss->multidev);
      libxl__multidev_prepared(egc, &sdss->multidev, 0);
  
-@@ -1984,6 +2048,10 @@ static void spawn_stub_launch_dm(libxl__
+@@ -1969,6 +2033,10 @@ static void spawn_stub_launch_dm(libxl__
      if (ret)
          goto out;
  
@@ -244,7 +244,7 @@ PATCHES
      if (guest_config->b_info.u.hvm.serial)
          num_console++;
  
-@@ -2009,14 +2077,20 @@ static void spawn_stub_launch_dm(libxl__
+@@ -1994,14 +2062,20 @@ static void spawn_stub_launch_dm(libxl__
                  free(filename);
                  break;
              case STUBDOM_CONSOLE_SAVE:
@@ -313,7 +313,7 @@ PATCHES
  #define TAP_DEVICE_SUFFIX "-emu"
  #define DOMID_XS_PATH "domid"
  #define INVALID_DOMID ~0
-@@ -2034,6 +2035,9 @@ _hidden libxl__json_object *libxl__json_
+@@ -2035,6 +2036,9 @@ _hidden libxl__json_object *libxl__json_
  _hidden int libxl__device_model_version_running(libxl__gc *gc, uint32_t domid);
    /* Return the system-wide default device model */
  _hidden libxl_device_model_version libxl__default_device_model(libxl__gc *gc);

--- a/recipes-extended/xen/files/libxl-RFC-7of7-Wait-for-QEMU-startup-in-stubdomain.patch
+++ b/recipes-extended/xen/files/libxl-RFC-7of7-Wait-for-QEMU-startup-in-stubdomain.patch
@@ -34,7 +34,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2141,6 +2141,39 @@ out:
+@@ -2126,6 +2126,39 @@ out:
      stubdom_pvqemu_cb(egc, &sdss->multidev, rc);
  }
  
@@ -74,7 +74,7 @@ PATCHES
  static void stubdom_pvqemu_cb(libxl__egc *egc,
                                libxl__multidev *multidev,
                                int rc)
-@@ -2148,6 +2181,7 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2133,6 +2166,7 @@ static void stubdom_pvqemu_cb(libxl__egc
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
      uint32_t dm_domid = sdss->pvqemu.guest_domid;
@@ -82,7 +82,7 @@ PATCHES
  
      libxl__xswait_init(&sdss->xswait);
  
-@@ -2157,6 +2191,17 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2142,6 +2176,17 @@ static void stubdom_pvqemu_cb(libxl__egc
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-RFC-fix-multiple-disks.patch
+++ b/recipes-extended/xen/files/libxl-RFC-fix-multiple-disks.patch
@@ -32,7 +32,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1580,7 +1580,10 @@ static int libxl__build_device_model_arg
+@@ -1565,7 +1565,10 @@ static int libxl__build_device_model_arg
                          return ERROR_INVAL;
                      }
                      if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {

--- a/recipes-extended/xen/files/libxl-RFC-fixes.patch
+++ b/recipes-extended/xen/files/libxl-RFC-fixes.patch
@@ -35,7 +35,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1691,12 +1691,14 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1676,12 +1676,14 @@ static void libxl__dm_vifs_from_hvm_gues
                                      libxl_domain_config * const guest_config,
                                      libxl_domain_config *dm_config)
  {
@@ -51,7 +51,7 @@ PATCHES
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;
          if (dm_config->nics[i].ifname)
              dm_config->nics[i].ifname = GCSPRINTF("%s" TAP_DEVICE_SUFFIX,
-@@ -2158,7 +2160,10 @@ static void stub_dm_watch_event(libxl__e
+@@ -2143,7 +2145,10 @@ static void stub_dm_watch_event(libxl__e
          if (dm_domid) {
              sdss->dis.ao = sdss->dm.spawn.ao;
              sdss->dis.domid = dm_domid;

--- a/recipes-extended/xen/files/libxl-atapi-pt.patch
+++ b/recipes-extended/xen/files/libxl-atapi-pt.patch
@@ -55,7 +55,7 @@ PATCHES
                 !disk->script) {
          if (stat(disk->pdev_path, &a.stab)) {
              LOGE(ERROR, "Disk vdev=%s failed to stat: %s",
-@@ -490,6 +496,14 @@ int libxl__device_disk_dev_number(const
+@@ -506,6 +512,14 @@ int libxl__device_disk_dev_number(const
      char *ep;
      unsigned long ul;
      int chrused;
@@ -72,7 +72,7 @@ PATCHES
      if ((sscanf(virtpath, "d%ip%i%n", &disk, &partition, &chrused)  >= 2
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1531,13 +1531,20 @@ static int libxl__build_device_model_arg
+@@ -1515,13 +1515,20 @@ static int libxl__build_device_model_arg
              }
  
              if (disks[i].is_cdrom) {
@@ -100,7 +100,7 @@ PATCHES
              } else {
                  /*
                   * Explicit sd disks are passed through as is.
-@@ -1693,6 +1700,34 @@ static int libxl__build_device_model_arg
+@@ -1677,6 +1684,34 @@ static int libxl__build_device_model_arg
      }
  }
  
@@ -135,7 +135,7 @@ PATCHES
  static void libxl__dm_vifs_from_hvm_guest_config(libxl__gc *gc,
                                      libxl_domain_config * const guest_config,
                                      libxl_domain_config *dm_config)
-@@ -1895,9 +1930,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1879,9 +1914,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.extra_hvm = guest_config->b_info.extra_hvm;
      dm_config->b_info.stubdom_cmdline = guest_config->b_info.stubdom_cmdline;
  

--- a/recipes-extended/xen/files/libxl-blktap3-support.patch
+++ b/recipes-extended/xen/files/libxl-blktap3-support.patch
@@ -215,7 +215,7 @@ PATCHES
  libxl__console_backend = Enumeration("console_backend", [
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
-@@ -920,7 +920,9 @@ void libxl__initiate_device_generic_remo
+@@ -936,7 +936,9 @@ void libxl__initiate_device_generic_remo
      STATE_AO_GC(aodev->ao);
      xs_transaction_t t = 0;
      char *be_path = libxl__device_backend_path(gc, aodev->dev);
@@ -225,7 +225,7 @@ PATCHES
      char *online_path = GCSPRINTF("%s/online", be_path);
      const char *state;
      libxl_dominfo info;
-@@ -990,6 +992,11 @@ void libxl__initiate_device_generic_remo
+@@ -1006,6 +1008,11 @@ void libxl__initiate_device_generic_remo
                  LOGD(ERROR, domid, "unable to write to xenstore path %s", state_path);
                  goto out;
              }

--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -51,7 +51,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1770,7 +1770,8 @@ _hidden int libxl__blktap_enabled(libxl_
+@@ -1771,7 +1771,8 @@ _hidden int libxl__blktap_enabled(libxl_
   */
  _hidden char *libxl__blktap_devpath(libxl__gc *gc,
                                      const char *disk,
@@ -135,7 +135,7 @@ PATCHES
      if (!err) {
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1516,7 +1516,7 @@ static int libxl__build_device_model_arg
+@@ -1500,7 +1500,7 @@ static int libxl__build_device_model_arg
                   */
                  if (disks[i].backend == LIBXL_DISK_BACKEND_TAP)
                      target_path = libxl__blktap_devpath(gc, disks[i].pdev_path,

--- a/recipes-extended/xen/files/libxl-disable-json-updates.patch
+++ b/recipes-extended/xen/files/libxl-disable-json-updates.patch
@@ -49,7 +49,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -3442,7 +3442,7 @@ _hidden void libxl__bootloader_run(libxl
+@@ -3443,7 +3443,7 @@ _hidden void libxl__bootloader_run(libxl
          libxl__prepare_ao_device(ao, aodev);                            \
          aodev->action = LIBXL__DEVICE_ACTION_ADD;                       \
          aodev->callback = device_addrm_aocomplete;                      \

--- a/recipes-extended/xen/files/libxl-disable-vnc-query-when-disabled.patch
+++ b/recipes-extended/xen/files/libxl-disable-vnc-query-when-disabled.patch
@@ -35,7 +35,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_qmp.c
 +++ b/tools/libxl/libxl_qmp.c
-@@ -1201,7 +1201,7 @@ int libxl__qmp_initializations(libxl__gc
+@@ -1203,7 +1203,7 @@ int libxl__qmp_initializations(libxl__gc
          ret = qmp_change(gc, qmp, "vnc", "password", vnc->passwd);
          qmp_write_domain_console_item(gc, domid, "vnc-pass", vnc->passwd);
      }

--- a/recipes-extended/xen/files/libxl-display-manager-support.patch
+++ b/recipes-extended/xen/files/libxl-display-manager-support.patch
@@ -46,7 +46,7 @@ PATCHES
  static int
  libxl__xc_device_get_rdm(libxl__gc *gc,
                           uint32_t flags,
-@@ -904,6 +912,7 @@ static int libxl__build_device_model_arg
+@@ -888,6 +896,7 @@ static int libxl__build_device_model_arg
      const int num_disks = guest_config->num_disks;
      const int num_nics = guest_config->num_nics;
      const libxl_vnc_info *vnc = libxl__dm_vnc(guest_config);
@@ -54,7 +54,7 @@ PATCHES
      const libxl_sdl_info *sdl = dm_sdl(guest_config);
      const char *keymap = dm_keymap(guest_config);
      char *machinearg;
-@@ -1023,7 +1032,10 @@ static int libxl__build_device_model_arg
+@@ -1007,7 +1016,10 @@ static int libxl__build_device_model_arg
      /*
       * OpenXT: the default display backend is Surfman
       */
@@ -68,7 +68,7 @@ PATCHES
          flexarray_append(dm_args, "-sdl");
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1707,6 +1707,8 @@ _hidden int libxl__wait_for_device_model
+@@ -1708,6 +1708,8 @@ _hidden int libxl__wait_for_device_model
  
  _hidden int libxl__destroy_device_model(libxl__gc *gc, uint32_t domid);
  

--- a/recipes-extended/xen/files/libxl-do-not-destroy-in-use-tapdevs.patch
+++ b/recipes-extended/xen/files/libxl-do-not-destroy-in-use-tapdevs.patch
@@ -88,7 +88,7 @@ PATCHES
          LOGEV(ERROR, -err, "Failed to destroy tap device id %d minor %d",
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
-@@ -746,7 +746,7 @@ int libxl__device_destroy(libxl__gc *gc,
+@@ -759,7 +759,7 @@ int libxl__device_destroy(libxl__gc *gc,
      }
  
      if (tapdisk_params)
@@ -99,7 +99,7 @@ PATCHES
      libxl__xs_transaction_abort(gc, &t);
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1757,7 +1757,7 @@ _hidden char *libxl__blktap_devpath(libx
+@@ -1758,7 +1758,7 @@ _hidden char *libxl__blktap_devpath(libx
   *   by be_path.
   *   Always logs on failure.
   */

--- a/recipes-extended/xen/files/libxl-domain-state.patch
+++ b/recipes-extended/xen/files/libxl-domain-state.patch
@@ -201,7 +201,7 @@ PATCHES
                          "hardware domain and toolstack.\n\n");
          exit(EXIT_FAILURE);
      }
-+    
++
 +    rc = libxl_domid_to_uuid(ctx, &uuid, domid);
 +    if (rc) {
 +        fprintf(stderr, "domid to uuid failed during domain destroy\n");

--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -52,7 +52,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1412,12 +1412,19 @@ _hidden int libxl__pci_topology_init(lib
+@@ -1413,12 +1413,19 @@ _hidden int libxl__pci_topology_init(lib
  
  /* from libxl_pci */
  
@@ -68,12 +68,12 @@ PATCHES
 +_hidden int libxl__device_pci_destroy_all(libxl__gc *gc, uint32_t domid, libxl_pci_dev_wrap **pciw);
  _hidden bool libxl__is_igd_vga_passthru(libxl__gc *gc,
                                          const libxl_domain_config *d_config);
-+_hidden int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain, 
++_hidden int libxl__device_pci_reset(libxl__gc *gc, unsigned int domain,
 +                                    unsigned int bus, unsigned int dev, unsigned int func);
  
  /* from libxl_dtdev */
  
-@@ -3608,6 +3615,7 @@ struct libxl__destroy_domid_state {
+@@ -3609,6 +3616,7 @@ struct libxl__destroy_domid_state {
      /* private to implementation */
      libxl__devices_remove_state drs;
      libxl__ev_child destroyer;
@@ -165,7 +165,7 @@ PATCHES
 +        for (int i = 0; i < dis->pciw->num_devs; i++) {
 +            libxl_device_pci *pcidev = &dis->pciw->pcidevs[i];
 +            libxl__device_pci_reset(gc, pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func);
-+        } 
++        }
 +        free(dis->pciw->pcidevs);
 +        free(dis->pciw);
 +    }

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -381,7 +381,7 @@ PATCHES
  
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1218,6 +1218,7 @@ _hidden int libxl__device_exists(libxl__
+@@ -1219,6 +1219,7 @@ _hidden int libxl__device_exists(libxl__
  _hidden int libxl__device_generic_add(libxl__gc *gc, xs_transaction_t t,
          libxl__device *device, char **bents, char **fents, char **ro_fents);
  _hidden char *libxl__device_backend_path(libxl__gc *gc, libxl__device *device);
@@ -389,7 +389,7 @@ PATCHES
  _hidden char *libxl__device_libxl_path(libxl__gc *gc, libxl__device *device);
  _hidden int libxl__parse_backend_path(libxl__gc *gc, const char *path,
                                        libxl__device *dev);
-@@ -1764,6 +1765,9 @@ _hidden char *libxl__blktap_devpath(libx
+@@ -1765,6 +1766,9 @@ _hidden char *libxl__blktap_devpath(libx
                                      const char *disk,
                                      libxl_disk_format format);
  
@@ -399,7 +399,7 @@ PATCHES
  /* libxl__device_destroy_tapdisk:
   *   Destroys any tapdisk process associated with the backend represented
   *   by be_path.
-@@ -1835,6 +1839,7 @@ _hidden int libxl__qmp_restore(libxl__gc
+@@ -1836,6 +1840,7 @@ _hidden int libxl__qmp_restore(libxl__gc
  /* Set dirty bitmap logging status */
  _hidden int libxl__qmp_set_global_dirty_log(libxl__gc *gc, int domid, bool enable);
  _hidden int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid, const libxl_device_disk *disk);

--- a/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
+++ b/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
@@ -37,7 +37,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1590,7 +1590,6 @@ static int libxl__build_device_model_arg
+@@ -1575,7 +1575,6 @@ static int libxl__build_device_model_arg
                                                    "/dev/xvdb",
                                                    "/dev/xvdc",
                                                    "/dev/xvdd"} [disk];
@@ -45,7 +45,7 @@ PATCHES
                      }
                      if (colo_mode == LIBXL__COLO_SECONDARY) {
                          drive = libxl__sprintf
-@@ -1835,7 +1834,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1820,7 +1819,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      char **args;
      struct xs_permissions perm[2];
      xs_transaction_t t;
@@ -53,7 +53,7 @@ PATCHES
  
      /* convenience aliases */
      libxl_domain_config *const dm_config = &sdss->dm_config;
-@@ -1924,20 +1922,12 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1909,20 +1907,12 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          stubdom_state->pv_ramdisk.path = "";
          break;
      case LIBXL_STUBDOMAIN_VERSION_LINUX:
@@ -79,7 +79,7 @@ PATCHES
          break;
      default:
          abort();
-@@ -2010,10 +2000,7 @@ retry_transaction:
+@@ -1995,10 +1985,7 @@ retry_transaction:
  
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
@@ -91,7 +91,7 @@ PATCHES
      libxl__add_disks(egc, ao, dm_domid, dm_config, &sdss->multidev);
      libxl__multidev_prepared(egc, &sdss->multidev, 0);
  
-@@ -2123,6 +2110,12 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2108,6 +2095,12 @@ static void spawn_stub_launch_dm(libxl__
      sdss->pvqemu.build_state = &sdss->dm_state;
      sdss->pvqemu.callback = spawn_stubdom_pvqemu_cb;
  
@@ -104,7 +104,7 @@ PATCHES
      libxl__spawn_local_dm(egc, &sdss->pvqemu);
  
      return;
-@@ -2156,42 +2149,6 @@ out:
+@@ -2141,42 +2134,6 @@ out:
      stubdom_pvqemu_cb(egc, &sdss->multidev, rc);
  }
  
@@ -147,7 +147,7 @@ PATCHES
  static void stubdom_pvqemu_cb(libxl__egc *egc,
                                libxl__multidev *multidev,
                                int rc)
-@@ -2209,16 +2166,7 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2194,16 +2151,7 @@ static void stubdom_pvqemu_cb(libxl__egc
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-move-extra-qemu-args-to-the-end.patch
+++ b/recipes-extended/xen/files/libxl-move-extra-qemu-args-to-the-end.patch
@@ -57,7 +57,7 @@ PATCHES
      flexarray_append(dm_args, NULL);
      *args = (char **) flexarray_contents(dm_args);
      flexarray_append(dm_envs, NULL);
-@@ -1395,8 +1395,6 @@ static int libxl__build_device_model_arg
+@@ -1379,8 +1379,6 @@ static int libxl__build_device_model_arg
          flexarray_append(dm_args, "-incoming");
          flexarray_append(dm_args, GCSPRINTF("fd:%d",*dm_state_fd));
      }
@@ -66,7 +66,7 @@ PATCHES
  
      flexarray_append(dm_args, "-machine");
      switch (b_info->type) {
-@@ -1655,6 +1653,8 @@ end_search:
+@@ -1639,6 +1637,8 @@ end_search:
              flexarray_append(dm_args, user);
          }
      }

--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -43,7 +43,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1940,6 +1940,41 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1925,6 +1925,41 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      if (ret)
          goto out;
      uint32_t dm_domid = sdss->pvqemu.guest_domid;

--- a/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
+++ b/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
@@ -90,15 +90,7 @@ PATCHES
          if (libxl_defbool_val(b_info->u.hvm.gfx_passthru)) {
              switch (b_info->u.hvm.gfx_passthru_kind) {
              case LIBXL_GFX_PASSTHRU_KIND_DEFAULT:
-@@ -665,6 +657,7 @@ static const char *qemu_disk_format_stri
-     case LIBXL_DISK_FORMAT_QED: return "qed";
-     case LIBXL_DISK_FORMAT_HOST_CDROM: return "host_cdrom";
-     case LIBXL_DISK_FORMAT_HOST_DEVICE: return "host_device";
-+    case LIBXL_DISK_FORMAT_FILE: return "file";
-     default: return NULL;
-     }
- }
-@@ -930,19 +923,20 @@ static int libxl__build_device_model_arg
+@@ -915,19 +907,20 @@ static int libxl__build_device_model_arg
                        "-xen-domid",
                        GCSPRINTF("%d", guest_domid), NULL);
  
@@ -127,7 +119,7 @@ PATCHES
      for (i = 0; i < guest_config->num_channels; i++) {
          connection = guest_config->channels[i].connection;
          devid = guest_config->channels[i].devid;
-@@ -982,7 +976,7 @@ static int libxl__build_device_model_arg
+@@ -967,7 +960,7 @@ static int libxl__build_device_model_arg
      }
  
      if (c_info->name) {
@@ -136,7 +128,7 @@ PATCHES
      }
  
      if (vnc && !is_stubdom) {
-@@ -1024,17 +1018,12 @@ static int libxl__build_device_model_arg
+@@ -1009,17 +1002,12 @@ static int libxl__build_device_model_arg
          }
  
          flexarray_append(dm_args, vncarg);
@@ -157,7 +149,7 @@ PATCHES
  
      if (sdl && !is_stubdom) {
          flexarray_append(dm_args, "-sdl");
-@@ -1136,7 +1125,7 @@ static int libxl__build_device_model_arg
+@@ -1121,7 +1109,7 @@ static int libxl__build_device_model_arg
  
          if (b_info->u.hvm.boot) {
              flexarray_vappend(dm_args, "-boot",
@@ -166,7 +158,7 @@ PATCHES
          }
          if (libxl_defbool_val(b_info->u.hvm.usb)
              || b_info->u.hvm.usbdevice
-@@ -1228,7 +1217,7 @@ static int libxl__build_device_model_arg
+@@ -1213,7 +1201,7 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
                  flexarray_append(dm_args,
@@ -175,7 +167,7 @@ PATCHES
                               nics[i].model, nics[i].devid,
                               nics[i].devid, smac));
                  flexarray_append(dm_args, "-netdev");
-@@ -1379,11 +1368,9 @@ static int libxl__build_device_model_arg
+@@ -1364,11 +1352,9 @@ static int libxl__build_device_model_arg
  #undef APPEND_COLO_SOCK_CLIENT
              }
          }
@@ -190,12 +182,12 @@ PATCHES
      } else {
          if (!sdl && !vnc) {
              flexarray_append(dm_args, "-nographic");
-@@ -1493,7 +1480,7 @@ static int libxl__build_device_model_arg
+@@ -1478,7 +1464,7 @@ static int libxl__build_device_model_arg
              } else if ((disks[i].is_cdrom) && (b_info->stubdomain_version ==
                                                 LIBXL_STUBDOMAIN_VERSION_LINUX))
              {
--                format = qemu_disk_format_string(LIBXL_DISK_FORMAT_HOST_CDROM);
-+                format = qemu_disk_format_string(LIBXL_DISK_FORMAT_FILE);
+-                format = libxl__qemu_disk_format_string(LIBXL_DISK_FORMAT_HOST_CDROM);
++                format = libxl__qemu_disk_format_string(LIBXL_DISK_FORMAT_FILE);
                  target_path = "/dev/xvdc";
              } else {
                  if (format == NULL) {
@@ -209,3 +201,13 @@ PATCHES
      ])
  
  libxl_disk_backend = Enumeration("disk_backend", [
+--- a/tools/libxl/libxl_device.c
++++ b/tools/libxl/libxl_device.c
+@@ -434,6 +434,7 @@ const char *libxl__qemu_disk_format_stri
+     case LIBXL_DISK_FORMAT_QED: return "qed";
+     case LIBXL_DISK_FORMAT_HOST_CDROM: return "host_cdrom";
+     case LIBXL_DISK_FORMAT_HOST_DEVICE: return "host_device";
++    case LIBXL_DISK_FORMAT_FILE: return "file";
+     default: return NULL;
+     }
+ }

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2029,6 +2029,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2013,6 +2013,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                                     libxl__xs_get_dompath(gc, guest_domid)),
                          "%s",
                          libxl_bios_type_to_string(LIBXL_BIOS_TYPE_SEABIOS));
@@ -48,7 +48,7 @@ PATCHES
      }
      ret = xc_domain_set_target(ctx->xch, dm_domid, guest_domid);
      if (ret<0) {
-@@ -2053,6 +2058,12 @@ retry_transaction:
+@@ -2037,6 +2042,12 @@ retry_transaction:
          if (errno == EAGAIN)
              goto retry_transaction;
  
@@ -61,7 +61,7 @@ PATCHES
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
      /* OpenXT: Again, no disk for the stubdom itself */
-@@ -2071,7 +2082,6 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2055,7 +2066,6 @@ static void spawn_stub_launch_dm(libxl__
  {
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
@@ -69,7 +69,7 @@ PATCHES
      int i, num_console = STUBDOM_SPECIAL_CONSOLES;
      libxl__device_console *console;
  
-@@ -2117,21 +2127,16 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2101,21 +2111,16 @@ static void spawn_stub_launch_dm(libxl__
      for (i = 0; i < num_console; i++) {
          libxl__device device;
          console[i].devid = i;
@@ -95,7 +95,7 @@ PATCHES
                  break;
              case STUBDOM_CONSOLE_SAVE:
                  if (guest_config->b_info.stubdomain_version
-@@ -2211,7 +2216,6 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2195,7 +2200,6 @@ static void stubdom_pvqemu_cb(libxl__egc
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
      uint32_t dm_domid = sdss->pvqemu.guest_domid;
@@ -103,7 +103,7 @@ PATCHES
  
      libxl__xswait_init(&sdss->xswait);
  
-@@ -2335,6 +2339,17 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2319,6 +2323,17 @@ void libxl__spawn_local_dm(libxl__egc *e
                           b_info->device_model_version==LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL &&
                           !libxl__vnuma_configured(b_info));
          free(path);

--- a/recipes-extended/xen/files/libxl-pass-qemu-options-through-linux-stubdom-cmdline.patch
+++ b/recipes-extended/xen/files/libxl-pass-qemu-options-through-linux-stubdom-cmdline.patch
@@ -38,7 +38,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1921,6 +1921,47 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1905,6 +1905,47 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      }
  
  
@@ -86,7 +86,7 @@ PATCHES
      /* fixme: this function can leak the stubdom if it fails */
      ret = libxl__domain_make(gc, dm_config, &sdss->pvqemu.guest_domid,
                               &stubdom_state->config);
-@@ -1966,14 +2007,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1950,14 +1991,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      if (ret)
          goto out;
  

--- a/recipes-extended/xen/files/libxl-pci-passthrough-fixes.patch
+++ b/recipes-extended/xen/files/libxl-pci-passthrough-fixes.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
-@@ -1799,6 +1799,32 @@ out:
+@@ -1815,6 +1815,32 @@ out:
      return AO_CREATE_FAIL(rc);
  }
  
@@ -71,7 +71,7 @@ PATCHES
   * mode: C
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1224,6 +1224,8 @@ _hidden int libxl__parse_backend_path(li
+@@ -1225,6 +1225,8 @@ _hidden int libxl__parse_backend_path(li
  _hidden int libxl__device_destroy(libxl__gc *gc, libxl__device *dev);
  _hidden int libxl__wait_for_backend(libxl__gc *gc, const char *be_path,
                                      const char *state);

--- a/recipes-extended/xen/files/libxl-stubdom-options.patch
+++ b/recipes-extended/xen/files/libxl-stubdom-options.patch
@@ -51,7 +51,7 @@ PATCHES
      ("iomem",            Array(libxl_iomem_range, "num_iomem")),
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1880,6 +1880,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1864,6 +1864,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          abort();
      }
      dm_config->b_info.max_memkb += guest_config->b_info.video_memkb;
@@ -59,7 +59,7 @@ PATCHES
      dm_config->b_info.target_memkb = dm_config->b_info.max_memkb;
  
      dm_config->b_info.u.pv.features = "";
-@@ -1891,6 +1892,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1875,6 +1876,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.extra = guest_config->b_info.extra;
      dm_config->b_info.extra_pv = guest_config->b_info.extra_pv;
      dm_config->b_info.extra_hvm = guest_config->b_info.extra_hvm;
@@ -67,7 +67,7 @@ PATCHES
  
      dm_config->disks = guest_config->disks;
      dm_config->num_disks = guest_config->num_disks;
-@@ -1947,6 +1949,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1931,6 +1933,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
       */
      if (guest_config->b_info.stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {
          int dmargs_size = 0;
@@ -75,7 +75,7 @@ PATCHES
          char *dmargs;
          char **arg;
  
-@@ -1955,10 +1958,15 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1939,10 +1942,15 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          arg++;
          for (; *arg; arg++)
              dmargs_size = dmargs_size + strlen(*arg) + 1;
@@ -91,7 +91,7 @@ PATCHES
          arg = args;
          arg++;
          if (arg) {
-@@ -1969,6 +1977,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1953,6 +1961,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
              strcat(dmargs, " ");
              strcat(dmargs, *arg);
          }

--- a/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
+++ b/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
@@ -31,7 +31,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -842,12 +842,13 @@ static char *qemu_disk_ide_drive_string(
+@@ -826,12 +826,13 @@ static char *qemu_disk_ide_drive_string(
      const char *exportname = disk->colo_export;
      const char *active_disk = disk->active_disk;
      const char *hidden_disk = disk->hidden_disk;
@@ -47,7 +47,7 @@ PATCHES
          break;
      case LIBXL__COLO_PRIMARY:
          /*
-@@ -860,13 +861,13 @@ static char *qemu_disk_ide_drive_string(
+@@ -844,13 +845,13 @@ static char *qemu_disk_ide_drive_string(
           *  vote-threshold=1
           */
          drive = GCSPRINTF(
@@ -63,7 +63,7 @@ PATCHES
          break;
      case LIBXL__COLO_SECONDARY:
          /*
-@@ -880,7 +881,7 @@ static char *qemu_disk_ide_drive_string(
+@@ -864,7 +865,7 @@ static char *qemu_disk_ide_drive_string(
           *  file.backing.backing=exportname,
           */
          drive = GCSPRINTF(
@@ -72,7 +72,7 @@ PATCHES
              "driver=replication,"
              "mode=secondary,"
              "top-id=top-colo,"
-@@ -889,7 +890,7 @@ static char *qemu_disk_ide_drive_string(
+@@ -873,7 +874,7 @@ static char *qemu_disk_ide_drive_string(
              "file.backing.driver=qcow2,"
              "file.backing.file.filename=%s,"
              "file.backing.backing=%s",
@@ -81,7 +81,7 @@ PATCHES
          break;
      default:
           abort();
-@@ -1577,11 +1578,6 @@ static int libxl__build_device_model_arg
+@@ -1561,11 +1562,6 @@ static int libxl__build_device_model_arg
                          disk, disk), NULL);
                      continue;
                  } else if (disk < 4) {

--- a/recipes-extended/xen/files/libxl-syslog.patch
+++ b/recipes-extended/xen/files/libxl-syslog.patch
@@ -67,7 +67,7 @@ PATCHES
  const char *libxl__domain_device_model(libxl__gc *gc,
                                         const libxl_domain_build_info *info)
  {
-@@ -2147,11 +2126,10 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2134,11 +2113,10 @@ void libxl__spawn_local_dm(libxl__egc *e
  
      libxl_ctx *ctx = CTX;
      libxl_domain_config *guest_config = dmss->guest_config;
@@ -80,7 +80,7 @@ PATCHES
      int rc;
      char **args, **arg, **envs;
      xs_transaction_t t;
-@@ -2205,12 +2183,6 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2192,12 +2170,6 @@ void libxl__spawn_local_dm(libxl__egc *e
          libxl__xs_printf(gc, XBT_NULL, GCSPRINTF("%s/disable_pf", path),
                           "%d", !libxl_defbool_val(b_info->u.hvm.xen_platform_pci));
  
@@ -93,7 +93,7 @@ PATCHES
      null = open("/dev/null", O_RDONLY);
      if (null < 0) {
          LOGED(ERROR, domid, "unable to open /dev/null");
-@@ -2264,14 +2236,13 @@ retry_transaction:
+@@ -2251,14 +2223,13 @@ retry_transaction:
          goto out_close;
      if (!rc) { /* inner child */
          setsid();
@@ -109,7 +109,7 @@ PATCHES
  out:
      if (dm_state_fd >= 0) close(dm_state_fd);
      if (rc)
-@@ -2360,7 +2331,7 @@ void libxl__spawn_qdisk_backend(libxl__e
+@@ -2347,7 +2318,7 @@ void libxl__spawn_qdisk_backend(libxl__e
      flexarray_t *dm_args, *dm_envs;
      char **args, **envs;
      const char *dm;
@@ -118,7 +118,7 @@ PATCHES
      uint32_t domid = dmss->guest_domid;
  
      /* Always use qemu-xen as device model */
-@@ -2385,11 +2356,6 @@ void libxl__spawn_qdisk_backend(libxl__e
+@@ -2372,11 +2343,6 @@ void libxl__spawn_qdisk_backend(libxl__e
      libxl__set_qemu_env_for_xsa_180(gc, dm_envs);
      envs = (char **) flexarray_contents(dm_envs);
  
@@ -130,7 +130,7 @@ PATCHES
      null = open("/dev/null", O_RDONLY);
      if (null < 0) {
         rc = ERROR_FAIL;
-@@ -2422,12 +2388,11 @@ void libxl__spawn_qdisk_backend(libxl__e
+@@ -2409,12 +2375,11 @@ void libxl__spawn_qdisk_backend(libxl__e
          goto out;
      if (!rc) { /* inner child */
          setsid();

--- a/recipes-extended/xen/files/libxl-vif-cleanup.patch
+++ b/recipes-extended/xen/files/libxl-vif-cleanup.patch
@@ -30,7 +30,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
-@@ -737,6 +737,10 @@ int libxl__device_destroy(libxl__gc *gc,
+@@ -752,6 +752,10 @@ int libxl__device_destroy(libxl__gc *gc,
              libxl__xs_path_cleanup(gc, t, be_path);
          }
  
@@ -41,7 +41,7 @@ PATCHES
          rc = libxl__xs_transaction_commit(gc, &t);
          if (!rc) break;
          if (rc < 0) goto out;
-@@ -1268,7 +1272,12 @@ static void device_destroy_be_watch_cb(l
+@@ -1283,7 +1287,12 @@ static void device_destroy_be_watch_cb(l
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-vif-make-ioemu-and-stubdom-mac-addresses-configurable.patch
+++ b/recipes-extended/xen/files/libxl-vif-make-ioemu-and-stubdom-mac-addresses-configurable.patch
@@ -59,7 +59,7 @@ PATCHES
                  const char *ifname = libxl__device_nic_devname(gc,
                                                  domid, nics[i].devid,
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
-@@ -1215,8 +1218,11 @@ static int libxl__build_device_model_arg
+@@ -1200,8 +1203,11 @@ static int libxl__build_device_model_arg
          }
          for (i = 0; i < num_nics; i++) {
              if (nics[i].nictype == LIBXL_NIC_TYPE_VIF_IOEMU) {
@@ -73,7 +73,7 @@ PATCHES
                  const char *ifname = libxl__device_nic_devname(gc,
                                                  guest_domid, nics[i].devid,
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
-@@ -1706,6 +1712,10 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1691,6 +1697,10 @@ static void libxl__dm_vifs_from_hvm_gues
          if (dm_config->nics[i].ifname)
              dm_config->nics[i].ifname = GCSPRINTF("%s" TAP_DEVICE_SUFFIX,
                                                    dm_config->nics[i].ifname);
@@ -97,7 +97,7 @@ PATCHES
              !(*mac)[3] && !(*mac)[4] && !(*mac)[5]);
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1787,7 +1787,7 @@ _hidden int libxl__parse_mac(const char
+@@ -1788,7 +1788,7 @@ _hidden int libxl__parse_mac(const char
  /* compare mac address @a and @b. 0 if the same, -ve if a<b and +ve if a>b */
  _hidden int libxl__compare_macs(libxl_mac *a, libxl_mac *b);
  /* return true if mac address is all zero (the default value) */

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -30,7 +30,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
-@@ -737,7 +737,8 @@ int libxl__device_destroy(libxl__gc *gc,
+@@ -753,7 +753,8 @@ int libxl__device_destroy(libxl__gc *gc,
              libxl__xs_path_cleanup(gc, t, be_path);
          }
  
@@ -40,7 +40,7 @@ PATCHES
              libxl__xs_path_cleanup(gc, t, be_path);
          }
  
-@@ -1277,7 +1278,9 @@ static void device_destroy_be_watch_cb(l
+@@ -1293,7 +1294,9 @@ static void device_destroy_be_watch_cb(l
       * in xenstore. NDVM doesn't do that, so let's not wait forever
       * here. libxl will take care of the xenstore nodes later
       */
@@ -51,7 +51,7 @@ PATCHES
          /* backend path still exists, wait a little longer... */
          return;
      }
-@@ -1409,6 +1412,15 @@ int libxl__device_nextid(libxl__gc *gc,
+@@ -1425,6 +1428,15 @@ int libxl__device_nextid(libxl__gc *gc,
      else
          nextid = strtoul(l[nb - 1], NULL, 10) + 1;
  
@@ -67,7 +67,7 @@ PATCHES
      return nextid;
  }
  
-@@ -1547,9 +1559,11 @@ static int add_device(libxl__egc *egc, l
+@@ -1563,9 +1575,11 @@ static int add_device(libxl__egc *egc, l
  
      switch(dev->backend_kind) {
      case LIBXL__DEVICE_KIND_VBD:
@@ -81,7 +81,7 @@ PATCHES
  
          GCNEW(aodev);
          libxl__prepare_ao_device(ao, aodev);
-@@ -1595,9 +1609,11 @@ static int remove_device(libxl__egc *egc
+@@ -1611,9 +1625,11 @@ static int remove_device(libxl__egc *egc
  
      switch(ddev->dev->backend_kind) {
      case LIBXL__DEVICE_KIND_VBD:
@@ -97,7 +97,7 @@ PATCHES
          libxl__prepare_ao_device(ao, aodev);
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1230,9 +1230,12 @@ static int libxl__build_device_model_arg
+@@ -1214,9 +1214,12 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
                  flexarray_append(dm_args,
@@ -113,7 +113,7 @@ PATCHES
                  flexarray_append(dm_args, "-netdev");
                  flexarray_append(dm_args,
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
-@@ -1703,6 +1706,8 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1687,6 +1690,8 @@ static void libxl__dm_vifs_from_hvm_gues
          libxl_device_nic_init(&dm_config->nics[i]);
          libxl_device_nic_copy(ctx, &dm_config->nics[i], &guest_config->nics[i]);
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -191,7 +191,7 @@ PATCHES
      switch (b_info->type) {
      case LIBXL_DOMAIN_TYPE_PV:
          flexarray_append(dm_args, "xenpv");
-@@ -1775,7 +1775,7 @@ static int libxl__write_stub_dmargs(libx
+@@ -1759,7 +1759,7 @@ static int libxl__write_stub_dmargs(libx
      while (args[i] != NULL) {
          if (linux_stubdom ||
              (strcmp(args[i], "-sdl") &&
@@ -200,7 +200,7 @@ PATCHES
              strcat(dmargs, " ");
              strcat(dmargs, args[i]);
          }
-@@ -1979,9 +1979,26 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1963,9 +1963,26 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                               &stubdom_state->config);
      if (ret)
          goto out;
@@ -228,7 +228,7 @@ PATCHES
      /* OpenXT: Start the QMP helper */
      pid = fork();
      if (pid == -1)
-@@ -2026,10 +2043,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2010,10 +2027,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      libxl__write_stub_dmargs(gc, dm_domid, guest_domid, args,
           guest_config->b_info.stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX);
      libxl__xs_printf(gc, XBT_NULL,
@@ -275,7 +275,7 @@ PATCHES
                  } else {                /* not found in xenstore */
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -1820,6 +1820,8 @@ _hidden int libxl__qmp_pci_del(libxl__gc
+@@ -1821,6 +1821,8 @@ _hidden int libxl__qmp_pci_del(libxl__gc
                                 libxl_device_pci *pcidev);
  /* Resume hvm domain */
  _hidden int libxl__qmp_system_wakeup(libxl__gc *gc, int domid);

--- a/recipes-extended/xen/files/openxt-xci-cpuid-signature.patch
+++ b/recipes-extended/xen/files/openxt-xci-cpuid-signature.patch
@@ -54,7 +54,7 @@ PATCHES
      cpuid(base + 2, &eax, &ebx, &ecx, &edx);
 --- a/xen/arch/x86/hvm/hvm.c
 +++ b/xen/arch/x86/hvm/hvm.c
-@@ -4152,6 +4152,10 @@ static int hvmop_set_param(
+@@ -4151,6 +4151,10 @@ static int hvmop_set_param(
               !(a.value & HVMPV_base_freq) )
              rc = -EINVAL;
          break;

--- a/recipes-extended/xen/files/openxt-xen-xsmv4vuse.patch
+++ b/recipes-extended/xen/files/openxt-xen-xsmv4vuse.patch
@@ -46,7 +46,7 @@ PATCHES
 ################################################################################
 --- a/xen/common/v4v.c
 +++ b/xen/common/v4v.c
-@@ -1765,7 +1765,7 @@ v4v_send (struct domain *src_d, v4v_addr
+@@ -1749,7 +1749,7 @@ v4v_send (struct domain *src_d, v4v_addr
      }
  
    /* XSM: verify if src is allowed to send to dst */
@@ -55,7 +55,7 @@ PATCHES
      {
        printk(KERN_ERR "V4V: XSM REJECTED %i -> %i\n",
               src_addr->domain, dst_addr->domain);
-@@ -1876,7 +1876,7 @@ v4v_sendv (struct domain *src_d, v4v_add
+@@ -1860,7 +1860,7 @@ v4v_sendv (struct domain *src_d, v4v_add
      }
  
    /* XSM: verify if src is allowed to send to dst */
@@ -64,7 +64,7 @@ PATCHES
      {
        printk(KERN_ERR "V4V: XSM REJECTED %i -> %i\n",
               src_addr->domain, dst_addr->domain);
-@@ -1956,7 +1956,11 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
+@@ -1940,7 +1940,11 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
             XEN_GUEST_HANDLE (void) arg3, uint32_t arg4, uint32_t arg5)
  {
    struct domain *d = current->domain;
@@ -77,7 +77,7 @@ PATCHES
  
  #ifdef V4V_DEBUG
  
-@@ -1967,6 +1971,8 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
+@@ -1951,6 +1955,8 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
  #endif
  
    domain_lock (d);

--- a/recipes-extended/xen/files/parse-video-from-mbi.patch
+++ b/recipes-extended/xen/files/parse-video-from-mbi.patch
@@ -52,7 +52,7 @@ PATCHES
  cpumask_t __read_mostly cpu_present_map;
  
  unsigned long __read_mostly xen_phys_start;
-@@ -472,7 +475,7 @@ struct boot_video_info {
+@@ -475,7 +478,7 @@ struct boot_video_info {
  };
  extern struct boot_video_info boot_vid_info;
  
@@ -61,7 +61,7 @@ PATCHES
  {
      struct boot_video_info *bvi = &bootsym(boot_vid_info);
  
-@@ -480,6 +483,30 @@ static void __init parse_video_info(void
+@@ -483,6 +486,30 @@ static void __init parse_video_info(void
      if ( efi_enabled(EFI_BOOT) )
          return;
  
@@ -92,7 +92,7 @@ PATCHES
      if ( (bvi->orig_video_isVGA == 1) && (bvi->orig_video_mode == 3) )
      {
          vga_console_info.video_type = XEN_VGATYPE_TEXT_MODE_3;
-@@ -691,7 +718,7 @@ void __init noreturn __start_xen(unsigne
+@@ -694,7 +721,7 @@ void __init noreturn __start_xen(unsigne
       * allocing any xenheap structures wanted in lower memory. */
      kexec_early_calculations();
  

--- a/recipes-extended/xen/files/shim-support-for-shim-lock-measure.patch
+++ b/recipes-extended/xen/files/shim-support-for-shim-lock-measure.patch
@@ -10,8 +10,6 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  xen/common/efi/boot.c | 75 +++++++++++++++++++++++++++++++++++++++++++++++----
  1 file changed, 70 insertions(+), 5 deletions(-)
 
-diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
-index 0772ba1c93..6a0951568c 100644
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
 @@ -46,8 +46,17 @@ typedef EFI_STATUS
@@ -32,7 +30,7 @@ index 0772ba1c93..6a0951568c 100644
  } EFI_SHIM_LOCK_PROTOCOL;
  
  struct _EFI_APPLE_PROPERTIES;
-@@ -1095,6 +1104,32 @@ static int __init __maybe_unused set_color(u32 mask, int bpp, u8 *pos, u8 *sz)
+@@ -1095,6 +1104,32 @@ static int __init __maybe_unused set_col
     return max(*pos + *sz, bpp);
  }
  
@@ -65,7 +63,7 @@ index 0772ba1c93..6a0951568c 100644
  void EFIAPI __init noreturn
  efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
  {
-@@ -1105,7 +1140,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+@@ -1105,7 +1140,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      unsigned int i, argc;
      CHAR16 **argv, *file_name, *cfg_file_name = L"openxt.cfg", *options = NULL;
      UINTN gop_mode = ~0;
@@ -74,7 +72,7 @@ index 0772ba1c93..6a0951568c 100644
      EFI_GRAPHICS_OUTPUT_PROTOCOL *gop = NULL;
      union string section = { NULL }, name;
      bool_t base_video = 0;
-@@ -1225,6 +1260,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+@@ -1225,6 +1260,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          }
          else if ( !read_file(dir_handle, cfg_file_name, &cfg, NULL) )
              blexit(L"Configuration file not found.");
@@ -88,7 +86,7 @@ index 0772ba1c93..6a0951568c 100644
          pre_parse(&cfg);
  
          if ( section.w )
-@@ -1262,16 +1304,34 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+@@ -1262,16 +1304,34 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          read_file(dir_handle, s2w(&name), &kernel, option_str);
          efi_bs->FreePool(name.w);
  
@@ -127,7 +125,7 @@ index 0772ba1c93..6a0951568c 100644
          }
  
          name.s = get_value(&cfg, section.s, "xsm");
-@@ -1279,6 +1339,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+@@ -1279,6 +1339,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          {
              read_file(dir_handle, s2w(&name), &xsm, NULL);
              efi_bs->FreePool(name.w);
@@ -139,6 +137,3 @@ index 0772ba1c93..6a0951568c 100644
          }
  
          name.s = get_value(&cfg, section.s, "options");
--- 
-2.11.0
-

--- a/recipes-extended/xen/files/smbios.patch
+++ b/recipes-extended/xen/files/smbios.patch
@@ -178,7 +178,7 @@ PATCHES
 +
 +    start += sizeof(struct smbios_type_7);
 +
-+    strcpy((char *)start, "Internal Cache"); 
++    strcpy((char *)start, "Internal Cache");
 +    start += strlen("Internal Cache") + 1;
 +
 +    *((uint8_t *)start) = 0;

--- a/recipes-extended/xen/files/v4v-viptables.patch
+++ b/recipes-extended/xen/files/v4v-viptables.patch
@@ -39,7 +39,7 @@ PATCHES
  
  /*Debugs*/
  
-@@ -1402,6 +1403,216 @@ v4v_ring_add (struct domain *d, XEN_GUES
+@@ -1386,6 +1387,216 @@ v4v_ring_add (struct domain *d, XEN_GUES
    return ret;
  }
  
@@ -256,7 +256,7 @@ PATCHES
  
  /**************************** io ***************************/
  
-@@ -1561,6 +1772,15 @@ v4v_send (struct domain *src_d, v4v_addr
+@@ -1545,6 +1756,15 @@ v4v_send (struct domain *src_d, v4v_addr
        ret = -EPERM;
        goto out;
      }
@@ -272,7 +272,7 @@ PATCHES
  
    do
      {
-@@ -1663,6 +1883,15 @@ v4v_sendv (struct domain *src_d, v4v_add
+@@ -1647,6 +1867,15 @@ v4v_sendv (struct domain *src_d, v4v_add
        ret = -ENOTCONN;
        goto out;
      }
@@ -288,7 +288,7 @@ PATCHES
  
    do
      {
-@@ -1820,6 +2049,38 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
+@@ -1804,6 +2033,38 @@ do_v4v_op (int cmd, XEN_GUEST_HANDLE (vo
          rc = v4v_notify (d, ring_data_hnd);
          break;
        }

--- a/recipes-extended/xen/files/xsa263-4.9/0001-x86-spec_ctrl-Read-MSR_ARCH_CAPABILITIES-only-once.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0001-x86-spec_ctrl-Read-MSR_ARCH_CAPABILITIES-only-once.patch
@@ -1,0 +1,105 @@
+From 79570591b03f3a52ed7c7d923dc943a6b9912f63 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 26 Apr 2018 12:21:00 +0100
+Subject: [PATCH] x86/spec_ctrl: Read MSR_ARCH_CAPABILITIES only once
+
+Make it available from the beginning of init_speculation_mitigations(), and
+pass it into appropriate functions.  Fix an RSBA typo while moving the
+affected comment.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit d6c65187252a6c1810fd24c4d46f812840de8d3c)
+---
+ xen/arch/x86/spec_ctrl.c | 34 ++++++++++++++--------------------
+ 1 file changed, 14 insertions(+), 20 deletions(-)
+
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -81,18 +81,15 @@ static int __init parse_bti(const char *
+ }
+ custom_param("bti", parse_bti);
+ 
+-static void __init print_details(enum ind_thunk thunk)
++static void __init print_details(enum ind_thunk thunk, uint64_t caps)
+ {
+     unsigned int _7d0 = 0, e8b = 0, tmp;
+-    uint64_t caps = 0;
+ 
+     /* Collect diagnostics about available mitigations. */
+     if ( boot_cpu_data.cpuid_level >= 7 )
+         cpuid_count(7, 0, &tmp, &tmp, &tmp, &_7d0);
+     if ( boot_cpu_data.extended_cpuid_level >= 0x80000008 )
+         cpuid(0x80000008, &tmp, &e8b, &tmp, &tmp);
+-    if ( _7d0 & cpufeat_mask(X86_FEATURE_ARCH_CAPS) )
+-        rdmsrl(MSR_ARCH_CAPABILITIES, caps);
+ 
+     printk(XENLOG_DEBUG "Speculative mitigation facilities:\n");
+ 
+@@ -125,7 +122,7 @@ static void __init print_details(enum in
+ }
+ 
+ /* Calculate whether Retpoline is known-safe on this CPU. */
+-static bool __init retpoline_safe(void)
++static bool __init retpoline_safe(uint64_t caps)
+ {
+     unsigned int ucode_rev = this_cpu(ucode_cpu_info).cpu_sig.rev;
+ 
+@@ -136,19 +133,12 @@ static bool __init retpoline_safe(void)
+          boot_cpu_data.x86 != 6 )
+         return false;
+ 
+-    if ( boot_cpu_has(X86_FEATURE_ARCH_CAPS) )
+-    {
+-        uint64_t caps;
+-
+-        rdmsrl(MSR_ARCH_CAPABILITIES, caps);
+-
+-        /*
+-         * RBSA may be set by a hypervisor to indicate that we may move to a
+-         * processor which isn't retpoline-safe.
+-         */
+-        if ( caps & ARCH_CAPS_RSBA )
+-            return false;
+-    }
++    /*
++     * RSBA may be set by a hypervisor to indicate that we may move to a
++     * processor which isn't retpoline-safe.
++     */
++    if ( caps & ARCH_CAPS_RSBA )
++        return false;
+ 
+     switch ( boot_cpu_data.x86_model )
+     {
+@@ -218,6 +208,10 @@ void __init init_speculation_mitigations
+ {
+     enum ind_thunk thunk = THUNK_DEFAULT;
+     bool ibrs = false;
++    uint64_t caps = 0;
++
++    if ( boot_cpu_has(X86_FEATURE_ARCH_CAPS) )
++        rdmsrl(MSR_ARCH_CAPABILITIES, caps);
+ 
+     /*
+      * Has the user specified any custom BTI mitigations?  If so, follow their
+@@ -246,7 +240,7 @@ void __init init_speculation_mitigations
+              * On Intel hardware, we'd like to use retpoline in preference to
+              * IBRS, but only if it is safe on this hardware.
+              */
+-            else if ( retpoline_safe() )
++            else if ( retpoline_safe(caps) )
+                 thunk = THUNK_RETPOLINE;
+             else if ( boot_cpu_has(X86_FEATURE_IBRSB) )
+                 ibrs = true;
+@@ -331,7 +325,7 @@ void __init init_speculation_mitigations
+     /* (Re)init BSP state now that default_bti_ist_info has been calculated. */
+     init_shadow_spec_ctrl_state();
+ 
+-    print_details(thunk);
++    print_details(thunk, caps);
+ }
+ 
+ static void __init __maybe_unused build_assertions(void)

--- a/recipes-extended/xen/files/xsa263-4.9/0002-x86-spec_ctrl-Express-Xen-s-choice-of-MSR_SPEC_CTRL-.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0002-x86-spec_ctrl-Express-Xen-s-choice-of-MSR_SPEC_CTRL-.patch
@@ -1,0 +1,125 @@
+From c7bf6074ea8c3496894d517371ea6d9d3bd90c98 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 17 Apr 2018 14:15:04 +0100
+Subject: [PATCH] x86/spec_ctrl: Express Xen's choice of MSR_SPEC_CTRL value as
+ a variable
+
+At the moment, we have two different encodings of Xen's MSR_SPEC_CTRL value,
+which is a side effect of how the Spectre series developed.  One encoding is
+via an alias with the bottom bit of bti_ist_info, and can encode IBRS or not,
+but not other configurations such as STIBP.
+
+Break Xen's value out into a separate variable (in the top of stack block for
+XPTI reasons) and use this instead of bti_ist_info in the IST path.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit 66dfae0f32bfbc899c2f3446d5ee57068cb7f957)
+---
+ xen/arch/x86/spec_ctrl.c            | 8 +++++---
+ xen/arch/x86/x86_64/asm-offsets.c   | 1 +
+ xen/include/asm-x86/current.h       | 1 +
+ xen/include/asm-x86/spec_ctrl.h     | 2 ++
+ xen/include/asm-x86/spec_ctrl_asm.h | 8 ++------
+ 5 files changed, 11 insertions(+), 9 deletions(-)
+
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -38,6 +38,7 @@ static int8_t __initdata opt_ibrs = -1;
+ static bool __initdata opt_rsb_native = true;
+ static bool __initdata opt_rsb_vmexit = true;
+ bool __read_mostly opt_ibpb = true;
++uint8_t __read_mostly default_xen_spec_ctrl;
+ uint8_t __read_mostly default_bti_ist_info;
+ 
+ static int __init parse_bti(const char *s)
+@@ -285,11 +286,14 @@ void __init init_speculation_mitigations
+          * guests.
+          */
+         if ( ibrs )
++        {
++            default_xen_spec_ctrl |= SPEC_CTRL_IBRS;
+             setup_force_cpu_cap(X86_FEATURE_XEN_IBRS_SET);
++        }
+         else
+             setup_force_cpu_cap(X86_FEATURE_XEN_IBRS_CLEAR);
+ 
+-        default_bti_ist_info |= BTI_IST_WRMSR | ibrs;
++        default_bti_ist_info |= BTI_IST_WRMSR;
+     }
+ 
+     /*
+@@ -330,8 +334,6 @@ void __init init_speculation_mitigations
+ 
+ static void __init __maybe_unused build_assertions(void)
+ {
+-    /* The optimised assembly relies on this alias. */
+-    BUILD_BUG_ON(BTI_IST_IBRS != SPEC_CTRL_IBRS);
+ }
+ 
+ /*
+--- a/xen/arch/x86/x86_64/asm-offsets.c
++++ b/xen/arch/x86/x86_64/asm-offsets.c
+@@ -142,6 +142,7 @@ void __dummy__(void)
+     OFFSET(CPUINFO_xen_cr3, struct cpu_info, xen_cr3);
+     OFFSET(CPUINFO_pv_cr3, struct cpu_info, pv_cr3);
+     OFFSET(CPUINFO_shadow_spec_ctrl, struct cpu_info, shadow_spec_ctrl);
++    OFFSET(CPUINFO_xen_spec_ctrl, struct cpu_info, xen_spec_ctrl);
+     OFFSET(CPUINFO_use_shadow_spec_ctrl, struct cpu_info, use_shadow_spec_ctrl);
+     OFFSET(CPUINFO_bti_ist_info, struct cpu_info, bti_ist_info);
+     DEFINE(CPUINFO_sizeof, sizeof(struct cpu_info));
+--- a/xen/include/asm-x86/current.h
++++ b/xen/include/asm-x86/current.h
+@@ -56,6 +56,7 @@ struct cpu_info {
+ 
+     /* See asm-x86/spec_ctrl_asm.h for usage. */
+     unsigned int shadow_spec_ctrl;
++    uint8_t      xen_spec_ctrl;
+     bool         use_shadow_spec_ctrl;
+     uint8_t      bti_ist_info;
+ 
+--- a/xen/include/asm-x86/spec_ctrl.h
++++ b/xen/include/asm-x86/spec_ctrl.h
+@@ -27,6 +27,7 @@
+ void init_speculation_mitigations(void);
+ 
+ extern bool opt_ibpb;
++extern uint8_t default_xen_spec_ctrl;
+ extern uint8_t default_bti_ist_info;
+ 
+ static inline void init_shadow_spec_ctrl_state(void)
+@@ -34,6 +35,7 @@ static inline void init_shadow_spec_ctrl
+     struct cpu_info *info = get_cpu_info();
+ 
+     info->shadow_spec_ctrl = info->use_shadow_spec_ctrl = 0;
++    info->xen_spec_ctrl = default_xen_spec_ctrl;
+     info->bti_ist_info = default_bti_ist_info;
+ }
+ 
+--- a/xen/include/asm-x86/spec_ctrl_asm.h
++++ b/xen/include/asm-x86/spec_ctrl_asm.h
+@@ -21,7 +21,6 @@
+ #define __X86_SPEC_CTRL_ASM_H__
+ 
+ /* Encoding of the bottom bits in cpuinfo.bti_ist_info */
+-#define BTI_IST_IBRS  (1 << 0)
+ #define BTI_IST_WRMSR (1 << 1)
+ #define BTI_IST_RSB   (1 << 2)
+ 
+@@ -285,12 +284,9 @@
+     setz %dl
+     and %dl, STACK_CPUINFO_FIELD(use_shadow_spec_ctrl)(%r14)
+ 
+-    /*
+-     * Load Xen's intended value.  SPEC_CTRL_IBRS vs 0 is encoded in the
+-     * bottom bit of bti_ist_info, via a deliberate alias with BTI_IST_IBRS.
+-     */
++    /* Load Xen's intended value. */
+     mov $MSR_SPEC_CTRL, %ecx
+-    and $BTI_IST_IBRS, %eax
++    movzbl STACK_CPUINFO_FIELD(xen_spec_ctrl)(%r14), %eax
+     xor %edx, %edx
+     wrmsr
+ 

--- a/recipes-extended/xen/files/xsa263-4.9/0003-x86-spec_ctrl-Merge-bti_ist_info-and-use_shadow_spec.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0003-x86-spec_ctrl-Merge-bti_ist_info-and-use_shadow_spec.patch
@@ -1,0 +1,323 @@
+From e57b5ea6fa2b2d93fde033cec11d6ec6d524ade3 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 17 Apr 2018 14:15:04 +0100
+Subject: [PATCH] x86/spec_ctrl: Merge bti_ist_info and use_shadow_spec_ctrl
+ into spec_ctrl_flags
+
+All 3 bits of information here are control flags for the entry/exit code
+behaviour.  Treat them as such, rather than having two different variables.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit 5262ba2e7799001402dfe139ff944e035dfff928)
+---
+ xen/arch/x86/acpi/power.c           |  4 +--
+ xen/arch/x86/spec_ctrl.c            | 10 ++++---
+ xen/arch/x86/x86_64/asm-offsets.c   |  3 +--
+ xen/include/asm-x86/current.h       |  3 +--
+ xen/include/asm-x86/nops.h          |  5 ++--
+ xen/include/asm-x86/spec_ctrl.h     | 10 +++----
+ xen/include/asm-x86/spec_ctrl_asm.h | 52 ++++++++++++++++++++-----------------
+ 7 files changed, 45 insertions(+), 42 deletions(-)
+
+--- a/xen/arch/x86/acpi/power.c
++++ b/xen/arch/x86/acpi/power.c
+@@ -215,7 +215,7 @@ static int enter_state(u32 state)
+     ci = get_cpu_info();
+     spec_ctrl_enter_idle(ci);
+     /* Avoid NMI/#MC using MSR_SPEC_CTRL until we've reloaded microcode. */
+-    ci->bti_ist_info = 0;
++    ci->spec_ctrl_flags &= ~SCF_ist_wrmsr;
+ 
+     ACPI_FLUSH_CPU_CACHE();
+ 
+@@ -256,7 +256,7 @@ static int enter_state(u32 state)
+     microcode_resume_cpu(0);
+ 
+     /* Re-enabled default NMI/#MC use of MSR_SPEC_CTRL. */
+-    ci->bti_ist_info = default_bti_ist_info;
++    ci->spec_ctrl_flags |= (default_spec_ctrl_flags & SCF_ist_wrmsr);
+     spec_ctrl_exit_idle(ci);
+ 
+  done:
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -39,7 +39,7 @@ static bool __initdata opt_rsb_native =
+ static bool __initdata opt_rsb_vmexit = true;
+ bool __read_mostly opt_ibpb = true;
+ uint8_t __read_mostly default_xen_spec_ctrl;
+-uint8_t __read_mostly default_bti_ist_info;
++uint8_t __read_mostly default_spec_ctrl_flags;
+ 
+ static int __init parse_bti(const char *s)
+ {
+@@ -293,7 +293,7 @@ void __init init_speculation_mitigations
+         else
+             setup_force_cpu_cap(X86_FEATURE_XEN_IBRS_CLEAR);
+ 
+-        default_bti_ist_info |= BTI_IST_WRMSR;
++        default_spec_ctrl_flags |= SCF_ist_wrmsr;
+     }
+ 
+     /*
+@@ -312,7 +312,7 @@ void __init init_speculation_mitigations
+     if ( opt_rsb_native )
+     {
+         setup_force_cpu_cap(X86_FEATURE_RSB_NATIVE);
+-        default_bti_ist_info |= BTI_IST_RSB;
++        default_spec_ctrl_flags |= SCF_ist_rsb;
+     }
+ 
+     /*
+@@ -326,7 +326,7 @@ void __init init_speculation_mitigations
+     if ( !boot_cpu_has(X86_FEATURE_IBRSB) && !boot_cpu_has(X86_FEATURE_IBPB) )
+         opt_ibpb = false;
+ 
+-    /* (Re)init BSP state now that default_bti_ist_info has been calculated. */
++    /* (Re)init BSP state now that default_spec_ctrl_flags has been calculated. */
+     init_shadow_spec_ctrl_state();
+ 
+     print_details(thunk, caps);
+@@ -334,6 +334,8 @@ void __init init_speculation_mitigations
+ 
+ static void __init __maybe_unused build_assertions(void)
+ {
++    /* The optimised assembly relies on this alias. */
++    BUILD_BUG_ON(SCF_use_shadow != 1);
+ }
+ 
+ /*
+--- a/xen/arch/x86/x86_64/asm-offsets.c
++++ b/xen/arch/x86/x86_64/asm-offsets.c
+@@ -143,8 +143,7 @@ void __dummy__(void)
+     OFFSET(CPUINFO_pv_cr3, struct cpu_info, pv_cr3);
+     OFFSET(CPUINFO_shadow_spec_ctrl, struct cpu_info, shadow_spec_ctrl);
+     OFFSET(CPUINFO_xen_spec_ctrl, struct cpu_info, xen_spec_ctrl);
+-    OFFSET(CPUINFO_use_shadow_spec_ctrl, struct cpu_info, use_shadow_spec_ctrl);
+-    OFFSET(CPUINFO_bti_ist_info, struct cpu_info, bti_ist_info);
++    OFFSET(CPUINFO_spec_ctrl_flags, struct cpu_info, spec_ctrl_flags);
+     DEFINE(CPUINFO_sizeof, sizeof(struct cpu_info));
+     BLANK();
+ 
+--- a/xen/include/asm-x86/current.h
++++ b/xen/include/asm-x86/current.h
+@@ -57,8 +57,7 @@ struct cpu_info {
+     /* See asm-x86/spec_ctrl_asm.h for usage. */
+     unsigned int shadow_spec_ctrl;
+     uint8_t      xen_spec_ctrl;
+-    bool         use_shadow_spec_ctrl;
+-    uint8_t      bti_ist_info;
++    uint8_t      spec_ctrl_flags;
+ 
+     unsigned long __pad;
+     /* get_stack_bottom() must be 16-byte aligned */
+--- a/xen/include/asm-x86/nops.h
++++ b/xen/include/asm-x86/nops.h
+@@ -62,10 +62,9 @@
+ #define ASM_NOP8 _ASM_MK_NOP(K8_NOP8)
+ 
+ #define ASM_NOP17 ASM_NOP8; ASM_NOP7; ASM_NOP2
+-#define ASM_NOP21 ASM_NOP8; ASM_NOP8; ASM_NOP5
++#define ASM_NOP22 ASM_NOP8; ASM_NOP8; ASM_NOP6
+ #define ASM_NOP24 ASM_NOP8; ASM_NOP8; ASM_NOP8
+-#define ASM_NOP29 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP5
+-#define ASM_NOP32 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP8
++#define ASM_NOP33 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP7; ASM_NOP2
+ #define ASM_NOP40 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP8
+ 
+ #define ASM_NOP_MAX 8
+--- a/xen/include/asm-x86/spec_ctrl.h
++++ b/xen/include/asm-x86/spec_ctrl.h
+@@ -28,15 +28,15 @@ void init_speculation_mitigations(void);
+ 
+ extern bool opt_ibpb;
+ extern uint8_t default_xen_spec_ctrl;
+-extern uint8_t default_bti_ist_info;
++extern uint8_t default_spec_ctrl_flags;
+ 
+ static inline void init_shadow_spec_ctrl_state(void)
+ {
+     struct cpu_info *info = get_cpu_info();
+ 
+-    info->shadow_spec_ctrl = info->use_shadow_spec_ctrl = 0;
++    info->shadow_spec_ctrl = 0;
+     info->xen_spec_ctrl = default_xen_spec_ctrl;
+-    info->bti_ist_info = default_bti_ist_info;
++    info->spec_ctrl_flags = default_spec_ctrl_flags;
+ }
+ 
+ /* WARNING! `ret`, `call *`, `jmp *` not safe after this call. */
+@@ -50,7 +50,7 @@ static always_inline void spec_ctrl_ente
+      */
+     info->shadow_spec_ctrl = val;
+     barrier();
+-    info->use_shadow_spec_ctrl = true;
++    info->spec_ctrl_flags |= SCF_use_shadow;
+     barrier();
+     asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_XEN_IBRS_SET)
+                    :: "a" (val), "c" (MSR_SPEC_CTRL), "d" (0) : "memory" );
+@@ -65,7 +65,7 @@ static always_inline void spec_ctrl_exit
+      * Disable shadowing before updating the MSR.  There are no SMP issues
+      * here; only local processor ordering concerns.
+      */
+-    info->use_shadow_spec_ctrl = false;
++    info->spec_ctrl_flags &= ~SCF_use_shadow;
+     barrier();
+     asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_XEN_IBRS_SET)
+                    :: "a" (val), "c" (MSR_SPEC_CTRL), "d" (0) : "memory" );
+--- a/xen/include/asm-x86/spec_ctrl_asm.h
++++ b/xen/include/asm-x86/spec_ctrl_asm.h
+@@ -20,9 +20,10 @@
+ #ifndef __X86_SPEC_CTRL_ASM_H__
+ #define __X86_SPEC_CTRL_ASM_H__
+ 
+-/* Encoding of the bottom bits in cpuinfo.bti_ist_info */
+-#define BTI_IST_WRMSR (1 << 1)
+-#define BTI_IST_RSB   (1 << 2)
++/* Encoding of cpuinfo.spec_ctrl_flags */
++#define SCF_use_shadow (1 << 0)
++#define SCF_ist_wrmsr  (1 << 1)
++#define SCF_ist_rsb    (1 << 2)
+ 
+ #ifdef __ASSEMBLY__
+ #include <asm/msr-index.h>
+@@ -49,20 +50,20 @@
+  * after VMEXIT.  The VMEXIT-specific code reads MSR_SPEC_CTRL and updates
+  * current before loading Xen's MSR_SPEC_CTRL setting.
+  *
+- * Factor 2 is harder.  We maintain a shadow_spec_ctrl value, and
+- * use_shadow_spec_ctrl boolean per cpu.  The synchronous use is:
++ * Factor 2 is harder.  We maintain a shadow_spec_ctrl value, and a use_shadow
++ * boolean in the per cpu spec_ctrl_flags.  The synchronous use is:
+  *
+  *  1) Store guest value in shadow_spec_ctrl
+- *  2) Set use_shadow_spec_ctrl boolean
++ *  2) Set the use_shadow boolean
+  *  3) Load guest value into MSR_SPEC_CTRL
+  *  4) Exit to guest
+  *  5) Entry from guest
+- *  6) Clear use_shadow_spec_ctrl boolean
++ *  6) Clear the use_shadow boolean
+  *  7) Load Xen's value into MSR_SPEC_CTRL
+  *
+  * The asynchronous use for interrupts/exceptions is:
+  *  -  Set/clear IBRS on entry to Xen
+- *  -  On exit to Xen, check use_shadow_spec_ctrl
++ *  -  On exit to Xen, check use_shadow
+  *  -  If set, load shadow_spec_ctrl
+  *
+  * Therefore, an interrupt/exception which hits the synchronous path between
+@@ -133,7 +134,7 @@
+     xor %edx, %edx
+ 
+     /* Clear SPEC_CTRL shadowing *before* loading Xen's value. */
+-    movb %dl, CPUINFO_use_shadow_spec_ctrl(%rsp)
++    andb $~SCF_use_shadow, CPUINFO_spec_ctrl_flags(%rsp)
+ 
+     /* Load Xen's intended value. */
+     mov $\ibrs_val, %eax
+@@ -159,12 +160,14 @@
+      * block so calculate the position directly.
+      */
+     .if \maybexen
++        xor %eax, %eax
+         /* Branchless `if ( !xen ) clear_shadowing` */
+         testb $3, UREGS_cs(%rsp)
+-        setz %al
+-        and %al, STACK_CPUINFO_FIELD(use_shadow_spec_ctrl)(%r14)
++        setnz %al
++        not %eax
++        and %al, STACK_CPUINFO_FIELD(spec_ctrl_flags)(%r14)
+     .else
+-        movb %dl, CPUINFO_use_shadow_spec_ctrl(%rsp)
++        andb $~SCF_use_shadow, CPUINFO_spec_ctrl_flags(%rsp)
+     .endif
+ 
+     /* Load Xen's intended value. */
+@@ -183,8 +186,8 @@
+  */
+     xor %edx, %edx
+ 
+-    cmpb %dl, STACK_CPUINFO_FIELD(use_shadow_spec_ctrl)(%rbx)
+-    je .L\@_skip
++    testb $SCF_use_shadow, STACK_CPUINFO_FIELD(spec_ctrl_flags)(%rbx)
++    jz .L\@_skip
+ 
+     mov STACK_CPUINFO_FIELD(shadow_spec_ctrl)(%rbx), %eax
+     mov $MSR_SPEC_CTRL, %ecx
+@@ -205,7 +208,7 @@
+     mov %eax, CPUINFO_shadow_spec_ctrl(%rsp)
+ 
+     /* Set SPEC_CTRL shadowing *before* loading the guest value. */
+-    movb $1, CPUINFO_use_shadow_spec_ctrl(%rsp)
++    orb $SCF_use_shadow, CPUINFO_spec_ctrl_flags(%rsp)
+ 
+     mov $MSR_SPEC_CTRL, %ecx
+     xor %edx, %edx
+@@ -216,7 +219,7 @@
+ #define SPEC_CTRL_ENTRY_FROM_VMEXIT                                     \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_RSB_VMEXIT;                       \
+-    ALTERNATIVE_2 __stringify(ASM_NOP32),                               \
++    ALTERNATIVE_2 __stringify(ASM_NOP33),                               \
+         __stringify(DO_SPEC_CTRL_ENTRY_FROM_VMEXIT                      \
+                     ibrs_val=SPEC_CTRL_IBRS),                           \
+         X86_FEATURE_XEN_IBRS_SET,                                       \
+@@ -228,7 +231,7 @@
+ #define SPEC_CTRL_ENTRY_FROM_PV                                         \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_RSB_NATIVE;                       \
+-    ALTERNATIVE_2 __stringify(ASM_NOP21),                               \
++    ALTERNATIVE_2 __stringify(ASM_NOP22),                               \
+         __stringify(DO_SPEC_CTRL_ENTRY maybexen=0                       \
+                     ibrs_val=SPEC_CTRL_IBRS),                           \
+         X86_FEATURE_XEN_IBRS_SET,                                       \
+@@ -239,7 +242,7 @@
+ #define SPEC_CTRL_ENTRY_FROM_INTR                                       \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_RSB_NATIVE;                       \
+-    ALTERNATIVE_2 __stringify(ASM_NOP29),                               \
++    ALTERNATIVE_2 __stringify(ASM_NOP33),                               \
+         __stringify(DO_SPEC_CTRL_ENTRY maybexen=1                       \
+                     ibrs_val=SPEC_CTRL_IBRS),                           \
+         X86_FEATURE_XEN_IBRS_SET,                                       \
+@@ -267,22 +270,23 @@
+  * This is logical merge of DO_OVERWRITE_RSB and DO_SPEC_CTRL_ENTRY
+  * maybexen=1, but with conditionals rather than alternatives.
+  */
+-    movzbl STACK_CPUINFO_FIELD(bti_ist_info)(%r14), %eax
++    movzbl STACK_CPUINFO_FIELD(spec_ctrl_flags)(%r14), %eax
+ 
+-    testb $BTI_IST_RSB, %al
++    test $SCF_ist_rsb, %al
+     jz .L\@_skip_rsb
+ 
+     DO_OVERWRITE_RSB tmp=rdx /* Clobbers %rcx/%rdx */
+ 
+ .L\@_skip_rsb:
+ 
+-    testb $BTI_IST_WRMSR, %al
++    test $SCF_ist_wrmsr, %al
+     jz .L\@_skip_wrmsr
+ 
+     xor %edx, %edx
+     testb $3, UREGS_cs(%rsp)
+-    setz %dl
+-    and %dl, STACK_CPUINFO_FIELD(use_shadow_spec_ctrl)(%r14)
++    setnz %dl
++    not %edx
++    and %dl, STACK_CPUINFO_FIELD(spec_ctrl_flags)(%r14)
+ 
+     /* Load Xen's intended value. */
+     mov $MSR_SPEC_CTRL, %ecx
+@@ -309,7 +313,7 @@ UNLIKELY_DISPATCH_LABEL(\@_serialise):
+  * Requires %rbx=stack_end
+  * Clobbers %rax, %rcx, %rdx
+  */
+-    testb $BTI_IST_WRMSR, STACK_CPUINFO_FIELD(bti_ist_info)(%rbx)
++    testb $SCF_ist_wrmsr, STACK_CPUINFO_FIELD(spec_ctrl_flags)(%rbx)
+     jz .L\@_skip
+ 
+     DO_SPEC_CTRL_EXIT_TO_XEN

--- a/recipes-extended/xen/files/xsa263-4.9/0004-x86-spec_ctrl-Fold-the-XEN_IBRS_-SET-CLEAR-ALTERNATI.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0004-x86-spec_ctrl-Fold-the-XEN_IBRS_-SET-CLEAR-ALTERNATI.patch
@@ -1,0 +1,208 @@
+From df0421d0368ba545f37b07c08b13591540227dcc Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 17 Apr 2018 14:15:04 +0100
+Subject: [PATCH] x86/spec_ctrl: Fold the XEN_IBRS_{SET,CLEAR} ALTERNATIVES
+ together
+
+Currently, the SPEC_CTRL_{ENTRY,EXIT}_* macros encode Xen's choice of
+MSR_SPEC_CTRL as an immediate constant, and chooses between IBRS or not by
+doubling up the entire alternative block.
+
+There is now a variable holding Xen's choice of value, so use that and
+simplify the alternatives.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit af949407eaba7af71067f23d5866cd0bf1f1144d)
+---
+ xen/arch/x86/spec_ctrl.c            | 12 +++++-----
+ xen/include/asm-x86/cpufeatures.h   |  3 +--
+ xen/include/asm-x86/nops.h          |  3 ++-
+ xen/include/asm-x86/spec_ctrl.h     |  6 ++---
+ xen/include/asm-x86/spec_ctrl_asm.h | 45 +++++++++++++------------------------
+ 5 files changed, 26 insertions(+), 43 deletions(-)
+
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -112,8 +112,9 @@ static void __init print_details(enum in
+            thunk == THUNK_RETPOLINE ? "RETPOLINE" :
+            thunk == THUNK_LFENCE    ? "LFENCE" :
+            thunk == THUNK_JMP       ? "JMP" : "?",
+-           boot_cpu_has(X86_FEATURE_XEN_IBRS_SET)    ? " IBRS+" :
+-           boot_cpu_has(X86_FEATURE_XEN_IBRS_CLEAR)  ? " IBRS-"      : "",
++           boot_cpu_has(X86_FEATURE_SC_MSR) ?
++           default_xen_spec_ctrl & SPEC_CTRL_IBRS    ? " IBRS+" :
++                                                       " IBRS-"      : "",
+            opt_ibpb                                  ? " IBPB"       : "",
+            boot_cpu_has(X86_FEATURE_RSB_NATIVE)      ? " RSB_NATIVE" : "",
+            boot_cpu_has(X86_FEATURE_RSB_VMEXIT)      ? " RSB_VMEXIT" : "");
+@@ -285,13 +286,10 @@ void __init init_speculation_mitigations
+          * need the IBRS entry/exit logic to virtualise IBRS support for
+          * guests.
+          */
++        setup_force_cpu_cap(X86_FEATURE_SC_MSR);
++
+         if ( ibrs )
+-        {
+             default_xen_spec_ctrl |= SPEC_CTRL_IBRS;
+-            setup_force_cpu_cap(X86_FEATURE_XEN_IBRS_SET);
+-        }
+-        else
+-            setup_force_cpu_cap(X86_FEATURE_XEN_IBRS_CLEAR);
+ 
+         default_spec_ctrl_flags |= SCF_ist_wrmsr;
+     }
+--- a/xen/include/asm-x86/cpufeatures.h
++++ b/xen/include/asm-x86/cpufeatures.h
+@@ -28,8 +28,7 @@ XEN_CPUFEATURE(LFENCE_DISPATCH, (FSCAPIN
+ XEN_CPUFEATURE(IND_THUNK_LFENCE,(FSCAPINTS+0)*32+15) /* Use IND_THUNK_LFENCE */
+ XEN_CPUFEATURE(IND_THUNK_JMP,   (FSCAPINTS+0)*32+16) /* Use IND_THUNK_JMP */
+ XEN_CPUFEATURE(XEN_IBPB,        (FSCAPINTS+0)*32+17) /* IBRSB || IBPB */
+-XEN_CPUFEATURE(XEN_IBRS_SET,    (FSCAPINTS+0)*32+18) /* IBRSB && IRBS set in Xen */
+-XEN_CPUFEATURE(XEN_IBRS_CLEAR,  (FSCAPINTS+0)*32+19) /* IBRSB && IBRS clear in Xen */
++XEN_CPUFEATURE(SC_MSR,          (FSCAPINTS+0)*32+18) /* MSR_SPEC_CTRL used by Xen */
+ XEN_CPUFEATURE(RSB_NATIVE,      (FSCAPINTS+0)*32+20) /* RSB overwrite needed for native */
+ XEN_CPUFEATURE(RSB_VMEXIT,      (FSCAPINTS+0)*32+21) /* RSB overwrite needed for vmexit */
+ XEN_CPUFEATURE(NO_XPTI,         (FSCAPINTS+0)*32+22) /* XPTI mitigation not in use */
+--- a/xen/include/asm-x86/nops.h
++++ b/xen/include/asm-x86/nops.h
+@@ -62,9 +62,10 @@
+ #define ASM_NOP8 _ASM_MK_NOP(K8_NOP8)
+ 
+ #define ASM_NOP17 ASM_NOP8; ASM_NOP7; ASM_NOP2
+-#define ASM_NOP22 ASM_NOP8; ASM_NOP8; ASM_NOP6
+ #define ASM_NOP24 ASM_NOP8; ASM_NOP8; ASM_NOP8
++#define ASM_NOP25 ASM_NOP8; ASM_NOP8; ASM_NOP7; ASM_NOP2
+ #define ASM_NOP33 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP7; ASM_NOP2
++#define ASM_NOP36 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP4
+ #define ASM_NOP40 ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP8; ASM_NOP8
+ 
+ #define ASM_NOP_MAX 8
+--- a/xen/include/asm-x86/spec_ctrl.h
++++ b/xen/include/asm-x86/spec_ctrl.h
+@@ -52,14 +52,14 @@ static always_inline void spec_ctrl_ente
+     barrier();
+     info->spec_ctrl_flags |= SCF_use_shadow;
+     barrier();
+-    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_XEN_IBRS_SET)
++    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_SC_MSR)
+                    :: "a" (val), "c" (MSR_SPEC_CTRL), "d" (0) : "memory" );
+ }
+ 
+ /* WARNING! `ret`, `call *`, `jmp *` not safe before this call. */
+ static always_inline void spec_ctrl_exit_idle(struct cpu_info *info)
+ {
+-    uint32_t val = SPEC_CTRL_IBRS;
++    uint32_t val = info->xen_spec_ctrl;
+ 
+     /*
+      * Disable shadowing before updating the MSR.  There are no SMP issues
+@@ -67,7 +67,7 @@ static always_inline void spec_ctrl_exit
+      */
+     info->spec_ctrl_flags &= ~SCF_use_shadow;
+     barrier();
+-    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_XEN_IBRS_SET)
++    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_SC_MSR)
+                    :: "a" (val), "c" (MSR_SPEC_CTRL), "d" (0) : "memory" );
+ }
+ 
+--- a/xen/include/asm-x86/spec_ctrl_asm.h
++++ b/xen/include/asm-x86/spec_ctrl_asm.h
+@@ -117,7 +117,7 @@
+     mov %\tmp, %rsp                 /* Restore old %rsp */
+ .endm
+ 
+-.macro DO_SPEC_CTRL_ENTRY_FROM_VMEXIT ibrs_val:req
++.macro DO_SPEC_CTRL_ENTRY_FROM_VMEXIT
+ /*
+  * Requires %rbx=current, %rsp=regs/cpuinfo
+  * Clobbers %rax, %rcx, %rdx
+@@ -137,11 +137,11 @@
+     andb $~SCF_use_shadow, CPUINFO_spec_ctrl_flags(%rsp)
+ 
+     /* Load Xen's intended value. */
+-    mov $\ibrs_val, %eax
++    movzbl CPUINFO_xen_spec_ctrl(%rsp), %eax
+     wrmsr
+ .endm
+ 
+-.macro DO_SPEC_CTRL_ENTRY maybexen:req ibrs_val:req
++.macro DO_SPEC_CTRL_ENTRY maybexen:req
+ /*
+  * Requires %rsp=regs (also cpuinfo if !maybexen)
+  * Requires %r14=stack_end (if maybexen)
+@@ -166,12 +166,12 @@
+         setnz %al
+         not %eax
+         and %al, STACK_CPUINFO_FIELD(spec_ctrl_flags)(%r14)
++        movzbl STACK_CPUINFO_FIELD(xen_spec_ctrl)(%r14), %eax
+     .else
+         andb $~SCF_use_shadow, CPUINFO_spec_ctrl_flags(%rsp)
++        movzbl CPUINFO_xen_spec_ctrl(%rsp), %eax
+     .endif
+ 
+-    /* Load Xen's intended value. */
+-    mov $\ibrs_val, %eax
+     wrmsr
+ .endm
+ 
+@@ -219,47 +219,32 @@
+ #define SPEC_CTRL_ENTRY_FROM_VMEXIT                                     \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_RSB_VMEXIT;                       \
+-    ALTERNATIVE_2 __stringify(ASM_NOP33),                               \
+-        __stringify(DO_SPEC_CTRL_ENTRY_FROM_VMEXIT                      \
+-                    ibrs_val=SPEC_CTRL_IBRS),                           \
+-        X86_FEATURE_XEN_IBRS_SET,                                       \
+-        __stringify(DO_SPEC_CTRL_ENTRY_FROM_VMEXIT                      \
+-                    ibrs_val=0),                                        \
+-        X86_FEATURE_XEN_IBRS_CLEAR
++    ALTERNATIVE __stringify(ASM_NOP36),                                 \
++        DO_SPEC_CTRL_ENTRY_FROM_VMEXIT, X86_FEATURE_SC_MSR
+ 
+ /* Use after an entry from PV context (syscall/sysenter/int80/int82/etc). */
+ #define SPEC_CTRL_ENTRY_FROM_PV                                         \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_RSB_NATIVE;                       \
+-    ALTERNATIVE_2 __stringify(ASM_NOP22),                               \
+-        __stringify(DO_SPEC_CTRL_ENTRY maybexen=0                       \
+-                    ibrs_val=SPEC_CTRL_IBRS),                           \
+-        X86_FEATURE_XEN_IBRS_SET,                                       \
+-        __stringify(DO_SPEC_CTRL_ENTRY maybexen=0 ibrs_val=0),          \
+-        X86_FEATURE_XEN_IBRS_CLEAR
++    ALTERNATIVE __stringify(ASM_NOP25),                                 \
++        __stringify(DO_SPEC_CTRL_ENTRY maybexen=0), X86_FEATURE_SC_MSR
+ 
+ /* Use in interrupt/exception context.  May interrupt Xen or PV context. */
+ #define SPEC_CTRL_ENTRY_FROM_INTR                                       \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_RSB_NATIVE;                       \
+-    ALTERNATIVE_2 __stringify(ASM_NOP33),                               \
+-        __stringify(DO_SPEC_CTRL_ENTRY maybexen=1                       \
+-                    ibrs_val=SPEC_CTRL_IBRS),                           \
+-        X86_FEATURE_XEN_IBRS_SET,                                       \
+-        __stringify(DO_SPEC_CTRL_ENTRY maybexen=1 ibrs_val=0),          \
+-        X86_FEATURE_XEN_IBRS_CLEAR
++    ALTERNATIVE __stringify(ASM_NOP33),                                 \
++        __stringify(DO_SPEC_CTRL_ENTRY maybexen=1), X86_FEATURE_SC_MSR
+ 
+ /* Use when exiting to Xen context. */
+ #define SPEC_CTRL_EXIT_TO_XEN                                           \
+-    ALTERNATIVE_2 __stringify(ASM_NOP17),                               \
+-        DO_SPEC_CTRL_EXIT_TO_XEN, X86_FEATURE_XEN_IBRS_SET,             \
+-        DO_SPEC_CTRL_EXIT_TO_XEN, X86_FEATURE_XEN_IBRS_CLEAR
++    ALTERNATIVE __stringify(ASM_NOP17),                                 \
++        DO_SPEC_CTRL_EXIT_TO_XEN, X86_FEATURE_SC_MSR
+ 
+ /* Use when exiting to guest context. */
+ #define SPEC_CTRL_EXIT_TO_GUEST                                         \
+-    ALTERNATIVE_2 __stringify(ASM_NOP24),                               \
+-        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_XEN_IBRS_SET,           \
+-        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_XEN_IBRS_CLEAR
++    ALTERNATIVE __stringify(ASM_NOP24),                                 \
++        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR
+ 
+ /* TODO: Drop these when the alternatives infrastructure is NMI/#MC safe. */
+ .macro SPEC_CTRL_ENTRY_FROM_INTR_IST

--- a/recipes-extended/xen/files/xsa263-4.9/0005-x86-spec_ctrl-Rename-bits-of-infrastructure-to-avoid.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0005-x86-spec_ctrl-Rename-bits-of-infrastructure-to-avoid.patch
@@ -1,0 +1,256 @@
+From e00632c06f088bfe4bd110686faa4a7e01a5667b Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 30 Apr 2018 14:20:23 +0100
+Subject: [PATCH] x86/spec_ctrl: Rename bits of infrastructure to avoid NATIVE
+ and VMEXIT
+
+In hindsight, using NATIVE and VMEXIT as naming terminology was not clever.
+A future change wants to split SPEC_CTRL_EXIT_TO_GUEST into PV and HVM
+specific implementations, and using VMEXIT as a term is completely wrong.
+
+Take the opportunity to fix some stale documentation in spec_ctrl_asm.h.  The
+IST helpers were missing from the large comment block, and since
+SPEC_CTRL_ENTRY_FROM_INTR_IST was introduced, we've gained a new piece of
+functionality which currently depends on the fine grain control, which exists
+in lieu of livepatching.  Note this in the comment.
+
+No functional change.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit d9822b8a38114e96e4516dc998f4055249364d5d)
+---
+ xen/arch/x86/hvm/svm/entry.S        |  4 ++--
+ xen/arch/x86/hvm/vmx/entry.S        |  4 ++--
+ xen/arch/x86/spec_ctrl.c            | 20 ++++++++++----------
+ xen/arch/x86/x86_64/compat/entry.S  |  2 +-
+ xen/arch/x86/x86_64/entry.S         |  2 +-
+ xen/include/asm-x86/cpufeatures.h   |  4 ++--
+ xen/include/asm-x86/spec_ctrl_asm.h | 36 +++++++++++++++++++++++++-----------
+ 7 files changed, 43 insertions(+), 29 deletions(-)
+
+--- a/xen/arch/x86/hvm/svm/entry.S
++++ b/xen/arch/x86/hvm/svm/entry.S
+@@ -80,7 +80,7 @@ UNLIKELY_END(svm_trace)
+         mov VCPU_arch_spec_ctrl(%rbx), %eax
+ 
+         /* WARNING! `ret`, `call *`, `jmp *` not safe beyond this point. */
+-        SPEC_CTRL_EXIT_TO_GUEST /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
++        SPEC_CTRL_EXIT_TO_HVM   /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
+ 
+         pop  %r15
+         pop  %r14
+@@ -105,7 +105,7 @@ UNLIKELY_END(svm_trace)
+ 
+         GET_CURRENT(bx)
+ 
+-        SPEC_CTRL_ENTRY_FROM_VMEXIT /* Req: b=curr %rsp=regs/cpuinfo, Clob: acd */
++        SPEC_CTRL_ENTRY_FROM_HVM    /* Req: b=curr %rsp=regs/cpuinfo, Clob: acd */
+         /* WARNING! `ret`, `call *`, `jmp *` not safe before this point. */
+ 
+         mov  VCPU_svm_vmcb(%rbx),%rcx
+--- a/xen/arch/x86/hvm/vmx/entry.S
++++ b/xen/arch/x86/hvm/vmx/entry.S
+@@ -36,7 +36,7 @@ ENTRY(vmx_asm_vmexit_handler)
+         movb $1,VCPU_vmx_launched(%rbx)
+         mov  %rax,VCPU_hvm_guest_cr2(%rbx)
+ 
+-        SPEC_CTRL_ENTRY_FROM_VMEXIT /* Req: b=curr %rsp=regs/cpuinfo, Clob: acd */
++        SPEC_CTRL_ENTRY_FROM_HVM    /* Req: b=curr %rsp=regs/cpuinfo, Clob: acd */
+         /* WARNING! `ret`, `call *`, `jmp *` not safe before this point. */
+ 
+         mov  %rsp,%rdi
+@@ -71,7 +71,7 @@ UNLIKELY_END(realmode)
+         mov VCPU_arch_spec_ctrl(%rbx), %eax
+ 
+         /* WARNING! `ret`, `call *`, `jmp *` not safe beyond this point. */
+-        SPEC_CTRL_EXIT_TO_GUEST /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
++        SPEC_CTRL_EXIT_TO_HVM   /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
+ 
+         mov  VCPU_hvm_guest_cr2(%rbx),%rax
+ 
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -35,8 +35,8 @@ static enum ind_thunk {
+     THUNK_JMP,
+ } opt_thunk __initdata = THUNK_DEFAULT;
+ static int8_t __initdata opt_ibrs = -1;
+-static bool __initdata opt_rsb_native = true;
+-static bool __initdata opt_rsb_vmexit = true;
++static bool __initdata opt_rsb_pv = true;
++static bool __initdata opt_rsb_hvm = true;
+ bool __read_mostly opt_ibpb = true;
+ uint8_t __read_mostly default_xen_spec_ctrl;
+ uint8_t __read_mostly default_spec_ctrl_flags;
+@@ -69,9 +69,9 @@ static int __init parse_bti(const char *
+         else if ( (val = parse_boolean("ibpb", s, ss)) >= 0 )
+             opt_ibpb = val;
+         else if ( (val = parse_boolean("rsb_native", s, ss)) >= 0 )
+-            opt_rsb_native = val;
++            opt_rsb_pv = val;
+         else if ( (val = parse_boolean("rsb_vmexit", s, ss)) >= 0 )
+-            opt_rsb_vmexit = val;
++            opt_rsb_hvm = val;
+         else
+             rc = -EINVAL;
+ 
+@@ -116,8 +116,8 @@ static void __init print_details(enum in
+            default_xen_spec_ctrl & SPEC_CTRL_IBRS    ? " IBRS+" :
+                                                        " IBRS-"      : "",
+            opt_ibpb                                  ? " IBPB"       : "",
+-           boot_cpu_has(X86_FEATURE_RSB_NATIVE)      ? " RSB_NATIVE" : "",
+-           boot_cpu_has(X86_FEATURE_RSB_VMEXIT)      ? " RSB_VMEXIT" : "");
++           boot_cpu_has(X86_FEATURE_SC_RSB_PV)       ? " RSB_NATIVE" : "",
++           boot_cpu_has(X86_FEATURE_SC_RSB_HVM)      ? " RSB_VMEXIT" : "");
+ 
+     printk("XPTI: %s\n",
+            boot_cpu_has(X86_FEATURE_NO_XPTI) ? "disabled" : "enabled");
+@@ -307,9 +307,9 @@ void __init init_speculation_mitigations
+      * If a processors speculates to 32bit PV guest kernel mappings, it is
+      * speculating in 64bit supervisor mode, and can leak data.
+      */
+-    if ( opt_rsb_native )
++    if ( opt_rsb_pv )
+     {
+-        setup_force_cpu_cap(X86_FEATURE_RSB_NATIVE);
++        setup_force_cpu_cap(X86_FEATURE_SC_RSB_PV);
+         default_spec_ctrl_flags |= SCF_ist_rsb;
+     }
+ 
+@@ -317,8 +317,8 @@ void __init init_speculation_mitigations
+      * HVM guests can always poison the RSB to point at Xen supervisor
+      * mappings.
+      */
+-    if ( opt_rsb_vmexit )
+-        setup_force_cpu_cap(X86_FEATURE_RSB_VMEXIT);
++    if ( opt_rsb_hvm )
++        setup_force_cpu_cap(X86_FEATURE_SC_RSB_HVM);
+ 
+     /* Check we have hardware IBPB support before using it... */
+     if ( !boot_cpu_has(X86_FEATURE_IBRSB) && !boot_cpu_has(X86_FEATURE_IBPB) )
+--- a/xen/arch/x86/x86_64/compat/entry.S
++++ b/xen/arch/x86/x86_64/compat/entry.S
+@@ -163,7 +163,7 @@ ENTRY(compat_restore_all_guest)
+         mov VCPU_arch_spec_ctrl(%rbx), %eax
+ 
+         /* WARNING! `ret`, `call *`, `jmp *` not safe beyond this point. */
+-        SPEC_CTRL_EXIT_TO_GUEST /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
++        SPEC_CTRL_EXIT_TO_PV    /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
+ 
+         RESTORE_ALL adj=8 compat=1
+ .Lft0:  iretq
+--- a/xen/arch/x86/x86_64/entry.S
++++ b/xen/arch/x86/x86_64/entry.S
+@@ -193,7 +193,7 @@ restore_all_guest:
+         mov   %r15d, %eax
+ 
+         /* WARNING! `ret`, `call *`, `jmp *` not safe beyond this point. */
+-        SPEC_CTRL_EXIT_TO_GUEST /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
++        SPEC_CTRL_EXIT_TO_PV    /* Req: a=spec_ctrl %rsp=regs/cpuinfo, Clob: cd */
+ 
+         RESTORE_ALL
+         testw $TRAP_syscall,4(%rsp)
+--- a/xen/include/asm-x86/cpufeatures.h
++++ b/xen/include/asm-x86/cpufeatures.h
+@@ -29,6 +29,6 @@ XEN_CPUFEATURE(IND_THUNK_LFENCE,(FSCAPIN
+ XEN_CPUFEATURE(IND_THUNK_JMP,   (FSCAPINTS+0)*32+16) /* Use IND_THUNK_JMP */
+ XEN_CPUFEATURE(XEN_IBPB,        (FSCAPINTS+0)*32+17) /* IBRSB || IBPB */
+ XEN_CPUFEATURE(SC_MSR,          (FSCAPINTS+0)*32+18) /* MSR_SPEC_CTRL used by Xen */
+-XEN_CPUFEATURE(RSB_NATIVE,      (FSCAPINTS+0)*32+20) /* RSB overwrite needed for native */
+-XEN_CPUFEATURE(RSB_VMEXIT,      (FSCAPINTS+0)*32+21) /* RSB overwrite needed for vmexit */
++XEN_CPUFEATURE(SC_RSB_PV,       (FSCAPINTS+0)*32+20) /* RSB overwrite needed for PV */
++XEN_CPUFEATURE(SC_RSB_HVM,      (FSCAPINTS+0)*32+21) /* RSB overwrite needed for HVM */
+ XEN_CPUFEATURE(NO_XPTI,         (FSCAPINTS+0)*32+22) /* XPTI mitigation not in use */
+--- a/xen/include/asm-x86/spec_ctrl_asm.h
++++ b/xen/include/asm-x86/spec_ctrl_asm.h
+@@ -72,11 +72,14 @@
+  *
+  * The following ASM fragments implement this algorithm.  See their local
+  * comments for further details.
+- *  - SPEC_CTRL_ENTRY_FROM_VMEXIT
++ *  - SPEC_CTRL_ENTRY_FROM_HVM
+  *  - SPEC_CTRL_ENTRY_FROM_PV
+  *  - SPEC_CTRL_ENTRY_FROM_INTR
++ *  - SPEC_CTRL_ENTRY_FROM_INTR_IST
++ *  - SPEC_CTRL_EXIT_TO_XEN_IST
+  *  - SPEC_CTRL_EXIT_TO_XEN
+- *  - SPEC_CTRL_EXIT_TO_GUEST
++ *  - SPEC_CTRL_EXIT_TO_PV
++ *  - SPEC_CTRL_EXIT_TO_HVM
+  */
+ 
+ .macro DO_OVERWRITE_RSB tmp=rax
+@@ -117,7 +120,7 @@
+     mov %\tmp, %rsp                 /* Restore old %rsp */
+ .endm
+ 
+-.macro DO_SPEC_CTRL_ENTRY_FROM_VMEXIT
++.macro DO_SPEC_CTRL_ENTRY_FROM_HVM
+ /*
+  * Requires %rbx=current, %rsp=regs/cpuinfo
+  * Clobbers %rax, %rcx, %rdx
+@@ -216,23 +219,23 @@
+ .endm
+ 
+ /* Use after a VMEXIT from an HVM guest. */
+-#define SPEC_CTRL_ENTRY_FROM_VMEXIT                                     \
++#define SPEC_CTRL_ENTRY_FROM_HVM                                        \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+-        DO_OVERWRITE_RSB, X86_FEATURE_RSB_VMEXIT;                       \
++        DO_OVERWRITE_RSB, X86_FEATURE_SC_RSB_HVM;                       \
+     ALTERNATIVE __stringify(ASM_NOP36),                                 \
+-        DO_SPEC_CTRL_ENTRY_FROM_VMEXIT, X86_FEATURE_SC_MSR
++        DO_SPEC_CTRL_ENTRY_FROM_HVM, X86_FEATURE_SC_MSR
+ 
+ /* Use after an entry from PV context (syscall/sysenter/int80/int82/etc). */
+ #define SPEC_CTRL_ENTRY_FROM_PV                                         \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+-        DO_OVERWRITE_RSB, X86_FEATURE_RSB_NATIVE;                       \
++        DO_OVERWRITE_RSB, X86_FEATURE_SC_RSB_PV;                        \
+     ALTERNATIVE __stringify(ASM_NOP25),                                 \
+         __stringify(DO_SPEC_CTRL_ENTRY maybexen=0), X86_FEATURE_SC_MSR
+ 
+ /* Use in interrupt/exception context.  May interrupt Xen or PV context. */
+ #define SPEC_CTRL_ENTRY_FROM_INTR                                       \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+-        DO_OVERWRITE_RSB, X86_FEATURE_RSB_NATIVE;                       \
++        DO_OVERWRITE_RSB, X86_FEATURE_SC_RSB_PV;                        \
+     ALTERNATIVE __stringify(ASM_NOP33),                                 \
+         __stringify(DO_SPEC_CTRL_ENTRY maybexen=1), X86_FEATURE_SC_MSR
+ 
+@@ -241,12 +244,22 @@
+     ALTERNATIVE __stringify(ASM_NOP17),                                 \
+         DO_SPEC_CTRL_EXIT_TO_XEN, X86_FEATURE_SC_MSR
+ 
+-/* Use when exiting to guest context. */
+-#define SPEC_CTRL_EXIT_TO_GUEST                                         \
++/* Use when exiting to PV guest context. */
++#define SPEC_CTRL_EXIT_TO_PV                                            \
+     ALTERNATIVE __stringify(ASM_NOP24),                                 \
+         DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR
+ 
+-/* TODO: Drop these when the alternatives infrastructure is NMI/#MC safe. */
++/* Use when exiting to HVM guest context. */
++#define SPEC_CTRL_EXIT_TO_HVM                                           \
++    ALTERNATIVE __stringify(ASM_NOP24),                                 \
++        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR
++
++/*
++ * Use in IST interrupt/exception context.  May interrupt Xen or PV context.
++ * Fine grain control of SCF_ist_wrmsr is needed for safety in the S3 resume
++ * path to avoid using MSR_SPEC_CTRL before the microcode introducing it has
++ * been reloaded.
++ */
+ .macro SPEC_CTRL_ENTRY_FROM_INTR_IST
+ /*
+  * Requires %rsp=regs, %r14=stack_end
+@@ -293,6 +306,7 @@ UNLIKELY_DISPATCH_LABEL(\@_serialise):
+     UNLIKELY_END(\@_serialise)
+ .endm
+ 
++/* Use when exiting to Xen in IST context. */
+ .macro SPEC_CTRL_EXIT_TO_XEN_IST
+ /*
+  * Requires %rbx=stack_end

--- a/recipes-extended/xen/files/xsa263-4.9/0006-x86-spec_ctrl-Elide-MSR_SPEC_CTRL-handling-in-idle-c.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0006-x86-spec_ctrl-Elide-MSR_SPEC_CTRL-handling-in-idle-c.patch
@@ -1,0 +1,62 @@
+From 12dec36f81cdd8aecc5388f983884cbb4e437ce8 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 7 May 2018 14:06:16 +0100
+Subject: [PATCH] x86/spec_ctrl: Elide MSR_SPEC_CTRL handling in idle context
+ when possible
+
+If Xen is virtualising MSR_SPEC_CTRL handling for guests, but using 0 as its
+own MSR_SPEC_CTRL value, spec_ctrl_{enter,exit}_idle() need not write to the
+MSR.
+
+Requested-by: Jan Beulich <JBeulich@suse.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit 94df6e8588e35cc2028ccb3fd2921c6e6360605e)
+---
+ xen/arch/x86/spec_ctrl.c          | 4 ++++
+ xen/include/asm-x86/cpufeatures.h | 1 +
+ xen/include/asm-x86/spec_ctrl.h   | 4 ++--
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -327,6 +327,10 @@ void __init init_speculation_mitigations
+     /* (Re)init BSP state now that default_spec_ctrl_flags has been calculated. */
+     init_shadow_spec_ctrl_state();
+ 
++    /* If Xen is using any MSR_SPEC_CTRL settings, adjust the idle path. */
++    if ( default_xen_spec_ctrl )
++        setup_force_cpu_cap(X86_FEATURE_SC_MSR_IDLE);
++
+     print_details(thunk, caps);
+ }
+ 
+--- a/xen/include/asm-x86/cpufeatures.h
++++ b/xen/include/asm-x86/cpufeatures.h
+@@ -32,3 +32,4 @@ XEN_CPUFEATURE(SC_MSR,          (FSCAPIN
+ XEN_CPUFEATURE(SC_RSB_PV,       (FSCAPINTS+0)*32+20) /* RSB overwrite needed for PV */
+ XEN_CPUFEATURE(SC_RSB_HVM,      (FSCAPINTS+0)*32+21) /* RSB overwrite needed for HVM */
+ XEN_CPUFEATURE(NO_XPTI,         (FSCAPINTS+0)*32+22) /* XPTI mitigation not in use */
++XEN_CPUFEATURE(SC_MSR_IDLE,     (FSCAPINTS+0)*32+23) /* SC_MSR && default_xen_spec_ctrl */
+--- a/xen/include/asm-x86/spec_ctrl.h
++++ b/xen/include/asm-x86/spec_ctrl.h
+@@ -52,7 +52,7 @@ static always_inline void spec_ctrl_ente
+     barrier();
+     info->spec_ctrl_flags |= SCF_use_shadow;
+     barrier();
+-    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_SC_MSR)
++    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_SC_MSR_IDLE)
+                    :: "a" (val), "c" (MSR_SPEC_CTRL), "d" (0) : "memory" );
+ }
+ 
+@@ -67,7 +67,7 @@ static always_inline void spec_ctrl_exit
+      */
+     info->spec_ctrl_flags &= ~SCF_use_shadow;
+     barrier();
+-    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_SC_MSR)
++    asm volatile ( ALTERNATIVE(ASM_NOP3, "wrmsr", X86_FEATURE_SC_MSR_IDLE)
+                    :: "a" (val), "c" (MSR_SPEC_CTRL), "d" (0) : "memory" );
+ }
+ 

--- a/recipes-extended/xen/files/xsa263-4.9/0007-x86-spec_ctrl-Split-X86_FEATURE_SC_MSR-into-PV-and-H.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0007-x86-spec_ctrl-Split-X86_FEATURE_SC_MSR-into-PV-and-H.patch
@@ -1,0 +1,102 @@
+From 161f6c16d82ed912f6b656c90572ca265a4f0f78 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 17 Apr 2018 14:15:04 +0100
+Subject: [PATCH] x86/spec_ctrl: Split X86_FEATURE_SC_MSR into PV and HVM
+ variants
+
+In order to separately control whether MSR_SPEC_CTRL is virtualised for PV and
+HVM guests, split the feature used to control runtime alternatives into two.
+Xen will use MSR_SPEC_CTRL itself if either of these features are active.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit fa9eb09d446a1279f5e861e6b84fa8675dabf148)
+---
+ xen/arch/x86/spec_ctrl.c            |  6 ++++--
+ xen/include/asm-x86/cpufeatures.h   |  5 +++--
+ xen/include/asm-x86/spec_ctrl_asm.h | 12 ++++++------
+ 3 files changed, 13 insertions(+), 10 deletions(-)
+
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -112,7 +112,8 @@ static void __init print_details(enum in
+            thunk == THUNK_RETPOLINE ? "RETPOLINE" :
+            thunk == THUNK_LFENCE    ? "LFENCE" :
+            thunk == THUNK_JMP       ? "JMP" : "?",
+-           boot_cpu_has(X86_FEATURE_SC_MSR) ?
++           (boot_cpu_has(X86_FEATURE_SC_MSR_PV) ||
++            boot_cpu_has(X86_FEATURE_SC_MSR_HVM)) ?
+            default_xen_spec_ctrl & SPEC_CTRL_IBRS    ? " IBRS+" :
+                                                        " IBRS-"      : "",
+            opt_ibpb                                  ? " IBPB"       : "",
+@@ -286,7 +287,8 @@ void __init init_speculation_mitigations
+          * need the IBRS entry/exit logic to virtualise IBRS support for
+          * guests.
+          */
+-        setup_force_cpu_cap(X86_FEATURE_SC_MSR);
++        setup_force_cpu_cap(X86_FEATURE_SC_MSR_PV);
++        setup_force_cpu_cap(X86_FEATURE_SC_MSR_HVM);
+ 
+         if ( ibrs )
+             default_xen_spec_ctrl |= SPEC_CTRL_IBRS;
+--- a/xen/include/asm-x86/cpufeatures.h
++++ b/xen/include/asm-x86/cpufeatures.h
+@@ -28,8 +28,9 @@ XEN_CPUFEATURE(LFENCE_DISPATCH, (FSCAPIN
+ XEN_CPUFEATURE(IND_THUNK_LFENCE,(FSCAPINTS+0)*32+15) /* Use IND_THUNK_LFENCE */
+ XEN_CPUFEATURE(IND_THUNK_JMP,   (FSCAPINTS+0)*32+16) /* Use IND_THUNK_JMP */
+ XEN_CPUFEATURE(XEN_IBPB,        (FSCAPINTS+0)*32+17) /* IBRSB || IBPB */
+-XEN_CPUFEATURE(SC_MSR,          (FSCAPINTS+0)*32+18) /* MSR_SPEC_CTRL used by Xen */
++XEN_CPUFEATURE(SC_MSR_PV,       (FSCAPINTS+0)*32+18) /* MSR_SPEC_CTRL used by Xen for PV */
++XEN_CPUFEATURE(SC_MSR_HVM,      (FSCAPINTS+0)*32+19) /* MSR_SPEC_CTRL used by Xen for HVM */
+ XEN_CPUFEATURE(SC_RSB_PV,       (FSCAPINTS+0)*32+20) /* RSB overwrite needed for PV */
+ XEN_CPUFEATURE(SC_RSB_HVM,      (FSCAPINTS+0)*32+21) /* RSB overwrite needed for HVM */
+ XEN_CPUFEATURE(NO_XPTI,         (FSCAPINTS+0)*32+22) /* XPTI mitigation not in use */
+-XEN_CPUFEATURE(SC_MSR_IDLE,     (FSCAPINTS+0)*32+23) /* SC_MSR && default_xen_spec_ctrl */
++XEN_CPUFEATURE(SC_MSR_IDLE,     (FSCAPINTS+0)*32+23) /* (SC_MSR_PV || SC_MSR_HVM) && default_xen_spec_ctrl */
+--- a/xen/include/asm-x86/spec_ctrl_asm.h
++++ b/xen/include/asm-x86/spec_ctrl_asm.h
+@@ -223,36 +223,36 @@
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_SC_RSB_HVM;                       \
+     ALTERNATIVE __stringify(ASM_NOP36),                                 \
+-        DO_SPEC_CTRL_ENTRY_FROM_HVM, X86_FEATURE_SC_MSR
++        DO_SPEC_CTRL_ENTRY_FROM_HVM, X86_FEATURE_SC_MSR_HVM
+ 
+ /* Use after an entry from PV context (syscall/sysenter/int80/int82/etc). */
+ #define SPEC_CTRL_ENTRY_FROM_PV                                         \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_SC_RSB_PV;                        \
+     ALTERNATIVE __stringify(ASM_NOP25),                                 \
+-        __stringify(DO_SPEC_CTRL_ENTRY maybexen=0), X86_FEATURE_SC_MSR
++        __stringify(DO_SPEC_CTRL_ENTRY maybexen=0), X86_FEATURE_SC_MSR_PV
+ 
+ /* Use in interrupt/exception context.  May interrupt Xen or PV context. */
+ #define SPEC_CTRL_ENTRY_FROM_INTR                                       \
+     ALTERNATIVE __stringify(ASM_NOP40),                                 \
+         DO_OVERWRITE_RSB, X86_FEATURE_SC_RSB_PV;                        \
+     ALTERNATIVE __stringify(ASM_NOP33),                                 \
+-        __stringify(DO_SPEC_CTRL_ENTRY maybexen=1), X86_FEATURE_SC_MSR
++        __stringify(DO_SPEC_CTRL_ENTRY maybexen=1), X86_FEATURE_SC_MSR_PV
+ 
+ /* Use when exiting to Xen context. */
+ #define SPEC_CTRL_EXIT_TO_XEN                                           \
+     ALTERNATIVE __stringify(ASM_NOP17),                                 \
+-        DO_SPEC_CTRL_EXIT_TO_XEN, X86_FEATURE_SC_MSR
++        DO_SPEC_CTRL_EXIT_TO_XEN, X86_FEATURE_SC_MSR_PV
+ 
+ /* Use when exiting to PV guest context. */
+ #define SPEC_CTRL_EXIT_TO_PV                                            \
+     ALTERNATIVE __stringify(ASM_NOP24),                                 \
+-        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR
++        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR_PV
+ 
+ /* Use when exiting to HVM guest context. */
+ #define SPEC_CTRL_EXIT_TO_HVM                                           \
+     ALTERNATIVE __stringify(ASM_NOP24),                                 \
+-        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR
++        DO_SPEC_CTRL_EXIT_TO_GUEST, X86_FEATURE_SC_MSR_HVM
+ 
+ /*
+  * Use in IST interrupt/exception context.  May interrupt Xen or PV context.

--- a/recipes-extended/xen/files/xsa263-4.9/0008-x86-spec_ctrl-Explicitly-set-Xen-s-default-MSR_SPEC_.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0008-x86-spec_ctrl-Explicitly-set-Xen-s-default-MSR_SPEC_.patch
@@ -1,0 +1,123 @@
+From be34661999a9090bd0dfbf2e47af3c12889a5ccf Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Wed, 9 May 2018 13:59:56 +0100
+Subject: [PATCH] x86/spec_ctrl: Explicitly set Xen's default MSR_SPEC_CTRL
+ value
+
+With the impending ability to disable MSR_SPEC_CTRL handling on a
+per-guest-type basis, the first exit-from-guest may not have the side effect
+of loading Xen's choice of value.  Explicitly set Xen's default during the BSP
+and AP boot paths.
+
+For the BSP however, delay setting a non-zero MSR_SPEC_CTRL default until
+after dom0 has been constructed when safe to do so.  Oracle report that this
+speeds up boots of some hardware by 50s.
+
+"when safe to do so" is based on whether we are virtualised.  A native boot
+won't have any other code running in a position to mount an attack.
+
+Reported-by: Zhenzhong Duan <zhenzhong.duan@oracle.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit cb8c12020307b39a89273d7699e89000451987ab)
+---
+ xen/arch/x86/setup.c            |  7 +++++++
+ xen/arch/x86/smpboot.c          |  8 ++++++++
+ xen/arch/x86/spec_ctrl.c        | 32 ++++++++++++++++++++++++++++++++
+ xen/include/asm-x86/spec_ctrl.h |  2 ++
+ 4 files changed, 49 insertions(+)
+
+--- a/xen/arch/x86/setup.c
++++ b/xen/arch/x86/setup.c
+@@ -1687,6 +1687,13 @@ void __init noreturn __start_xen(unsigne
+ 
+     setup_io_bitmap(dom0);
+ 
++    if ( bsp_delay_spec_ctrl )
++    {
++        get_cpu_info()->spec_ctrl_flags &= ~SCF_use_shadow;
++        barrier();
++        wrmsrl(MSR_SPEC_CTRL, default_xen_spec_ctrl);
++    }
++
+     /* Jump to the 1:1 virtual mappings of cpu0_stack. */
+     asm volatile ("mov %[stk], %%rsp; jmp %c[fn]" ::
+                   [stk] "g" (__va(__pa(get_stack_bottom()))),
+--- a/xen/arch/x86/smpboot.c
++++ b/xen/arch/x86/smpboot.c
+@@ -344,6 +344,14 @@ void start_secondary(void *unused)
+     else
+         microcode_resume_cpu(cpu);
+ 
++    /*
++     * If MSR_SPEC_CTRL is available, apply Xen's default setting and discard
++     * any firmware settings.  Note: MSR_SPEC_CTRL may only become available
++     * after loading microcode.
++     */
++    if ( boot_cpu_has(X86_FEATURE_IBRSB) )
++        wrmsrl(MSR_SPEC_CTRL, default_xen_spec_ctrl);
++
+     smp_callin();
+ 
+     init_percpu_time();
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -38,6 +38,8 @@ static int8_t __initdata opt_ibrs = -1;
+ static bool __initdata opt_rsb_pv = true;
+ static bool __initdata opt_rsb_hvm = true;
+ bool __read_mostly opt_ibpb = true;
++
++bool __initdata bsp_delay_spec_ctrl;
+ uint8_t __read_mostly default_xen_spec_ctrl;
+ uint8_t __read_mostly default_spec_ctrl_flags;
+ 
+@@ -334,6 +336,36 @@ void __init init_speculation_mitigations
+         setup_force_cpu_cap(X86_FEATURE_SC_MSR_IDLE);
+ 
+     print_details(thunk, caps);
++
++    /*
++     * If MSR_SPEC_CTRL is available, apply Xen's default setting and discard
++     * any firmware settings.  For performance reasons, when safe to do so, we
++     * delay applying non-zero settings until after dom0 has been constructed.
++     *
++     * "when safe to do so" is based on whether we are virtualised.  A native
++     * boot won't have any other code running in a position to mount an
++     * attack.
++     */
++    if ( boot_cpu_has(X86_FEATURE_IBRSB) )
++    {
++        bsp_delay_spec_ctrl = !cpu_has_hypervisor && default_xen_spec_ctrl;
++
++        /*
++         * If delaying MSR_SPEC_CTRL setup, use the same mechanism as
++         * spec_ctrl_enter_idle(), by using a shadow value of zero.
++         */
++        if ( bsp_delay_spec_ctrl )
++        {
++            struct cpu_info *info = get_cpu_info();
++
++            info->shadow_spec_ctrl = 0;
++            barrier();
++            info->spec_ctrl_flags |= SCF_use_shadow;
++            barrier();
++        }
++
++        wrmsrl(MSR_SPEC_CTRL, bsp_delay_spec_ctrl ? 0 : default_xen_spec_ctrl);
++    }
+ }
+ 
+ static void __init __maybe_unused build_assertions(void)
+--- a/xen/include/asm-x86/spec_ctrl.h
++++ b/xen/include/asm-x86/spec_ctrl.h
+@@ -27,6 +27,8 @@
+ void init_speculation_mitigations(void);
+ 
+ extern bool opt_ibpb;
++
++extern bool bsp_delay_spec_ctrl;
+ extern uint8_t default_xen_spec_ctrl;
+ extern uint8_t default_spec_ctrl_flags;
+ 

--- a/recipes-extended/xen/files/xsa263-4.9/0009-x86-cpuid-Improvements-to-guest-policies-for-specula.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0009-x86-cpuid-Improvements-to-guest-policies-for-specula.patch
@@ -1,0 +1,127 @@
+From eea942504afa2b91a3934b8f712758277a0adf00 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 1 May 2018 11:59:03 +0100
+Subject: [PATCH] x86/cpuid: Improvements to guest policies for speculative
+ sidechannel features
+
+If Xen isn't virtualising MSR_SPEC_CTRL for guests, IBRSB shouldn't be
+advertised.  It is not currently possible to express this via the existing
+command line options, but such an ability will be introduced.
+
+Another useful option in some usecases is to offer IBPB without IBRS.  When a
+guest kernel is known to be compatible (uses retpoline and knows about the AMD
+IBPB feature bit), an administrator with pre-Skylake hardware may wish to hide
+IBRS.  This allows the VM to have full protection, without Xen or the VM
+needing to touch MSR_SPEC_CTRL, which can reduce the overhead of Spectre
+mitigations.
+
+Break the logic common to both PV and HVM CPUID calculations into a common
+helper, to avoid duplication.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit cb06b308ec71b23f37a44f5e2351fe2cae0306e9)
+---
+ xen/arch/x86/cpuid.c | 60 ++++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 37 insertions(+), 23 deletions(-)
+
+--- a/xen/arch/x86/cpuid.c
++++ b/xen/arch/x86/cpuid.c
+@@ -374,6 +374,28 @@ static void __init calculate_host_policy
+     }
+ }
+ 
++static void __init guest_common_feature_adjustments(uint32_t *fs)
++{
++    /* Unconditionally claim to be able to set the hypervisor bit. */
++    __set_bit(X86_FEATURE_HYPERVISOR, fs);
++
++    /*
++     * If IBRS is offered to the guest, unconditionally offer STIBP.  It is a
++     * nop on non-HT hardware, and has this behaviour to make heterogeneous
++     * setups easier to manage.
++     */
++    if ( test_bit(X86_FEATURE_IBRSB, fs) )
++        __set_bit(X86_FEATURE_STIBP, fs);
++
++    /*
++     * On hardware which supports IBRS/IBPB, we can offer IBPB independently
++     * of IBRS by using the AMD feature bit.  An administrator may wish for
++     * performance reasons to offer IBPB without IBRS.
++     */
++    if ( boot_cpu_has(X86_FEATURE_IBRSB) )
++        __set_bit(X86_FEATURE_IBPB, fs);
++}
++
+ static void __init calculate_pv_max_policy(void)
+ {
+     struct cpuid_policy *p = &pv_max_policy;
+@@ -386,18 +408,14 @@ static void __init calculate_pv_max_poli
+     for ( i = 0; i < ARRAY_SIZE(pv_featureset); ++i )
+         pv_featureset[i] &= pv_featuremask[i];
+ 
+-    /* Unconditionally claim to be able to set the hypervisor bit. */
+-    __set_bit(X86_FEATURE_HYPERVISOR, pv_featureset);
+-
+-    /* On hardware with IBRS/IBPB support, there are further adjustments. */
+-    if ( test_bit(X86_FEATURE_IBRSB, pv_featureset) )
+-    {
+-        /* Offer STIBP unconditionally.  It is a nop on non-HT hardware. */
+-        __set_bit(X86_FEATURE_STIBP, pv_featureset);
++    /*
++     * If Xen isn't virtualising MSR_SPEC_CTRL for PV guests because of
++     * administrator choice, hide the feature.
++     */
++    if ( !boot_cpu_has(X86_FEATURE_SC_MSR_PV) )
++        __clear_bit(X86_FEATURE_IBRSB, pv_featureset);
+ 
+-        /* AMD's IBPB is a subset of IBRS/IBPB. */
+-        __set_bit(X86_FEATURE_IBPB, pv_featureset);
+-    }
++    guest_common_feature_adjustments(pv_featureset);
+ 
+     sanitise_featureset(pv_featureset);
+     cpuid_featureset_to_policy(pv_featureset, p);
+@@ -425,9 +443,6 @@ static void __init calculate_hvm_max_pol
+     for ( i = 0; i < ARRAY_SIZE(hvm_featureset); ++i )
+         hvm_featureset[i] &= hvm_featuremask[i];
+ 
+-    /* Unconditionally claim to be able to set the hypervisor bit. */
+-    __set_bit(X86_FEATURE_HYPERVISOR, hvm_featureset);
+-
+     /*
+      * Xen can provide an APIC emulation to HVM guests even if the host's APIC
+      * isn't enabled.
+@@ -443,6 +458,13 @@ static void __init calculate_hvm_max_pol
+         __set_bit(X86_FEATURE_SEP, hvm_featureset);
+ 
+     /*
++     * If Xen isn't virtualising MSR_SPEC_CTRL for HVM guests because of
++     * administrator choice, hide the feature.
++     */
++    if ( !boot_cpu_has(X86_FEATURE_SC_MSR_HVM) )
++        __clear_bit(X86_FEATURE_IBRSB, hvm_featureset);
++
++    /*
+      * With VT-x, some features are only supported by Xen if dedicated
+      * hardware support is also available.
+      */
+@@ -455,15 +477,7 @@ static void __init calculate_hvm_max_pol
+             __clear_bit(X86_FEATURE_XSAVES, hvm_featureset);
+     }
+ 
+-    /* On hardware with IBRS/IBPB support, there are further adjustments. */
+-    if ( test_bit(X86_FEATURE_IBRSB, hvm_featureset) )
+-    {
+-        /* Offer STIBP unconditionally.  It is a nop on non-HT hardware. */
+-        __set_bit(X86_FEATURE_STIBP, hvm_featureset);
+-
+-        /* AMD's IBPB is a subset of IBRS/IBPB. */
+-        __set_bit(X86_FEATURE_IBPB, hvm_featureset);
+-    }
++    guest_common_feature_adjustments(hvm_featureset);
+ 
+     sanitise_featureset(hvm_featureset);
+     cpuid_featureset_to_policy(hvm_featureset, p);

--- a/recipes-extended/xen/files/xsa263-4.9/0010-x86-spec_ctrl-Introduce-a-new-spec-ctrl-command-line.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0010-x86-spec_ctrl-Introduce-a-new-spec-ctrl-command-line.patch
@@ -1,0 +1,337 @@
+From 128146fcee77e9f27262dda89620f20f7386cd04 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 26 Apr 2018 10:52:55 +0100
+Subject: [PATCH] x86/spec_ctrl: Introduce a new `spec-ctrl=` command line
+ argument to replace `bti=`
+
+In hindsight, the options for `bti=` aren't as flexible or useful as expected
+(including several options which don't appear to behave as intended).
+Changing the behaviour of an existing option is problematic for compatibility,
+so introduce a new `spec-ctrl=` in the hopes that we can do better.
+
+One common way of deploying Xen is with a single PV dom0 and all domUs being
+HVM domains.  In such a setup, an administrator who has weighed up the risks
+may wish to forgo protection against malicious PV domains, to reduce the
+overall performance hit.  To cater for this usecase, `spec-ctrl=no-pv` will
+disable all speculative protection for PV domains, while leaving all
+speculative protection for HVM domains intact.
+
+For coding clarity as much as anything else, the suboptions are grouped by
+logical area; those which affect the alternatives blocks, and those which
+affect Xen's in-hypervisor settings.  See the xen-command-line.markdown for
+full details of the new options.
+
+While changing the command line options, take the time to change how the data
+is reported to the user.  The three DEBUG printks are upgraded to unilateral,
+as they are all relevant pieces of information, and the old "mitigations:"
+line is split in the two logical areas described above.
+
+Sample output from booting with `spec-ctrl=no-pv` looks like:
+
+  (XEN) Speculative mitigation facilities:
+  (XEN)   Hardware features: IBRS/IBPB STIBP IBPB
+  (XEN)   Compiled-in support: INDIRECT_THUNK
+  (XEN)   Xen settings: BTI-Thunk RETPOLINE, SPEC_CTRL: IBRS-, Other: IBPB
+  (XEN)   Support for VMs: PV: None, HVM: MSR_SPEC_CTRL RSB
+  (XEN)   XPTI (64-bit PV only): Dom0 enabled, DomU enabled
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Wei Liu <wei.liu2@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-acked-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit 3352afc26c497d26ecb70527db3cb29daf7b1422)
+---
+ docs/misc/xen-command-line.markdown |  49 +++++++++++
+ xen/arch/x86/spec_ctrl.c            | 160 ++++++++++++++++++++++++++++++------
+ 2 files changed, 186 insertions(+), 23 deletions(-)
+
+--- a/docs/misc/xen-command-line.markdown
++++ b/docs/misc/xen-command-line.markdown
+@@ -255,6 +255,9 @@ the NMI watchdog is also enabled.
+ ### bti (x86)
+ > `= List of [ thunk=retpoline|lfence|jmp, ibrs=<bool>, ibpb=<bool>, rsb_{vmexit,native}=<bool> ]`
+ 
++**WARNING: This command line option is deprecated, and superseded by
++_spec-ctrl=_ - using both options in combination is undefined.**
++
+ Branch Target Injection controls.  By default, Xen will pick the most
+ appropriate BTI mitigations based on compiled in support, loaded microcode,
+ and hardware details.
+@@ -1606,6 +1609,52 @@ enforces the maximum theoretically neces
+ is being interpreted as a custom timeout in milliseconds. Zero or boolean
+ false disable the quirk workaround, which is also the default.
+ 
++### spec-ctrl (x86)
++> `= List of [ <bool>, xen=<bool>, {pv,hvm,msr-sc,rsb}=<bool>,
++>              bti-thunk=retpoline|lfence|jmp, {ibrs,ibpb}=<bool> ]`
++
++Controls for speculative execution sidechannel mitigations.  By default, Xen
++will pick the most appropriate mitigations based on compiled in support,
++loaded microcode, and hardware details, and will virtualise appropriate
++mitigations for guests to use.
++
++**WARNING: Any use of this option may interfere with heuristics.  Use with
++extreme care.**
++
++An overall boolean value, `spec-ctrl=no`, can be specified to turn off all
++mitigations, including pieces of infrastructure used to virtualise certain
++mitigation features for guests.  Alternatively, a slightly more restricted
++`spec-ctrl=no-xen` can be used to turn off all of Xen's mitigations, while
++leaving the virtualisation support in place for guests to use.  Use of a
++positive boolean value for either of these options is invalid.
++
++The booleans `pv=`, `hvm=`, `msr-sc=` and `rsb=` offer fine grained control
++over the alternative blocks used by Xen.  These impact Xen's ability to
++protect itself, and Xen's ability to virtualise support for guests to use.
++
++* `pv=` and `hvm=` offer control over all suboptions for PV and HVM guests
++  respectively.
++* `msr-sc=` offers control over Xen's support for manipulating MSR\_SPEC\_CTRL
++  on entry and exit.  These blocks are necessary to virtualise support for
++  guests and if disabled, guests will be unable to use IBRS/STIBP/etc.
++* `rsb=` offers control over whether to overwrite the Return Stack Buffer /
++  Return Address Stack on entry to Xen.
++
++If Xen was compiled with INDIRECT\_THUNK support, `bti-thunk=` can be used to
++select which of the thunks gets patched into the `__x86_indirect_thunk_%reg`
++locations.  The default thunk is `retpoline` (generally preferred for Intel
++hardware), with the alternatives being `jmp` (a `jmp *%reg` gadget, minimal
++overhead), and `lfence` (an `lfence; jmp *%reg` gadget, preferred for AMD).
++
++On hardware supporting IBRS (Indirect Branch Restricted Speculation), the
++`ibrs=` option can be used to force or prevent Xen using the feature itself.
++If Xen is not using IBRS itself, functionality is still set up so IBRS can be
++virtualised for guests.
++
++On hardware supporting IBPB (Indirect Branch Prediction Barrier), the `ibpb=`
++option can be used to force (the default) or prevent Xen from issuing branch
++prediction barriers on vcpu context switches.
++
+ ### sync\_console
+ > `= <boolean>`
+ 
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -26,6 +26,13 @@
+ #include <asm/spec_ctrl.h>
+ #include <asm/spec_ctrl_asm.h>
+ 
++/* Cmdline controls for Xen's alternative blocks. */
++static bool __initdata opt_msr_sc_pv = true;
++static bool __initdata opt_msr_sc_hvm = true;
++static bool __initdata opt_rsb_pv = true;
++static bool __initdata opt_rsb_hvm = true;
++
++/* Cmdline controls for Xen's speculative settings. */
+ static enum ind_thunk {
+     THUNK_DEFAULT, /* Decide which thunk to use at boot time. */
+     THUNK_NONE,    /* Missing compiler support for thunks. */
+@@ -35,8 +42,6 @@ static enum ind_thunk {
+     THUNK_JMP,
+ } opt_thunk __initdata = THUNK_DEFAULT;
+ static int8_t __initdata opt_ibrs = -1;
+-static bool __initdata opt_rsb_pv = true;
+-static bool __initdata opt_rsb_hvm = true;
+ bool __read_mostly opt_ibpb = true;
+ 
+ bool __initdata bsp_delay_spec_ctrl;
+@@ -84,8 +89,95 @@ static int __init parse_bti(const char *
+ }
+ custom_param("bti", parse_bti);
+ 
++static int __init parse_spec_ctrl(const char *s)
++{
++    const char *ss;
++    int val, rc = 0;
++
++    do {
++        ss = strchr(s, ',');
++        if ( !ss )
++            ss = strchr(s, '\0');
++
++        /* Global and Xen-wide disable. */
++        val = parse_bool(s);
++        if ( !val )
++        {
++            opt_msr_sc_pv = false;
++            opt_msr_sc_hvm = false;
++
++        disable_common:
++            opt_rsb_pv = false;
++            opt_rsb_hvm = false;
++
++            opt_thunk = THUNK_JMP;
++            opt_ibrs = 0;
++            opt_ibpb = false;
++        }
++        else if ( val > 0 )
++            rc = -EINVAL;
++        else if ( (val = parse_boolean("xen", s, ss)) >= 0 )
++        {
++            if ( !val )
++                goto disable_common;
++
++            rc = -EINVAL;
++        }
++
++        /* Xen's alternative blocks. */
++        else if ( (val = parse_boolean("pv", s, ss)) >= 0 )
++        {
++            opt_msr_sc_pv = val;
++            opt_rsb_pv = val;
++        }
++        else if ( (val = parse_boolean("hvm", s, ss)) >= 0 )
++        {
++            opt_msr_sc_hvm = val;
++            opt_rsb_hvm = val;
++        }
++        else if ( (val = parse_boolean("msr-sc", s, ss)) >= 0 )
++        {
++            opt_msr_sc_pv = val;
++            opt_msr_sc_hvm = val;
++        }
++        else if ( (val = parse_boolean("rsb", s, ss)) >= 0 )
++        {
++            opt_rsb_pv = val;
++            opt_rsb_hvm = val;
++        }
++
++        /* Xen's speculative sidechannel mitigation settings. */
++        else if ( !strncmp(s, "bti-thunk=", 10) )
++        {
++            s += 10;
++
++            if ( !strncmp(s, "retpoline", ss - s) )
++                opt_thunk = THUNK_RETPOLINE;
++            else if ( !strncmp(s, "lfence", ss - s) )
++                opt_thunk = THUNK_LFENCE;
++            else if ( !strncmp(s, "jmp", ss - s) )
++                opt_thunk = THUNK_JMP;
++            else
++                rc = -EINVAL;
++        }
++        else if ( (val = parse_boolean("ibrs", s, ss)) >= 0 )
++            opt_ibrs = val;
++        else if ( (val = parse_boolean("ibpb", s, ss)) >= 0 )
++            opt_ibpb = val;
++        else
++            rc = -EINVAL;
++
++        s = ss + 1;
++    } while ( *ss );
++
++    return rc;
++}
++custom_param("spec-ctrl", parse_spec_ctrl);
++
+ static void __init print_details(enum ind_thunk thunk, uint64_t caps)
+ {
++    bool use_spec_ctrl = (boot_cpu_has(X86_FEATURE_SC_MSR_PV) ||
++                          boot_cpu_has(X86_FEATURE_SC_MSR_HVM));
+     unsigned int _7d0 = 0, e8b = 0, tmp;
+ 
+     /* Collect diagnostics about available mitigations. */
+@@ -94,10 +186,10 @@ static void __init print_details(enum in
+     if ( boot_cpu_data.extended_cpuid_level >= 0x80000008 )
+         cpuid(0x80000008, &tmp, &e8b, &tmp, &tmp);
+ 
+-    printk(XENLOG_DEBUG "Speculative mitigation facilities:\n");
++    printk("Speculative mitigation facilities:\n");
+ 
+     /* Hardware features which pertain to speculative mitigations. */
+-    printk(XENLOG_DEBUG "  Hardware features:%s%s%s%s%s%s\n",
++    printk("  Hardware features:%s%s%s%s%s%s\n",
+            (_7d0 & cpufeat_mask(X86_FEATURE_IBRSB)) ? " IBRS/IBPB" : "",
+            (_7d0 & cpufeat_mask(X86_FEATURE_STIBP)) ? " STIBP"     : "",
+            (e8b  & cpufeat_mask(X86_FEATURE_IBPB))  ? " IBPB"      : "",
+@@ -107,20 +199,31 @@ static void __init print_details(enum in
+ 
+     /* Compiled-in support which pertains to BTI mitigations. */
+     if ( IS_ENABLED(CONFIG_INDIRECT_THUNK) )
+-        printk(XENLOG_DEBUG "  Compiled-in support: INDIRECT_THUNK\n");
++        printk("  Compiled-in support: INDIRECT_THUNK\n");
+ 
+-    printk("BTI mitigations: Thunk %s, Others:%s%s%s%s\n",
++    /* Settings for Xen's protection, irrespective of guests. */
++    printk("  Xen settings: BTI-Thunk %s, SPEC_CTRL: %s, Other:%s\n",
+            thunk == THUNK_NONE      ? "N/A" :
+            thunk == THUNK_RETPOLINE ? "RETPOLINE" :
+            thunk == THUNK_LFENCE    ? "LFENCE" :
+            thunk == THUNK_JMP       ? "JMP" : "?",
++           !use_spec_ctrl                            ?  "No" :
++           (default_xen_spec_ctrl & SPEC_CTRL_IBRS)  ?  "IBRS+" :  "IBRS-",
++           opt_ibpb                                  ? " IBPB"  : "");
++
++    /*
++     * Alternatives blocks for protecting against and/or virtualising
++     * mitigation support for guests.
++     */
++    printk("  Support for VMs: PV:%s%s%s, HVM:%s%s%s\n",
+            (boot_cpu_has(X86_FEATURE_SC_MSR_PV) ||
+-            boot_cpu_has(X86_FEATURE_SC_MSR_HVM)) ?
+-           default_xen_spec_ctrl & SPEC_CTRL_IBRS    ? " IBRS+" :
+-                                                       " IBRS-"      : "",
+-           opt_ibpb                                  ? " IBPB"       : "",
+-           boot_cpu_has(X86_FEATURE_SC_RSB_PV)       ? " RSB_NATIVE" : "",
+-           boot_cpu_has(X86_FEATURE_SC_RSB_HVM)      ? " RSB_VMEXIT" : "");
++            boot_cpu_has(X86_FEATURE_SC_RSB_PV))     ? ""               : " None",
++           boot_cpu_has(X86_FEATURE_SC_MSR_PV)       ? " MSR_SPEC_CTRL" : "",
++           boot_cpu_has(X86_FEATURE_SC_RSB_PV)       ? " RSB"           : "",
++           (boot_cpu_has(X86_FEATURE_SC_MSR_HVM) ||
++            boot_cpu_has(X86_FEATURE_SC_RSB_HVM))    ? ""               : " None",
++           boot_cpu_has(X86_FEATURE_SC_MSR_HVM)      ? " MSR_SPEC_CTRL" : "",
++           boot_cpu_has(X86_FEATURE_SC_RSB_HVM)      ? " RSB"           : "");
+ 
+     printk("XPTI: %s\n",
+            boot_cpu_has(X86_FEATURE_NO_XPTI) ? "disabled" : "enabled");
+@@ -212,7 +315,7 @@ static bool __init retpoline_safe(uint64
+ void __init init_speculation_mitigations(void)
+ {
+     enum ind_thunk thunk = THUNK_DEFAULT;
+-    bool ibrs = false;
++    bool use_spec_ctrl = false, ibrs = false;
+     uint64_t caps = 0;
+ 
+     if ( boot_cpu_has(X86_FEATURE_ARCH_CAPS) )
+@@ -282,20 +385,31 @@ void __init init_speculation_mitigations
+     else if ( thunk == THUNK_JMP )
+         setup_force_cpu_cap(X86_FEATURE_IND_THUNK_JMP);
+ 
++    /*
++     * If we are on hardware supporting MSR_SPEC_CTRL, see about setting up
++     * the alternatives blocks so we can virtualise support for guests.
++     */
+     if ( boot_cpu_has(X86_FEATURE_IBRSB) )
+     {
+-        /*
+-         * Even if we've chosen to not have IBRS set in Xen context, we still
+-         * need the IBRS entry/exit logic to virtualise IBRS support for
+-         * guests.
+-         */
+-        setup_force_cpu_cap(X86_FEATURE_SC_MSR_PV);
+-        setup_force_cpu_cap(X86_FEATURE_SC_MSR_HVM);
++        if ( opt_msr_sc_pv )
++        {
++            use_spec_ctrl = true;
++            setup_force_cpu_cap(X86_FEATURE_SC_MSR_PV);
++        }
+ 
+-        if ( ibrs )
+-            default_xen_spec_ctrl |= SPEC_CTRL_IBRS;
++        if ( opt_msr_sc_hvm )
++        {
++            use_spec_ctrl = true;
++            setup_force_cpu_cap(X86_FEATURE_SC_MSR_HVM);
++        }
++
++        if ( use_spec_ctrl )
++        {
++            if ( ibrs )
++                default_xen_spec_ctrl |= SPEC_CTRL_IBRS;
+ 
+-        default_spec_ctrl_flags |= SCF_ist_wrmsr;
++            default_spec_ctrl_flags |= SCF_ist_wrmsr;
++        }
+     }
+ 
+     /*

--- a/recipes-extended/xen/files/xsa263-4.9/0011-x86-AMD-Mitigations-for-GPZ-SP4-Speculative-Store-By.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0011-x86-AMD-Mitigations-for-GPZ-SP4-Speculative-Store-By.patch
@@ -1,0 +1,112 @@
+From 21c05fe06fb62aea7f29d4d216b8ab623754ae98 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 26 Apr 2018 10:56:28 +0100
+Subject: [PATCH] x86/AMD: Mitigations for GPZ SP4 - Speculative Store Bypass
+
+AMD processors will execute loads and stores with the same base register in
+program order, which is typically how a compiler emits code.
+
+Therefore, by default no mitigating actions are taken, despite there being
+corner cases which are vulnerable to the issue.
+
+For performance testing, or for users with particularly sensitive workloads,
+the `spec-ctrl=ssbd` command line option is available to force Xen to disable
+Memory Disambiguation on applicable hardware.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ docs/misc/xen-command-line.markdown |  7 ++++++-
+ xen/arch/x86/cpu/amd.c              | 20 ++++++++++++++++++++
+ xen/arch/x86/spec_ctrl.c            |  3 +++
+ xen/include/asm-x86/spec_ctrl.h     |  1 +
+ 4 files changed, 30 insertions(+), 1 deletion(-)
+
+--- a/docs/misc/xen-command-line.markdown
++++ b/docs/misc/xen-command-line.markdown
+@@ -1611,7 +1611,7 @@ false disable the quirk workaround, whic
+ 
+ ### spec-ctrl (x86)
+ > `= List of [ <bool>, xen=<bool>, {pv,hvm,msr-sc,rsb}=<bool>,
+->              bti-thunk=retpoline|lfence|jmp, {ibrs,ibpb}=<bool> ]`
++>              bti-thunk=retpoline|lfence|jmp, {ibrs,ibpb,ssbd}=<bool> ]`
+ 
+ Controls for speculative execution sidechannel mitigations.  By default, Xen
+ will pick the most appropriate mitigations based on compiled in support,
+@@ -1655,6 +1655,11 @@ On hardware supporting IBPB (Indirect Br
+ option can be used to force (the default) or prevent Xen from issuing branch
+ prediction barriers on vcpu context switches.
+ 
++On hardware supporting SSBD (Speculative Store Bypass Disable), the `ssbd=`
++option can be used to force or prevent Xen using the feature itself.  On AMD
++hardware, this is a global option applied at boot, and not virtualised for
++guest use.
++
+ ### sync\_console
+ > `= <boolean>`
+ 
+--- a/xen/arch/x86/cpu/amd.c
++++ b/xen/arch/x86/cpu/amd.c
+@@ -9,6 +9,7 @@
+ #include <asm/amd.h>
+ #include <asm/hvm/support.h>
+ #include <asm/setup.h> /* amd_init_cpu */
++#include <asm/spec_ctrl.h>
+ #include <asm/acpi.h>
+ #include <asm/apic.h>
+ 
+@@ -590,6 +591,25 @@ static void init_amd(struct cpuinfo_x86
+ 				  c->x86_capability);
+ 	}
+ 
++	/*
++	 * If the user has explicitly chosen to disable Memory Disambiguation
++	 * to mitigiate Speculative Store Bypass, poke the appropriate MSR.
++	 */
++	if (opt_ssbd) {
++		int bit = -1;
++
++		switch (c->x86) {
++		case 0x15: bit = 54; break;
++		case 0x16: bit = 33; break;
++		case 0x17: bit = 10; break;
++		}
++
++		if (bit >= 0 && !rdmsr_safe(MSR_AMD64_LS_CFG, value)) {
++			value |= 1ull << bit;
++			wrmsr_safe(MSR_AMD64_LS_CFG, value);
++		}
++	}
++
+ 	/* MFENCE stops RDTSC speculation */
+ 	if (!cpu_has_lfence_dispatch)
+ 		__set_bit(X86_FEATURE_MFENCE_RDTSC, c->x86_capability);
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -43,6 +43,7 @@ static enum ind_thunk {
+ } opt_thunk __initdata = THUNK_DEFAULT;
+ static int8_t __initdata opt_ibrs = -1;
+ bool __read_mostly opt_ibpb = true;
++bool __read_mostly opt_ssbd = false;
+ 
+ bool __initdata bsp_delay_spec_ctrl;
+ uint8_t __read_mostly default_xen_spec_ctrl;
+@@ -164,6 +165,8 @@ static int __init parse_spec_ctrl(const
+             opt_ibrs = val;
+         else if ( (val = parse_boolean("ibpb", s, ss)) >= 0 )
+             opt_ibpb = val;
++        else if ( (val = parse_boolean("ssbd", s, ss)) >= 0 )
++            opt_ssbd = val;
+         else
+             rc = -EINVAL;
+ 
+--- a/xen/include/asm-x86/spec_ctrl.h
++++ b/xen/include/asm-x86/spec_ctrl.h
+@@ -27,6 +27,7 @@
+ void init_speculation_mitigations(void);
+ 
+ extern bool opt_ibpb;
++extern bool opt_ssbd;
+ 
+ extern bool bsp_delay_spec_ctrl;
+ extern uint8_t default_xen_spec_ctrl;

--- a/recipes-extended/xen/files/xsa263-4.9/0012-x86-Intel-Mitigations-for-GPZ-SP4-Speculative-Store-.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0012-x86-Intel-Mitigations-for-GPZ-SP4-Speculative-Store-.patch
@@ -1,0 +1,205 @@
+From 55325566b3a14167501fd0cb045d6343b17b6946 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Wed, 28 Mar 2018 15:21:39 +0100
+Subject: [PATCH] x86/Intel: Mitigations for GPZ SP4 - Speculative Store Bypass
+
+To combat GPZ SP4 "Speculative Store Bypass", Intel have extended their
+speculative sidechannel mitigations specification as follows:
+
+ * A feature bit to indicate that Speculative Store Bypass Disable is
+   supported.
+ * A new bit in MSR_SPEC_CTRL which, when set, disables memory disambiguation
+   in the pipeline.
+ * A new bit in MSR_ARCH_CAPABILITIES, which will be set in future hardware,
+   indicating that the hardware is not susceptible to Speculative Store Bypass
+   sidechannels.
+
+For contemporary processors, this interface will be implemented via a
+microcode update.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ docs/misc/xen-command-line.markdown         | 12 +++++++-----
+ tools/libxl/libxl_cpuid.c                   |  1 +
+ tools/misc/xen-cpuid.c                      |  3 +--
+ xen/arch/x86/cpuid.c                        |  5 +++++
+ xen/arch/x86/spec_ctrl.c                    | 15 ++++++++++++---
+ xen/include/asm-x86/msr-index.h             |  2 ++
+ xen/include/public/arch-x86/cpufeatureset.h |  1 +
+ xen/tools/gen-cpuid.py                      | 17 +++++++++++++----
+ 8 files changed, 42 insertions(+), 14 deletions(-)
+
+--- a/docs/misc/xen-command-line.markdown
++++ b/docs/misc/xen-command-line.markdown
+@@ -456,9 +456,10 @@ accounting for hardware capabilities as
+ 
+ Currently accepted:
+ 
+-The Speculation Control hardware features `ibrsb`, `stibp`, `ibpb` are used by
+-default if avaiable.  They can be ignored, e.g. `no-ibrsb`, at which point Xen
+-won't use them itself, and won't offer them to guests.
++The Speculation Control hardware features `ibrsb`, `stibp`, `ibpb`, `ssbd` are
++used by default if available and applicable.  They can be ignored,
++e.g. `no-ibrsb`, at which point Xen won't use them itself, and won't offer
++them to guests.
+ 
+ ### cpuid\_mask\_cpu (AMD only)
+ > `= fam_0f_rev_c | fam_0f_rev_d | fam_0f_rev_e | fam_0f_rev_f | fam_0f_rev_g | fam_10_rev_b | fam_10_rev_c | fam_11_rev_b`
+@@ -1636,7 +1637,7 @@ protect itself, and Xen's ability to vir
+   respectively.
+ * `msr-sc=` offers control over Xen's support for manipulating MSR\_SPEC\_CTRL
+   on entry and exit.  These blocks are necessary to virtualise support for
+-  guests and if disabled, guests will be unable to use IBRS/STIBP/etc.
++  guests and if disabled, guests will be unable to use IBRS/STIBP/SSBD/etc.
+ * `rsb=` offers control over whether to overwrite the Return Stack Buffer /
+   Return Address Stack on entry to Xen.
+ 
+@@ -1658,7 +1659,8 @@ prediction barriers on vcpu context swit
+ On hardware supporting SSBD (Speculative Store Bypass Disable), the `ssbd=`
+ option can be used to force or prevent Xen using the feature itself.  On AMD
+ hardware, this is a global option applied at boot, and not virtualised for
+-guest use.
++guest use.  On Intel hardware, the feature is virtualised for guests,
++independently of Xen's choice of setting.
+ 
+ ### sync\_console
+ > `= <boolean>`
+--- a/tools/libxl/libxl_cpuid.c
++++ b/tools/libxl/libxl_cpuid.c
+@@ -161,6 +161,7 @@ int libxl_cpuid_parse_config(libxl_cpuid
+         {"ibrsb",        0x00000007,  0, CPUID_REG_EDX, 26,  1},
+         {"stibp",        0x00000007,  0, CPUID_REG_EDX, 27,  1},
+         {"arch-caps",    0x00000007,  0, CPUID_REG_EDX, 29,  1},
++        {"ssbd",         0x00000007,  0, CPUID_REG_EDX, 31,  1},
+         {"topoext",      0x80000001, NA, CPUID_REG_ECX, 22,  1},
+         {"tbm",          0x80000001, NA, CPUID_REG_ECX, 21,  1},
+         {"nodeid",       0x80000001, NA, CPUID_REG_ECX, 19,  1},
+--- a/tools/misc/xen-cpuid.c
++++ b/tools/misc/xen-cpuid.c
+@@ -161,8 +161,7 @@ static const char *str_7d0[32] =
+ 
+     [26] = "ibrsb",         [27] = "stibp",
+     [28] = "REZ",           [29] = "arch_caps",
+-
+-    [30 ... 31] = "REZ",
++    [30] = "REZ",           [31] = "ssbd",
+ };
+ 
+ static struct {
+--- a/xen/arch/x86/cpuid.c
++++ b/xen/arch/x86/cpuid.c
+@@ -43,6 +43,11 @@ static int __init parse_xen_cpuid(const
+             if ( !val )
+                 setup_clear_cpu_cap(X86_FEATURE_STIBP);
+         }
++        else if ( (val = parse_boolean("ssbd", s, ss)) >= 0 )
++        {
++            if ( !val )
++                setup_clear_cpu_cap(X86_FEATURE_SSBD);
++        }
+         else
+             rc = -EINVAL;
+ 
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -192,26 +192,31 @@ static void __init print_details(enum in
+     printk("Speculative mitigation facilities:\n");
+ 
+     /* Hardware features which pertain to speculative mitigations. */
+-    printk("  Hardware features:%s%s%s%s%s%s\n",
++    printk("  Hardware features:%s%s%s%s%s%s%s%s\n",
+            (_7d0 & cpufeat_mask(X86_FEATURE_IBRSB)) ? " IBRS/IBPB" : "",
+            (_7d0 & cpufeat_mask(X86_FEATURE_STIBP)) ? " STIBP"     : "",
++           (_7d0 & cpufeat_mask(X86_FEATURE_SSBD))  ? " SSBD"      : "",
+            (e8b  & cpufeat_mask(X86_FEATURE_IBPB))  ? " IBPB"      : "",
+            (caps & ARCH_CAPABILITIES_IBRS_ALL)      ? " IBRS_ALL"  : "",
+            (caps & ARCH_CAPABILITIES_RDCL_NO)       ? " RDCL_NO"   : "",
+-           (caps & ARCH_CAPS_RSBA)                  ? " RSBA"      : "");
++           (caps & ARCH_CAPS_RSBA)                  ? " RSBA"      : "",
++           (caps & ARCH_CAPS_SSB_NO)                ? " SSB_NO"    : "");
+ 
+     /* Compiled-in support which pertains to BTI mitigations. */
+     if ( IS_ENABLED(CONFIG_INDIRECT_THUNK) )
+         printk("  Compiled-in support: INDIRECT_THUNK\n");
+ 
+     /* Settings for Xen's protection, irrespective of guests. */
+-    printk("  Xen settings: BTI-Thunk %s, SPEC_CTRL: %s, Other:%s\n",
++    printk("  Xen settings: BTI-Thunk %s, SPEC_CTRL: %s%s, Other:%s\n",
+            thunk == THUNK_NONE      ? "N/A" :
+            thunk == THUNK_RETPOLINE ? "RETPOLINE" :
+            thunk == THUNK_LFENCE    ? "LFENCE" :
+            thunk == THUNK_JMP       ? "JMP" : "?",
+            !use_spec_ctrl                            ?  "No" :
+            (default_xen_spec_ctrl & SPEC_CTRL_IBRS)  ?  "IBRS+" :  "IBRS-",
++           !use_spec_ctrl || !boot_cpu_has(X86_FEATURE_SSBD)
++                                                     ? "" :
++           (default_xen_spec_ctrl & SPEC_CTRL_SSBD)  ? " SSBD+" : " SSBD-",
+            opt_ibpb                                  ? " IBPB"  : "");
+ 
+     /*
+@@ -415,6 +420,10 @@ void __init init_speculation_mitigations
+         }
+     }
+ 
++    /* If we have SSBD available, see whether we should use it. */
++    if ( boot_cpu_has(X86_FEATURE_SSBD) && use_spec_ctrl && opt_ssbd )
++        default_xen_spec_ctrl |= SPEC_CTRL_SSBD;
++
+     /*
+      * PV guests can poison the RSB to any virtual address from which
+      * they can execute a call instruction.  This is necessarily outside
+--- a/xen/include/asm-x86/msr-index.h
++++ b/xen/include/asm-x86/msr-index.h
+@@ -38,6 +38,7 @@
+ #define MSR_SPEC_CTRL			0x00000048
+ #define SPEC_CTRL_IBRS			(_AC(1, ULL) << 0)
+ #define SPEC_CTRL_STIBP			(_AC(1, ULL) << 1)
++#define SPEC_CTRL_SSBD			(_AC(1, ULL) << 2)
+ 
+ #define MSR_PRED_CMD			0x00000049
+ #define PRED_CMD_IBPB			(_AC(1, ULL) << 0)
+@@ -46,6 +47,7 @@
+ #define ARCH_CAPABILITIES_RDCL_NO	(_AC(1, ULL) << 0)
+ #define ARCH_CAPABILITIES_IBRS_ALL	(_AC(1, ULL) << 1)
+ #define ARCH_CAPS_RSBA			(_AC(1, ULL) << 2)
++#define ARCH_CAPS_SSB_NO		(_AC(1, ULL) << 4)
+ 
+ /* Intel MSRs. Some also available on other CPUs */
+ #define MSR_IA32_PERFCTR0		0x000000c1
+--- a/xen/include/public/arch-x86/cpufeatureset.h
++++ b/xen/include/public/arch-x86/cpufeatureset.h
+@@ -244,6 +244,7 @@ XEN_CPUFEATURE(AVX512_4FMAPS, 9*32+ 3) /
+ XEN_CPUFEATURE(IBRSB,         9*32+26) /*A  IBRS and IBPB support (used by Intel) */
+ XEN_CPUFEATURE(STIBP,         9*32+27) /*A! STIBP */
+ XEN_CPUFEATURE(ARCH_CAPS,     9*32+29) /*   IA32_ARCH_CAPABILITIES MSR */
++XEN_CPUFEATURE(SSBD,          9*32+31) /*   MSR_SPEC_CTRL.SSBD available */
+ 
+ #endif /* XEN_CPUFEATURE */
+ 
+--- a/xen/tools/gen-cpuid.py
++++ b/xen/tools/gen-cpuid.py
+@@ -257,10 +257,19 @@ def crunch_numbers(state):
+                   AVX512BW, AVX512VL, AVX512VBMI, AVX512_4VNNIW,
+                   AVX512_4FMAPS, AVX512_VPOPCNTDQ],
+ 
+-        # Single Thread Indirect Branch Predictors enumerates a new bit in the
+-        # MSR enumerated by Indirect Branch Restricted Speculation/Indirect
+-        # Branch Prediction Barrier enumeration.
+-        IBRSB: [STIBP],
++        # The features:
++        #   * Single Thread Indirect Branch Predictors
++        #   * Speculative Store Bypass Disable
++        #
++        # enumerate new bits in MSR_SPEC_CTRL, which is enumerated by Indirect
++        # Branch Restricted Speculation/Indirect Branch Prediction Barrier.
++        #
++        # In practice, these features also enumerate the presense of
++        # MSR_SPEC_CTRL.  However, no real hardware will exist with SSBD but
++        # not IBRSB, and we pass this MSR directly to guests.  Treating them
++        # as dependent features simplifies Xen's logic, and prevents the guest
++        # from seeing implausible configurations.
++        IBRSB: [STIBP, SSBD],
+     }
+ 
+     deep_features = tuple(sorted(deps.keys()))

--- a/recipes-extended/xen/files/xsa263-4.9/0013-x86-msr-Virtualise-MSR_SPEC_CTRL.SSBD-for-guests-to-.patch
+++ b/recipes-extended/xen/files/xsa263-4.9/0013-x86-msr-Virtualise-MSR_SPEC_CTRL.SSBD-for-guests-to-.patch
@@ -1,0 +1,64 @@
+From 76da4cf6ec259ffa43b83af75e19cdf289e5731e Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Fri, 13 Apr 2018 15:42:34 +0000
+Subject: [PATCH] x86/msr: Virtualise MSR_SPEC_CTRL.SSBD for guests to use
+
+Almost all infrastructure is already in place.  Update the reserved bits
+calculation in guest_wrmsr(), and offer SSBD to guests by default.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/domctl.c                       | 3 ++-
+ xen/arch/x86/hvm/hvm.c                      | 3 ++-
+ xen/arch/x86/traps.c                        | 3 ++-
+ xen/include/public/arch-x86/cpufeatureset.h | 2 +-
+ 4 files changed, 7 insertions(+), 4 deletions(-)
+
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -1408,7 +1408,8 @@ long arch_do_domctl(
+                      * ignored) when STIBP isn't enumerated in hardware.
+                      */
+ 
+-                    if ( msr.value & ~(SPEC_CTRL_IBRS | SPEC_CTRL_STIBP) )
++                    if ( msr.value & ~(SPEC_CTRL_IBRS | SPEC_CTRL_STIBP |
++                                       (d->arch.cpuid->feat.ssbd ? SPEC_CTRL_SSBD : 0)) )
+                         break;
+                     v->arch.spec_ctrl = msr.value;
+                     continue;
+--- a/xen/arch/x86/hvm/hvm.c
++++ b/xen/arch/x86/hvm/hvm.c
+@@ -3619,7 +3619,8 @@ int hvm_msr_write_intercept(unsigned int
+          * when STIBP isn't enumerated in hardware.
+          */
+ 
+-        if ( msr_content & ~(SPEC_CTRL_IBRS | SPEC_CTRL_STIBP) )
++        if ( msr_content & ~(SPEC_CTRL_IBRS | SPEC_CTRL_STIBP |
++                             (d->arch.cpuid->feat.ssbd ? SPEC_CTRL_SSBD : 0)) )
+             goto gp_fault; /* Rsvd bit set? */
+ 
+         v->arch.spec_ctrl = msr_content;
+--- a/xen/arch/x86/traps.c
++++ b/xen/arch/x86/traps.c
+@@ -2858,7 +2858,8 @@ static int priv_op_write_msr(unsigned in
+          * when STIBP isn't enumerated in hardware.
+          */
+ 
+-        if ( val & ~(SPEC_CTRL_IBRS | SPEC_CTRL_STIBP) )
++        if ( val & ~(SPEC_CTRL_IBRS | SPEC_CTRL_STIBP |
++                     (currd->arch.cpuid->feat.ssbd ? SPEC_CTRL_SSBD : 0)) )
+             break; /* Rsvd bit set? */
+ 
+         curr->arch.spec_ctrl = val;
+--- a/xen/include/public/arch-x86/cpufeatureset.h
++++ b/xen/include/public/arch-x86/cpufeatureset.h
+@@ -244,7 +244,7 @@ XEN_CPUFEATURE(AVX512_4FMAPS, 9*32+ 3) /
+ XEN_CPUFEATURE(IBRSB,         9*32+26) /*A  IBRS and IBPB support (used by Intel) */
+ XEN_CPUFEATURE(STIBP,         9*32+27) /*A! STIBP */
+ XEN_CPUFEATURE(ARCH_CAPS,     9*32+29) /*   IA32_ARCH_CAPABILITIES MSR */
+-XEN_CPUFEATURE(SSBD,          9*32+31) /*   MSR_SPEC_CTRL.SSBD available */
++XEN_CPUFEATURE(SSBD,          9*32+31) /*A  MSR_SPEC_CTRL.SSBD available */
+ 
+ #endif /* XEN_CPUFEATURE */
+ 

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -14,6 +14,19 @@ SRC_URI = "git://xenbits.xen.org/xen.git;branch=${XEN_BRANCH}"
 require ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', 'xen-blktap2.inc', 'xen-blktap3.inc', d)}
 
 SRC_URI_append = " \
+    file://xsa263-4.9/0001-x86-spec_ctrl-Read-MSR_ARCH_CAPABILITIES-only-once.patch \
+    file://xsa263-4.9/0002-x86-spec_ctrl-Express-Xen-s-choice-of-MSR_SPEC_CTRL-.patch \
+    file://xsa263-4.9/0003-x86-spec_ctrl-Merge-bti_ist_info-and-use_shadow_spec.patch \
+    file://xsa263-4.9/0004-x86-spec_ctrl-Fold-the-XEN_IBRS_-SET-CLEAR-ALTERNATI.patch \
+    file://xsa263-4.9/0005-x86-spec_ctrl-Rename-bits-of-infrastructure-to-avoid.patch \
+    file://xsa263-4.9/0006-x86-spec_ctrl-Elide-MSR_SPEC_CTRL-handling-in-idle-c.patch \
+    file://xsa263-4.9/0007-x86-spec_ctrl-Split-X86_FEATURE_SC_MSR-into-PV-and-H.patch \
+    file://xsa263-4.9/0008-x86-spec_ctrl-Explicitly-set-Xen-s-default-MSR_SPEC_.patch \
+    file://xsa263-4.9/0009-x86-cpuid-Improvements-to-guest-policies-for-specula.patch \
+    file://xsa263-4.9/0010-x86-spec_ctrl-Introduce-a-new-spec-ctrl-command-line.patch \
+    file://xsa263-4.9/0011-x86-AMD-Mitigations-for-GPZ-SP4-Speculative-Store-By.patch \
+    file://xsa263-4.9/0012-x86-Intel-Mitigations-for-GPZ-SP4-Speculative-Store-.patch \
+    file://xsa263-4.9/0013-x86-msr-Virtualise-MSR_SPEC_CTRL.SSBD-for-guests-to-.patch \
     file://defconfig \
     file://config.patch \
     file://disable-xen-root-check.patch \

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -1,10 +1,11 @@
 LIC_FILES_CHKSUM := "file://COPYING;md5=bbb4b1bdc2c3b6743da3c39d03249095"
 
-PV = "${XEN_VERSION}"
+require xen-version.inc
 
-SRC_URI := "${XEN_SRC_URI}"
-SRC_URI[md5sum] := "${XEN_SRC_MD5SUM}"
-SRC_URI[sha256sum] := "${XEN_SRC_SHA256SUM}"
+PV = "${XEN_PV}"
+
+SRCREV = "${XEN_SRCREV}"
+SRC_URI = "git://xenbits.xen.org/xen.git;branch=${XEN_BRANCH}"
 
 # XSA patches take precedence and belong at the head of the queue.
 # This ensures that any collisions with other patches get addressed
@@ -103,7 +104,7 @@ COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'
 PACKAGECONFIG =+ "xsm"
 PACKAGECONFIG =+ "hvm"
 
-S = "${WORKDIR}/xen-${PV}"
+S = "${WORKDIR}/git"
 
 #--
 # Override meta-virtualization's path to seabios:

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -105,8 +105,8 @@ INITSCRIPT_PARAMS_xen-xl = "defaults 21"
 
 do_configure_prepend() {
 	#remove optimizations in the config files
-	sed -i 's/-O2//g' ${WORKDIR}/xen-${XEN_VERSION}/Config.mk
-	sed -i 's/-O2//g' ${WORKDIR}/xen-${XEN_VERSION}/config/StdGNU.mk
+	sed -i 's/-O2//g' ${S}/Config.mk
+	sed -i 's/-O2//g' ${S}/config/StdGNU.mk
 }
 
 do_compile() {

--- a/recipes-extended/xen/xen-version.inc
+++ b/recipes-extended/xen/xen-version.inc
@@ -1,0 +1,3 @@
+XEN_PV = "4.9.3-pre"
+XEN_BRANCH = "stable-4.9"
+XEN_SRCREV = "74fa9552c1e3ef79bd4db0a67fc538bbd61b7561"

--- a/recipes-extended/xen/xen-xsm-policy_git.bb
+++ b/recipes-extended/xen/xen-xsm-policy_git.bb
@@ -6,7 +6,9 @@ PROVIDES = "xen-xsm-policy"
 
 S = "${WORKDIR}/git"
 
-PV = "${XEN_VERSION}+git${SRCPV}"
+require xen-version.inc
+
+PV = "${XEN_PV}+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/xsm-policy.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"


### PR DESCRIPTION
- Fetch Xen sources from the git repository at the latest revisions required to backport the latest XSA. This also add the latest XSA up to XSA-262, as well as fixes pushed to the stable branch.
- Add XSA-263 to the patch-queue until it makes its way to 4.9.3-pre, or until RELEASE-4.9.3 is tagged.

Relates to:
- https://github.com/OpenXT/openxt/pull/313