### PR TITLE
OXT-1373: linux: micro upgrade to 4.14.53

### DIFF
--- a/recipes-kernel/linux/4.14/defconfigs/openxt-installer/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/openxt-installer/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-dom0/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-dom0/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-ndvm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-ndvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-nilfvm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-nilfvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-stubdomain/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-stubdomain/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-syncvm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-syncvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-uivm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-uivm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.47 Kernel Configuration
+# Linux/x86 4.14.53 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y

--- a/recipes-kernel/linux/4.14/linux-openxt_4.14.53.bb
+++ b/recipes-kernel/linux/4.14/linux-openxt_4.14.53.bb
@@ -48,6 +48,6 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://defconfig \
     "
 
-SRC_URI[kernel.md5sum] = "c998ebfbabfdc640060b28839a7a9fca"
-SRC_URI[kernel.sha256sum] = "672b3b6a6b3baac184380028d0a6298d12920f0ede049a20aeb868e0129d8819"
+SRC_URI[kernel.md5sum] = "bfbc0300cfac4b00fd7cee1d95082d92"
+SRC_URI[kernel.sha256sum] = "a85f2572f97dc551f4a159d0c0858e6f40b925afd2d14a0aa25ee9238da80bbf"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"

--- a/recipes-kernel/linux/4.14/patches/extra-mt-input-devices.patch
+++ b/recipes-kernel/linux/4.14/patches/extra-mt-input-devices.patch
@@ -37,7 +37,7 @@ PATCHES
 ################################################################################
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -1046,6 +1046,7 @@
+@@ -1054,6 +1054,7 @@
  #define USB_DEVICE_ID_TURBOX_KEYBOARD	0x0201
  #define USB_DEVICE_ID_ASUS_MD_5110	0x5110
  #define USB_DEVICE_ID_TURBOX_TOUCHSCREEN_MOSART	0x7100

--- a/recipes-kernel/linux/4.14/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.14/patches/usbback-base.patch
@@ -304,7 +304,7 @@ PATCHES
  enum hub_activation_type {
  	HUB_INIT, HUB_INIT2, HUB_INIT3,		/* INITs must come first */
  	HUB_POST_RESET, HUB_RESUME, HUB_RESET_RESUME,
-@@ -5661,7 +5670,7 @@ int usb_reset_device(struct usb_device *
+@@ -5663,7 +5672,7 @@ int usb_reset_device(struct usb_device *
  			struct usb_driver *drv;
  			int unbind = 0;
  
@@ -313,7 +313,7 @@ PATCHES
  				drv = to_usb_driver(cintf->dev.driver);
  				if (drv->pre_reset && drv->post_reset)
  					unbind = (drv->pre_reset)(cintf);
-@@ -5682,7 +5691,12 @@ int usb_reset_device(struct usb_device *
+@@ -5684,7 +5693,12 @@ int usb_reset_device(struct usb_device *
  		for (i = config->desc.bNumInterfaces - 1; i >= 0; --i) {
  			struct usb_interface *cintf = config->interface[i];
  			struct usb_driver *drv;


### PR DESCRIPTION
No significant change to the patch-queue of defconfig.
```
                d08dfdeaf49d xen: Remove unnecessary BUG_ON from __unbind_from_irq()
                dbb37d98b93d x86/xen: Add call of speculative_store_bypass_ht_init() to PV paths
CVE-2018-10840  21542545990c ext4: correctly handle a zero-length xattr with a non-zero e_value_offs
CVE-2018-11412  02d45ec6e770 ext4: bubble errors from ext4_find_inline_data_nolock() up to ext4_iget()
CVE-2018-11412  e81d371dac30 ext4: do not allow external inodes for inline data
                a951cf4da896 x86/xen: Reset VCPU0 info pointer after shared_info remap
                ff3080bab10d xen: xenbus_dev_frontend: Really return response string
                53e4b19fcd0c kvm: x86: use correct privilege level for sgdt/sidt/fxsave/fxrstor access
```