### PR TITLE
dnsmasq: Refresh patch against new minor version.

### DIFF
--- a/recipes-support/dnsmasq/patches/dnsmasq_dnsout_interface.patch
+++ b/recipes-support/dnsmasq/patches/dnsmasq_dnsout_interface.patch
@@ -1,16 +1,14 @@
-Index: dnsmasq-2.76/src/dnsmasq.h
-===================================================================
---- dnsmasq-2.76.orig/src/dnsmasq.h
-+++ dnsmasq-2.76/src/dnsmasq.h
-@@ -519,6 +519,7 @@ struct irec {
+--- a/src/dnsmasq.h
++++ b/src/dnsmasq.h
+@@ -532,6 +532,7 @@ struct irec {
    struct in_addr netmask; /* only valid for IPv4 */
-   int tftp_ok, dhcp_ok, mtu, done, warned, dad, dns_auth, index, multicast_done, found;
+   int tftp_ok, dhcp_ok, mtu, done, warned, dad, dns_auth, index, multicast_done, found, label;
    char *name; 
 +  int idx;
    struct irec *next;
  };
  
-@@ -946,7 +947,8 @@ extern struct daemon {
+@@ -966,7 +967,8 @@ extern struct daemon {
    struct cond_domain *cond_domain, *synth_domains;
    char *runfile; 
    char *lease_change_command;
@@ -20,11 +18,9 @@ Index: dnsmasq-2.76/src/dnsmasq.h
    struct bogus_addr *bogus_addr, *ignore_addr;
    struct server *servers;
    struct ipsets *ipsets;
-Index: dnsmasq-2.76/src/network.c
-===================================================================
---- dnsmasq-2.76.orig/src/network.c
-+++ dnsmasq-2.76/src/network.c
-@@ -489,6 +489,7 @@ static int iface_allowed(struct iface_pa
+--- a/src/network.c
++++ b/src/network.c
+@@ -493,6 +493,7 @@ static int iface_allowed(struct iface_pa
  	  daemon->interfaces = iface;
  	  return 1;
  	}
@@ -32,7 +28,7 @@ Index: dnsmasq-2.76/src/network.c
        free(iface);
  
      }
-@@ -1121,6 +1122,12 @@ void join_multicast(int dienow)
+@@ -1134,6 +1135,12 @@ void join_multicast(int dienow)
  int random_sock(int family)
  {
    int fd;
@@ -45,7 +41,7 @@ Index: dnsmasq-2.76/src/network.c
  
    if ((fd = socket(family, SOCK_DGRAM, 0)) != -1)
      {
-@@ -1159,6 +1166,13 @@ int random_sock(int family)
+@@ -1172,6 +1179,13 @@ int random_sock(int family)
  #endif
  	      }
  #endif
@@ -59,19 +55,17 @@ Index: dnsmasq-2.76/src/network.c
  	    
  	    if (bind(fd, (struct sockaddr *)&addr, sa_len(&addr)) == 0)
  	      return fd;
-Index: dnsmasq-2.76/src/option.c
-===================================================================
---- dnsmasq-2.76.orig/src/option.c
-+++ dnsmasq-2.76/src/option.c
-@@ -159,6 +159,7 @@ struct myoption {
- #define LOPT_SCRIPT_ARP    347
+--- a/src/option.c
++++ b/src/option.c
+@@ -160,6 +160,7 @@ struct myoption {
  #define LOPT_DHCPTTL       348
  #define LOPT_TFTP_MTU      349
-+#define LOPT_DNSOUT_IF     350
+ #define LOPT_REPLY_DELAY   350
++#define LOPT_DNSOUT_IF     351
   
  #ifdef HAVE_GETOPT_LONG
  static const struct option opts[] =  
-@@ -189,6 +190,7 @@ static const struct myoption opts[] =
+@@ -190,6 +191,7 @@ static const struct myoption opts[] =
      { "domain", 1, 0, 's' },
      { "domain-suffix", 1, 0, 's' },
      { "interface", 1, 0, 'i' },
@@ -79,7 +73,7 @@ Index: dnsmasq-2.76/src/option.c
      { "listen-address", 1, 0, 'a' },
      { "local-service", 0, 0, LOPT_LOCAL_SERVICE },
      { "bogus-priv", 0, 0, 'b' },
-@@ -362,6 +364,7 @@ static struct {
+@@ -364,6 +366,7 @@ static struct {
    { 'H', ARG_DUP, "<path>", gettext_noop("Specify a hosts file to be read in addition to %s."), HOSTSFILE },
    { LOPT_HOST_INOTIFY, ARG_DUP, "<path>", gettext_noop("Read hosts files from a directory."), NULL },
    { 'i', ARG_DUP, "<interface>", gettext_noop("Specify interface(s) to listen on."), NULL },
@@ -87,7 +81,7 @@ Index: dnsmasq-2.76/src/option.c
    { 'I', ARG_DUP, "<interface>", gettext_noop("Specify interface(s) NOT to listen on.") , NULL },
    { 'j', ARG_DUP, "set:<tag>,<class>", gettext_noop("Map DHCP user class to tag."), NULL },
    { LOPT_CIRCUIT, ARG_DUP, "set:<tag>,<circuit>", gettext_noop("Map RFC3046 circuit-id to tag."), NULL },
-@@ -2218,6 +2221,20 @@ static int one_opt(int option, char *arg
+@@ -2275,6 +2278,20 @@ static int one_opt(int option, char *arg
  	break;
        /* fall through */
  


### PR DESCRIPTION
Upstream upgrade to 2.78:
[a9c2ab5e7 dnsmasq: upgrade to 2.78](https://github.com/openembedded/meta-openembedded/commit/a9c2ab5e7527c2ccdb9fc375a9bf3b1faa57bb57)

Refresh the patch since new options were introduced.

Fix master builds.