### PR TITLE
STABLE-8: qemu-dm: Avoid segfault in dmbus_send

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-2.6.2/switcher.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-2.6.2/switcher.patch
@@ -89,7 +89,7 @@ Index: qemu-2.6.2/ui/xen-input.c
 ===================================================================
 --- /dev/null
 +++ qemu-2.6.2/ui/xen-input.c
-@@ -0,0 +1,596 @@
+@@ -0,0 +1,598 @@
 +/*
 + * Copyright (c) 2012 Citrix Systems, Inc.
 + *
@@ -676,13 +676,15 @@ Index: qemu-2.6.2/ui/xen-input.c
 +
 +int32_t xen_input_send_shutdown(int32_t reason)
 +{
-+    int32_t rc;
++    int32_t rc = 0;
 +    struct msg_switcher_shutdown msg;
 +
 +    msg.reason = reason;
 +
-+    rc = dmbus_send(input.service, DMBUS_MSG_SWITCHER_SHUTDOWN, &msg,
-+                    sizeof(struct msg_switcher_shutdown));
++    if (input.service) {
++        rc = dmbus_send(input.service, DMBUS_MSG_SWITCHER_SHUTDOWN, &msg,
++                        sizeof(struct msg_switcher_shutdown));
++    }
 +
 +    return rc;
 +}


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/xenclient-oe/pull/971

acpi.patch adds this call chain:
acpi_pm1_cnt_write
--xenstore_update_power
----xen_input_send_shutdown
------dmbus_send

When xen_input has not been initialized, dmbus_send segfaults since
input.service is NULL.  If we aren't using xen-input, then we don't need
to notify input_server.  That way we avoid the segfault.

Maybe this should be moved to xen_input_deinit?  In that case, we
wouldn't have the shutdown reason on hand - it would need to be stashed
somewhere.

OXT-1360

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 2ed4eeae384615f16e4d97c2fbb287fdfd054d4c)