### PR TITLE
OXT-1362: Fix UEFI forward-seal

### DIFF
--- a/recipes-openxt/openxt/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt/openxt-measuredlaunch/seal-system
@@ -128,10 +128,10 @@ forward)
     # PCR8 holds the hashes of the other critical components of OpenXT's boot:
     #  openxt.cfg, the initrd and the XSM policy.
     # If PCR8 is all 0 we were not booting with UEFI
-    if [ "${tpm2}" -ne 0 ]; then
+    if [ "${tpm2}" -eq 0 ]; then
         pcr8=$(tpm2_listpcrs | grep PCR_08 | cut -f2 -d: | tr -d ' ' | tail -n1)
     else
-        pcr8=$(grep PCR-08 ${TPM_DEV}/device/pcrs | cut -f2 -d: | tr -d ' ')
+        pcr8=$(grep PCR-08 ${TPM_DEV}/pcrs | cut -f2 -d: | tr -d ' ')
     fi
 
     if [[ "${pcr8}" = *[!0]* ]]; then


### PR DESCRIPTION
Select correct TPM version and TPM_DEV already includes /device in the
TPM1.2 path

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>