### PR TITLE
sshd: disable "none" authentication module

### DIFF
--- a/recipes-connectivity/openssh/openssh/disable-auth2-none.patch
+++ b/recipes-connectivity/openssh/openssh/disable-auth2-none.patch
@@ -1,0 +1,11 @@
+diff -u a/auth2.c b/auth2.c
+--- a/auth2.c	2018-07-02 14:36:45.795787892 -0400
++++ b/auth2.c	2018-07-02 14:36:57.175788121 -0400
+@@ -74,7 +74,6 @@
+ #endif
+ 
+ Authmethod *authmethods[] = {
+-	&method_none,
+ 	&method_pubkey,
+ #ifdef GSSAPI
+ 	&method_gssapi,

--- a/recipes-connectivity/openssh/openssh_7.5p1.bb
+++ b/recipes-connectivity/openssh/openssh_7.5p1.bb
@@ -25,6 +25,7 @@ SRC_URI = "http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${PV}.tar
            file://openssh-7.1p1-conditional-compile-des-in-cipher.patch \
            file://openssh-7.1p1-conditional-compile-des-in-pkcs11.patch \
            file://fix-potential-signed-overflow-in-pointer-arithmatic.patch \
+           file://disable-auth2-none.patch \
            file://sshd_check_keys \
            "
 


### PR DESCRIPTION
The auth2-none is responsible for handling the PermitEmptyPasswords option.
Whenever that option is set, sshd will try to login all users without a passwords.
For users that do have a password, that means a failed login attempt and a 2 seconds retry timeout.
auth-passwd can handle empty password, clients can just press enter when prompted for a passsword.
Without auth2-none, users that do have a password won't have to wait anymore.

Signed-off-by: Jed <lejosnej@ainfosec.com>