### PR TITLE
STABLE-8: OXT-136{4,5,6,7}: avc denials.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.iptables.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.iptables.diff
@@ -1,0 +1,27 @@
+--- a/policy/modules/system/iptables.if
++++ b/policy/modules/system/iptables.if
+@@ -165,6 +165,24 @@ interface(`iptables_manage_config',`
+ 	manage_files_pattern($1, iptables_conf_t, iptables_conf_t)
+ ')
+ 
++###################################
++## <summary>
++##     dontaudit reading iptables_var_run_t
++## </summary>
++## <param name="domain">
++##     <summary>
++##     Domain to not audit.
++##     </summary>
++## </param>
++#
++interface(`iptables_dontaudit_read_pids',`
++       gen_require(`
++               type iptables_var_run_t;
++       ')
++
++       dontaudit $1 iptables_var_run_t:file read;
++')
++
+ ########################################
+ ## <summary>
+ ##	All of the rules required to

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.lvm.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.lvm.diff
@@ -1,7 +1,5 @@
-Index: refpolicy/policy/modules/system/lvm.fc
-===================================================================
---- refpolicy.orig/policy/modules/system/lvm.fc
-+++ refpolicy/policy/modules/system/lvm.fc
+--- a/policy/modules/system/lvm.fc
++++ b/policy/modules/system/lvm.fc
 @@ -24,6 +24,19 @@ ifdef(`distro_gentoo',`
  /etc/lvmtab\.d(/.*)?		gen_context(system_u:object_r:lvm_metadata_t,s0)
  
@@ -22,10 +20,13 @@ Index: refpolicy/policy/modules/system/lvm.fc
  # /lib
  #
  /lib/lvm-10/.*		--	gen_context(system_u:object_r:lvm_exec_t,s0)
-Index: refpolicy/policy/modules/system/lvm.if
-===================================================================
---- refpolicy.orig/policy/modules/system/lvm.if
-+++ refpolicy/policy/modules/system/lvm.if
+@@ -159,3 +172,4 @@ ifdef(`distro_gentoo',`
+ /var/lock/lvm(/.*)?		gen_context(system_u:object_r:lvm_lock_t,s0)
+ /run/multipathd\.sock -s	gen_context(system_u:object_r:lvm_var_run_t,s0)
+ /run/dmevent.*		gen_context(system_u:object_r:lvm_var_run_t,s0)
++/run/lvm(/.*)?		gen_context(system_u:object_r:lvm_var_run_t,s0)
+--- a/policy/modules/system/lvm.if
++++ b/policy/modules/system/lvm.if
 @@ -125,6 +125,45 @@ interface(`lvm_create_lock_dirs',`
  	files_add_entry_lock_dirs($1)
  ')
@@ -72,10 +73,8 @@ Index: refpolicy/policy/modules/system/lvm.if
  ######################################
  ## <summary>
  ##	Execute a domain transition to run clvmd.
-Index: refpolicy/policy/modules/system/lvm.te
-===================================================================
---- refpolicy.orig/policy/modules/system/lvm.te
-+++ refpolicy/policy/modules/system/lvm.te
+--- a/policy/modules/system/lvm.te
++++ b/policy/modules/system/lvm.te
 @@ -100,6 +100,7 @@ dev_dontaudit_getattr_all_blk_files(clvm
  dev_dontaudit_getattr_all_chr_files(clvmd_t)
  dev_create_generic_dirs(clvmd_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.modutils.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.modutils.diff
@@ -1,7 +1,5 @@
-Index: refpolicy/policy/modules/system/modutils.te
-===================================================================
---- refpolicy.orig/policy/modules/system/modutils.te
-+++ refpolicy/policy/modules/system/modutils.te
+--- a/policy/modules/system/modutils.te
++++ b/policy/modules/system/modutils.te
 @@ -71,6 +71,7 @@ allow kmod_t kmod_var_run_t:dir manage_d
  allow kmod_t kmod_var_run_t:file manage_file_perms;
  
@@ -18,3 +16,14 @@ Index: refpolicy/policy/modules/system/modutils.te
  seutil_read_file_contexts(kmod_t)
  
  userdom_use_user_terminals(kmod_t)
+@@ -135,6 +137,10 @@ optional_policy(`
+ ')
+ 
+ optional_policy(`
++       iptables_dontaudit_read_pids(kmod_t)
++')
++
++optional_policy(`
+ 	mount_domtrans(kmod_t)
+ ')
+ 

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/input-server.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/input-server.te
@@ -66,6 +66,7 @@ corecmd_exec_bin(input_server_t)
 files_read_usr_files(input_server_t)
 miscfiles_read_localization(input_server_t)
 xen_stream_connect_xenstore(input_server_t)
+udev_search_pids(input_server_t)
 
 # local auth setup
 corecmd_exec_shell(input_server_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/updatemgr.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/updatemgr.te
@@ -57,6 +57,7 @@ files_dontaudit_search_home(updatemgr_t)
 fs_list_inotifyfs(updatemgr_t)
 # openssl reads meminfo
 kernel_read_system_state(updatemgr_t)
+kernel_read_vm_sysctls(updatemgr_t)
 logging_send_syslog_msg(updatemgr_t)
 
 dbd_dbus_chat(updatemgr_t)

--- a/recipes-security/refpolicy/refpolicy-mcs_2.%.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.%.bbappend
@@ -138,6 +138,7 @@ SRC_URI += " \
     file://patches/policy.modules.system.logging.diff \
     file://patches/policy.modules.system.lvm.diff \
     file://patches/policy.modules.system.miscfiles.diff \
+    file://patches/policy.modules.system.iptables.diff \
     file://patches/policy.modules.system.modutils.diff \
     file://patches/policy.modules.system.mount.diff \
     file://patches/policy.modules.system.selinuxutil.diff \


### PR DESCRIPTION
Backport one upstream modification to the refpolicy-mcs and attend a few other AVC that regularly trigger on OpenXT.