### PR TITLE
sshd_config: use alternative auth method that handles empty passwords correctly

### DIFF
--- a/recipes-connectivity/openssh/files/xenclient-dom0/sshd_config
+++ b/recipes-connectivity/openssh/files/xenclient-dom0/sshd_config
@@ -69,11 +69,11 @@ PermitRootLogin yes
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-#PasswordAuthentication yes
+PasswordAuthentication no
 PermitEmptyPasswords yes
 
 # Change to no to disable s/key passwords
-ChallengeResponseAuthentication no
+ChallengeResponseAuthentication yes
 
 # Kerberos options
 #KerberosAuthentication no


### PR DESCRIPTION
OXT-1389

Signed-off-by: Jed <lejosnej@ainfosec.com>