### PR TITLE
OXT-1377: Work around sensitive EFI firmwares

### DIFF
--- a/recipes-core/images/xenclient-installer-image/grub.cfg
+++ b/recipes-core/images/xenclient-installer-image/grub.cfg
@@ -2,19 +2,16 @@ set timeout=10
 
 menuentry --hotkey=i 'OpenXT Install' {
     set background_color=black
-    multiboot2 /isolinux/xen.gz placeholder flask=disabled console=com1 com1=115200,8n1,pci mbi-video vga=current loglvl=debug guest_loglvl=debug sync_console
-    module2    /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=/dev/tty2 selinux=0
-    module2    /isolinux/rootfs.gz
+    linux   /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=/dev/tty2 selinux=0
+    initrd  /isolinux/rootfs.gz
 }
 menuentry --hotkey=v 'OpenXT Install (verbose)' {
     set background_color=black
-    multiboot2 /isolinux/xen.gz placeholder flask=disabled console=com1 com1=115200,8n1,pci mbi-video vga=current loglvl=debug guest_loglvl=debug sync_console
-    module2    /isolinux/vmlinuz placeholder splash root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=/dev/tty2 selinux=0
-    module2    /isolinux/rootfs.gz
+    linux   /isolinux/vmlinuz placeholder splash root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=/dev/tty2 selinux=0
+    initrd  /isolinux/rootfs.gz
 }
 menuentry --hotkey=a 'OpenXT Install (automatic)' {
     set background_color=black
-    multiboot2 /isolinux/xen.gz placeholder flask=disabled console=com1 com1=115200,8n1,pci mbi-video vga=current loglvl=debug guest_loglvl=debug sync_console
-    module2    /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/auto-cd.ans console=hvc0 console=/dev/tty2 selinux=0
-    module2    /isolinux/rootfs.gz
+    linux   /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/auto-cd.ans console=hvc0 console=/dev/tty2 selinux=0
+    initrd  /isolinux/rootfs.gz
 }

--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
@@ -2,35 +2,35 @@
 default=openxt-normal
 
 [openxt-normal]
-options=console=com1 dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
+options=console=com1 dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 autostart
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-safe-graphics]
-options=console=com1 dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
+options=console=com1 dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 safe-graphic nomodeset
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-amt]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-console]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24
 ucode=microcode_intel.bin
 
 [openxt-support-console-amt]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24


### PR DESCRIPTION
When using OpenXT UEFI installer, boot only Linux. The current main graph of the UEFI installer does not use Xen.
When booting into OpenXT, pass efi=no-rs to Xen to disable EFI runtime services. Runtime services are currently only used during the installation. Add attr=uc as well, some firmwares flag their memory incorrectly.

This allows OpenXT to install, Boot and setup MLE (including performing forward-seal) on HP 800 G1 and HP 850 G2 with UEFI, as surely other machines with similar firmware.

Other work-around have been attempted before and are documented in the ticket.