### PR TITLE
refpolicy: allow modprobe to search the securityfs to load txt

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.modutils.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.modutils.diff
@@ -8,7 +8,7 @@
  dev_search_usbfs(kmod_t)
  dev_rw_mtrr(kmod_t)
  dev_read_urand(kmod_t)
-@@ -105,6 +106,7 @@ logging_search_logs(kmod_t)
+@@ -105,12 +106,16 @@ logging_search_logs(kmod_t)
  
  miscfiles_read_localization(kmod_t)
  
@@ -16,7 +16,16 @@
  seutil_read_file_contexts(kmod_t)
  
  userdom_use_user_terminals(kmod_t)
-@@ -135,6 +137,10 @@ optional_policy(`
+ 
+ userdom_dontaudit_search_user_home_dirs(kmod_t)
+ 
++# OpenXT: the txt module searches the securityfs at init time
++selinux_search_fs(kmod_t)
++
+ ifdef(`init_systemd',`
+ 	init_rw_stream_sockets(kmod_t)
+ 
+@@ -135,6 +140,10 @@ optional_policy(`
  ')
  
  optional_policy(`


### PR DESCRIPTION
During its initialization, our "txt" Linux module searches the securityfs.
Therefore, modprobe (insmod) needs to be able to do that.

Signed-off-by: Jed <lejosnej@ainfosec.com>