### PR TITLE
STABLE-8: customtask: python reduce was moved in functools.

### DIFF
--- a/classes/xenclient-customtask.bbclass
+++ b/classes/xenclient-customtask.bbclass
@@ -6,9 +6,11 @@ __makeclean() {
     oe_runmake clean
 }
 python do_makeclean() {
+    import functools
+
     workdir = d.getVar('B', True)
     makefiles = [ '/Makefile', '/GNUmakefile', '/makefile' ]
-    if reduce(lambda x, y: x or os.path.exists(workdir + y), makefiles, False):
+    if functools.reduce(lambda x, y: x or os.path.exists(workdir + y), makefiles, False):
         bb.build.exec_func('__makeclean', d)
         bb.build.write_taint('do_compile' , d)
         sstate_clean_cachefiles(d)


### PR DESCRIPTION
xenclient-customtask does not work with Python 3 recent versions:
https://docs.python.org/3/library/functools.html

(cherry picked from commit 1e0472694326152af785cae12999d13fc2a7f52c)
