### PR TITLE
OXT-1378: installer: Remove tapback-daemon initscript.

### DIFF
--- a/recipes-core/images/xenclient-installer-image.bb
+++ b/recipes-core/images/xenclient-installer-image.bb
@@ -99,6 +99,7 @@ ROOTFS_POSTPROCESS_COMMAND += "post_rootfs_shell_commands; "
 # Remove initscripts pulled-in by dependencies or not required for operation.
 remove_nonessential_initscripts() {
     remove_initscript "blktap"
+    remove_initscript "tapback-daemon"
     remove_initscript "sshd-v4v"
 }
 ROOTFS_POSTPROCESS_COMMAND += "remove_nonessential_initscripts; "


### PR DESCRIPTION
OpenXT installer does not have CONFIG_BLK_DEV_TAP required to start the
daemon. This is not fatal, and will only log at startup:
```
tapback: tapback.c:612 Unable to find blktap2 device major
```
[...] and shutdown:
```
Stopping tapback: no /usr/bin/tapback found; none killed
```