### PR TITLE
qemu-dm: Avoid segfault in dmbus_send

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm/switcher.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm/switcher.patch
@@ -115,7 +115,7 @@ PATCHES
  x_keymap.o-cflags := $(X11_CFLAGS)
 --- /dev/null
 +++ b/ui/xen-input.c
-@@ -0,0 +1,427 @@
+@@ -0,0 +1,429 @@
 +/*
 + * Copyright (c) 2012 Citrix Systems, Inc.
 + *
@@ -533,13 +533,15 @@ PATCHES
 +
 +int32_t xen_input_send_shutdown(int32_t reason)
 +{
-+    int32_t rc;
++    int32_t rc = 0;
 +    struct msg_switcher_shutdown msg;
 +
 +    msg.reason = reason;
 +
-+    rc = dmbus_send(input.service, DMBUS_MSG_SWITCHER_SHUTDOWN, &msg,
-+                    sizeof(struct msg_switcher_shutdown));
++    if (input.service) {
++        rc = dmbus_send(input.service, DMBUS_MSG_SWITCHER_SHUTDOWN, &msg,
++                        sizeof(struct msg_switcher_shutdown));
++    }
 +
 +    return rc;
 +}


### PR DESCRIPTION
acpi.patch adds this call chain:
acpi_pm1_cnt_write
  xenstore_update_power
    xen_input_send_shutdown
      dmbus_send

When xen_input has not been initialized, dmbus_send segfaults since
input.service is NULL.  If we aren't using xen-input, then we don't need
to notify input_server.  That way we avoid the segfault.

Maybe this should be moved to xen_input_deinit?  In that case, we
wouldn't have the shutdown reason on hand - it would need to be stashed
somewhere.

OXT-1360

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>