### PR TITLE
OXT-1352, OXT-1353: tapback, xcpmd: Fixes to initscript to use pidfiles.

### DIFF
--- a/recipes-extended/xen/blktap3/tapback.initscript
+++ b/recipes-extended/xen/blktap3/tapback.initscript
@@ -32,18 +32,20 @@
 . /etc/init.d/functions
 
 PROG=/usr/bin/tapback
+PIDFILE="/var/run/tapback.pid"
+TAPBACK_OPTS="-p ${PIDFILE}"
 
 [ -f /etc/default/rcS ] && . /etc/default/rcS
 [ -f "$PROG" ] || exit 0
 
 case "$1" in
     start)
-        start-stop-daemon -S -x "$PROG"
+        start-stop-daemon -p "${PIDFILE}" -S -x "${PROG}" -- ${TAPBACK_OPTS}
 	echo "OK"
         ;;
     stop)
         echo -n "Stopping tapback: "
-        start-stop-daemon -K -x "$PROG"
+        start-stop-daemon -p "${PIDFILE}" -K -x "${PROG}"
         echo "OK"
         ;;
     restart|reload)

--- a/recipes-openxt/xctools/xcpmd/xcpmd.initscript
+++ b/recipes-openxt/xctools/xcpmd/xcpmd.initscript
@@ -24,14 +24,17 @@
 # Make sure xcpmd exist
 [ -f /usr/sbin/xcpmd ] || exit 0
 
+PROG="/usr/sbin/xcpmd"
+PIDFILE="/var/run/xcpmd.pid"
+
 start() {
  	echo -n "Starting xcpmd: "
-	start-stop-daemon --start --quiet --oknodo --exec /usr/sbin/xcpmd
+	start-stop-daemon --start --quiet --oknodo --pidfile "${PIDFILE}" --exec "${PROG}"
 	echo "OK"
 }
 stop() {
 	echo -n "Stopping xcpmd: "
-	start-stop-daemon --stop --quiet --oknodo --pidfile /var/run/xcpmd.pid
+	start-stop-daemon --stop --quiet --oknodo --pidfile "${PIDFILE}" --exec "${PROG}"
 	echo "OK"
 }
 

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/blktap.fc
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/blktap.fc
@@ -25,3 +25,4 @@
 /var/run/blktap-control(/.*)?		gen_context(system_u:object_r:tapdisk_var_run_t,s0)
 /dev/xen/control		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/blktap-control		-c	gen_context(system_u:object_r:blktap_device_t,s0)
+/run/tapback\..*			gen_context(system_u:object_r:tapback_var_run_t,s0)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/blktap.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/blktap.te
@@ -45,6 +45,11 @@ files_pid_filetrans(tapctl_t, tapdisk_var_run_t, { dir })
 
 type tapback_t;
 type tapback_exec_t;
+type tapback_var_run_t;
+files_pid_file(tapback_var_run_t)
+files_search_pids(tapback_t)
+files_pid_filetrans(tapback_t, tapback_var_run_t, file)
+manage_files_pattern(tapback_t, tapback_var_run_t, tapback_var_run_t)
 
 domain_type(tapback_t)
 files_type(tapback_exec_t)


### PR DESCRIPTION
Use pidfiles to track daemons processes and stop them with `start-stop-daemon`.

# Related:
https://github.com/OpenXT/blktap3/pull/7
https://github.com/OpenXT/xctools/pull/44