### PR TITLE
OXT-1363: linux: Allow disabling txt event log in Kconfig

### DIFF
--- a/recipes-kernel/linux/4.14/patches/xen-txt-add-xen-txt-eventlog-module.patch
+++ b/recipes-kernel/linux/4.14/patches/xen-txt-add-xen-txt-eventlog-module.patch
@@ -29,16 +29,18 @@ Subject: [PATCH] xen-txt: add xen txt eventlog module
  {
 --- a/drivers/xen/Kconfig
 +++ b/drivers/xen/Kconfig
-@@ -172,6 +172,13 @@ config XEN_TMEM
+@@ -172,6 +172,15 @@ config XEN_TMEM
  	  Shim to interface in-kernel Transcendent Memory hooks
  	  (e.g. cleancache and frontswap) to Xen tmem hypercalls.
  
 +config XEN_TXT
-+	tristate
++	tristate "Xen TXT event log retrieval"
 +	depends on X86 && TCG_TPM
-+	default m
++	default n
 +	help
-+	  Exports TXT information to user space.
++	  Support the Xen hypercall to retrieve the tboot TXT
++	  event log.  The log can be read through securityfs
++	  txt/tpm12_binary_evtlog or txt/tpm20_binary_evtlog
 +
  config XEN_PCIDEV_BACKEND
  	tristate "Xen PCI-device backend driver"


### PR DESCRIPTION
Without text, the tristate option is not displayed in menuconfig and
cannot be disabled. Add text to allow disabling, but also default to
disabled.  Also, slightly improve the help text.

The Dom0 and Installer kernels already select this in their respective
defconfigs, so it doesn't change for them.

OXT-1363

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>