### PR TITLE
STABLE-8: OXT-1361: dbus: Avoid segfault when stopping dbus-daemon.

### DIFF
--- a/recipes-core/dbus/dbus_1.%.bbappend
+++ b/recipes-core/dbus/dbus_1.%.bbappend
@@ -16,6 +16,7 @@ SRC_URI += " \
     file://0001-Make-the-default-DBus-reply-timeout-configurable.patch \
     file://add-domid-authentication.patch \
     file://v4v.patch \
+    file://fix-segfault-bus_connection_disconnected.patch \
 "
 
 do_install_append() {

--- a/recipes-core/dbus/patches/fix-segfault-bus_connection_disconnected.patch
+++ b/recipes-core/dbus/patches/fix-segfault-bus_connection_disconnected.patch
@@ -1,0 +1,13 @@
+--- a/bus/connection.c
++++ b/bus/connection.c
+@@ -302,7 +302,9 @@ bus_connection_disconnected (DBusConnect
+       if (mm != NULL)
+         bus_matchmaker_disconnected (mm, connection);
+ 
+-      _dbus_list_remove_link (&d->connections->monitors, d->link_in_monitors);
++      if (d->connections->monitors != NULL)
++        _dbus_list_remove_link (&d->connections->monitors, d->link_in_monitors);
++
+       d->link_in_monitors = NULL;
+     }
+ 


### PR DESCRIPTION
Running /etc/init.d/dbus-1 stop will segfault consistently on OpenXT:
dbus-daemon[728]: segfault at 0 ip b7eb170a sp bf8468a8 error 6 in libdbus-1.so.3.14.9[b7e83000+5a000]

Here is a trace:
```
Thread 1 "dbus-daemon" received signal SIGSEGV, Segmentation fault.
0xb7ee970a in _dbus_list_unlink (list=0x8c78580, link=0x8c8e200) at /usr/src/debug/dbus/1.10.14-r0/dbus-1.10.14/dbus/dbus-list.c:510
510           link->next->prev = link->prev;
(gdb) bt
```

It seems that bus_context_unref can re-use a cleared list in its path:
```
-> bus_context_unref
  -> bus/connection.c:544: _dbus_list_clear (&connections->monitors);
  -> bus/connection.c:555: bus_connection_disconnected (connection);
    -> bus/connection.c:305: _dbus_list_remove_link (&d->connections->monitors, d->link_in_monitors);
         d->connections->monitors is NULL since _dbus_list_clear since connections == d->connections apparently.
```
From the previous gdb session:
```
305           _dbus_list_remove_link (&d->connections->monitors, d->link_in_monitors);
(gdb) p d->connections
$19 = (BusConnections *) 0x8c78558
555               bus_connection_disconnected (connection);
(gdb) p connections
$22 = (BusConnections *) 0x8c78558
```

d->link_in_monitors in this case is a stray pointer to a list that has
been cleared.

(cherry picked from commit 86988d2543ba8dd09a0615c0e89e009a34695202)
