### PR TITLE
OXT-1396: seal-system: change TPM1.2 EV_SEPARATOR to the sha1 of 0xFFFFFFFF

### DIFF
--- a/recipes-openxt/openxt/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt/openxt-measuredlaunch/seal-system
@@ -144,7 +144,9 @@ forward)
 
         # PCR4 is first extended with the digest of EV_SEPARATOR
         # See TCG EFI Protocol Specification 5.2 Crypto Agile Log Entry Format
-        ev_separator="9069ca78e7450a285173431b3e52c5c25299e473"
+        # The specs says that ev_separator is the hash of 0x00000000
+        # However, TPM1.2 implementations use the sha1 of 0xffffffff...
+        ev_separator="d9be6524a5f5047db5866813acf3277892a7a30a"
         [ "${tpm2}" -eq 0 ] && ev_separator="df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"
 
         pcr4=$(hash_extend 0 $ev_separator $hashalg)


### PR DESCRIPTION
(instead of 0x00000000)

Signed-off-by: Jed <lejosnej@ainfosec.com>