### PR TITLE
OXT-1390: linux: micro upgrade to 4.14.57

### DIFF
--- a/recipes-kernel/linux/4.14/defconfigs/openxt-installer/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/openxt-installer/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y
@@ -3961,7 +3961,6 @@ CONFIG_CRYPTO_DES=y
 CONFIG_CRYPTO_FCRYPT=y
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_X86_64 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_CHACHA20_X86_64 is not set
 # CONFIG_CRYPTO_SEED is not set

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-dom0/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-dom0/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -3921,7 +3921,6 @@ CONFIG_CRYPTO_DES=m
 CONFIG_CRYPTO_FCRYPT=m
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_586 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-ndvm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-ndvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -2569,7 +2569,6 @@ CONFIG_CRYPTO_DES=y
 # CONFIG_CRYPTO_FCRYPT is not set
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_586 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-nilfvm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-nilfvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -2922,7 +2922,6 @@ CONFIG_CRYPTO_DES=y
 # CONFIG_CRYPTO_FCRYPT is not set
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_586 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-stubdomain/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-stubdomain/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -1938,7 +1938,6 @@ CONFIG_CRYPTO_AES_586=y
 # CONFIG_CRYPTO_FCRYPT is not set
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_586 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-syncvm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-syncvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -2045,7 +2045,6 @@ CONFIG_CRYPTO_AES_586=y
 # CONFIG_CRYPTO_FCRYPT is not set
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_586 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set

--- a/recipes-kernel/linux/4.14/defconfigs/xenclient-uivm/defconfig
+++ b/recipes-kernel/linux/4.14/defconfigs/xenclient-uivm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.14.53 Kernel Configuration
+# Linux/x86 4.14.57 Kernel Configuration
 #
 # CONFIG_64BIT is not set
 CONFIG_X86_32=y
@@ -1727,7 +1727,6 @@ CONFIG_CRYPTO_AES_586=y
 # CONFIG_CRYPTO_FCRYPT is not set
 # CONFIG_CRYPTO_KHAZAD is not set
 # CONFIG_CRYPTO_SALSA20 is not set
-# CONFIG_CRYPTO_SALSA20_586 is not set
 # CONFIG_CRYPTO_CHACHA20 is not set
 # CONFIG_CRYPTO_SEED is not set
 # CONFIG_CRYPTO_SERPENT is not set

--- a/recipes-kernel/linux/4.14/linux-openxt_4.14.57.bb
+++ b/recipes-kernel/linux/4.14/linux-openxt_4.14.57.bb
@@ -48,6 +48,6 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://defconfig \
     "
 
-SRC_URI[kernel.md5sum] = "bfbc0300cfac4b00fd7cee1d95082d92"
-SRC_URI[kernel.sha256sum] = "a85f2572f97dc551f4a159d0c0858e6f40b925afd2d14a0aa25ee9238da80bbf"
+SRC_URI[kernel.md5sum] = "7badf9d4911a2c26601f862199243fca"
+SRC_URI[kernel.sha256sum] = "4a9540f256b8ee91d49c3d55def90be3af8c0ddb1ff274d20bc56a42dcdbd810"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"


### PR DESCRIPTION
Excerpt:
```
                54ca2776fcca xen: setup pv irq ops vector earlier
                702027291bf5 HID: i2c-hid: Fix "incomplete report" noise
CVE-2018-10882  c24aab6d8664 ext4: add more inode number paranoia checks
CVE-2018-10883  02945e49dc20 ext4: avoid running out of journal credits when appending to an inline file
CVE-2018-10880  8a9ef17c0dc9 ext4: never move the system.data xattr out of the inode body
CVE-2018-10881  deb465ec750b ext4: clear i_data in ext4_inode_info when removing inline data
CVE-2018-10877  d69a9df614fc ext4: verify the depth of extent tree in ext4_find_extent()
CVE-2018-10876  44a4bc970bfa ext4: only look at the bg_flags field if it is valid
CVE-2018-10879  3150e8913b95 ext4: always verify the magic number in xattr blocks
CVE-2018-10879  0dc148230f38 ext4: add corruption check in ext4_xattr_set_entry()
```