### PR TITLE
STABLE-8: OXT-1393: refpolicy-mcs: Allow installer part2 to mount ESP.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/xc-installer-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/xc-installer-interfaces.diff
@@ -1,10 +1,19 @@
-Index: refpolicy/policy/modules/system/lvm.te
-===================================================================
---- refpolicy.orig/policy/modules/system/lvm.te
-+++ refpolicy/policy/modules/system/lvm.te
+--- a/policy/modules/system/lvm.te
++++ b/policy/modules/system/lvm.te
 @@ -427,4 +427,5 @@ optional_policy(`
  	updatemgr_dontaudit_rw_fifo_files(lvm_t)
  	updatemgr_dontaudit_rw_stream_sockets(lvm_t)
  	updatemgr_dontaudit_search_storage(lvm_t)
 +	xc_installer_read_tmp_files(lvm_t)
  ')
+--- a/policy/modules/system/mount.te
++++ b/policy/modules/system/mount.te
+@@ -275,3 +275,8 @@ optional_policy(`
+ optional_policy(`
+ 	xc_dontaudit_rw_v4v_chr(mount_t)
+ ')
++
++# Installer part2 needs mounton for ESP partition.
++optional_policy(`
++	xc_installer_mounton_tmp_dirs(mount_t)
++')

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/system/xc-installer.if
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/system/xc-installer.if
@@ -85,3 +85,21 @@ interface(`xc_installer_read_tmp_files',`
 
 	read_files_pattern($1, xc_installer_tmp_t, xc_installer_tmp_t)
 ')
+########################################
+## <summary>
+##	Allow the calling domain to mount filesystem on all tmpfs directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`xc_installer_mounton_tmp_dirs',`
+	gen_require(`
+		type xc_installer_tmp_t;
+	')
+
+	allow $1 xc_installer_tmp_t:dir mounton;
+')
+


### PR DESCRIPTION
While performing OTA upgrade, part2 installer scripts will fail in
seal-system because of an AVC:
avc:  denied  { mounton } for  pid=3949 comm="mount" path="/tmp/esp" dev="tmpfs" ino=26094 scontext=system_u:system_r:mount_t:s0-s0:c0.c1023 tcontext=system_u:object_r:xc_installer_tmp_t:s0 tclass=dir permissive=0

(cherry picked from commit 4f29bf573e588e42e95f03fd9033c1306f730329)
