### PR TITLE
OXT-1378: linux: Work-around noisy i2c hid device.

### DIFF
--- a/recipes-kernel/linux/4.14/linux-openxt_4.14.53.bb
+++ b/recipes-kernel/linux/4.14/linux-openxt_4.14.53.bb
@@ -45,6 +45,7 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch;patch=1 \
     file://0001-mm-handle_mm_fault-xen_pmd_val-radix_tree_lookup_slo.patch;patch=1 \
+    file://0001-i2c-hid-Silence-incomplete-report-spam.patch;patch=1 \
     file://defconfig \
     "
 

--- a/recipes-kernel/linux/4.14/patches/0001-i2c-hid-Silence-incomplete-report-spam.patch
+++ b/recipes-kernel/linux/4.14/patches/0001-i2c-hid-Silence-incomplete-report-spam.patch
@@ -1,0 +1,36 @@
+From 64a885842bb58913ac90f248ae96494d92fe184a Mon Sep 17 00:00:00 2001
+From: Eric Chanudet <chanudete@ainfosec.com>
+Date: Fri, 20 Jul 2018 17:52:17 -0400
+Subject: [PATCH] i2c-hid: Silence "incomplete report" spam.
+
+Attended once by:
+ef6eaf27274c HID: i2c-hid: Fix "incomplete report" noise
+
+Similar touchpad will spam:
+[ 1538.596775] i2c_hid i2c-DLL07A0:01: i2c_hid_get_input: incomplete report (83/2)
+... for each action on the touchpad and buttons.
+
+Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>
+---
+ drivers/hid/i2c-hid/i2c-hid.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/hid/i2c-hid/i2c-hid.c b/drivers/hid/i2c-hid/i2c-hid.c
+index d92827556389..3ead44decd39 100644
+--- a/drivers/hid/i2c-hid/i2c-hid.c
++++ b/drivers/hid/i2c-hid/i2c-hid.c
+@@ -477,8 +477,9 @@ static void i2c_hid_get_input(struct i2c_hid *ihid)
+ 	}
+ 
+ 	if ((ret_size > size) || (ret_size < 2)) {
+-		dev_err(&ihid->client->dev, "%s: incomplete report (%d/%d)\n",
+-			__func__, size, ret_size);
++		dev_err_once(&ihid->client->dev,
++				"%s: incomplete report (%d/%d)\n",
++				__func__, size, ret_size);
+ 		return;
+ 	}
+ 
+-- 
+2.17.0
+


### PR DESCRIPTION
Seen on Dell E7480.

Every action on the hid device will log a couple of:
```
[ 1538.596775] i2c_hid i2c-DLL07A0:01: i2c_hid_get_input: incomplete report (83/2)
```

Log was already reduced by upstream commit:
```
ef6eaf27274c HID: i2c-hid: Fix "incomplete report" noise
```
Work-around the problem by logging the issue only once.