### PR TITLE
OXT-1364: lvm: lvmetad context is lvm_exec_t

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.lvm.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.lvm.diff
@@ -20,7 +20,23 @@
  # /lib
  #
  /lib/lvm-10/.*		--	gen_context(system_u:object_r:lvm_exec_t,s0)
-@@ -159,3 +172,4 @@ ifdef(`distro_gentoo',`
+@@ -43,6 +56,7 @@ ifdef(`distro_gentoo',`
+ /sbin/lvdisplay		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvextend		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvm		--	gen_context(system_u:object_r:lvm_exec_t,s0)
++/sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvm\.static	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvmchange		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /sbin/lvmdiskscan	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+@@ -108,6 +122,7 @@ ifdef(`distro_gentoo',`
+ /usr/sbin/lvdisplay		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvextend		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvm			--	gen_context(system_u:object_r:lvm_exec_t,s0)
++/usr/sbin/lvmetad		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvm\.static		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvmchange		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvmdiskscan		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+@@ -159,3 +174,4 @@ ifdef(`distro_gentoo',`
  /var/lock/lvm(/.*)?		gen_context(system_u:object_r:lvm_lock_t,s0)
  /run/multipathd\.sock -s	gen_context(system_u:object_r:lvm_var_run_t,s0)
  /run/dmevent.*		gen_context(system_u:object_r:lvm_var_run_t,s0)


### PR DESCRIPTION
This will allow proper transition when creating pidfile.

Silence `lvmetad.socket` related AVCs.