### PR TITLE
STABLE-8: fstab.early: mount the securityfs for the txt module

### DIFF
--- a/recipes-core/base-files/files/fstab.early
+++ b/recipes-core/base-files/files/fstab.early
@@ -14,3 +14,6 @@ tmpfs       /tmp                    tmpfs       defaults,rootcontext=system_u:ob
 tmpfs       /var/volatile           tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=2M         0 0
 tmpfs       /var/cache              tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=100M       0 0
 tmpfs       /var/lock               tmpfs       defaults,rootcontext=system_u:object_r:var_lock_t:s0,size=1M    0 0
+
+# OpenXT: modutils.sh loads before mountall.sh, and modutils.sh will load the txt module, which needs this:
+securityfs                     /sys/kernel/security    securityfs  defaults                                                                        0 0


### PR DESCRIPTION
Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit f057ec31a76dff9de7486a304905d4f6c6c7e90e)
Signed-off-by: Jed <lejosnej@ainfosec.com>