### PR TITLE
OXT-1395: tpm2-tools: reset hash_set variable during parsing

### DIFF
--- a/recipes-openxt/tss/tpm2-tools/tpm2-fix-forward-seal.patch
+++ b/recipes-openxt/tss/tpm2-tools/tpm2-fix-forward-seal.patch
@@ -1,8 +1,6 @@
-Index: tpm2-tools/lib/pcr.c
-===================================================================
---- tpm2-tools.orig/lib/pcr.c
-+++ tpm2-tools/lib/pcr.c
-@@ -61,7 +61,7 @@ static int pcr_parse_selection(const cha
+--- a/lib/pcr.c
++++ b/lib/pcr.c
+@@ -61,20 +61,25 @@ static int pcr_parse_selection(const cha
      return 0;
  }
  
@@ -11,8 +9,11 @@ Index: tpm2-tools/lib/pcr.c
  {
      char * pstr;
      UINT16 length;
-@@ -69,12 +69,16 @@ int pcr_parse_arg(char *arg, UINT32 *pcr
-     if (strchr(arg, ':')) {
+     int ret = 0;
+-    if (strchr(arg, ':')) {
++
++    *hash_set = (strchr(arg, ':') != NULL);
++    if (*hash_set) {
          //read forward hash and convert to hex to byte
          pstr = strtok(arg, ":");
 -        if (pstr)
@@ -26,15 +27,12 @@ Index: tpm2-tools/lib/pcr.c
 +        if (pstr) {
 +            length = sizeof(BYTE)*32;
              hex2ByteStructure(pstr, &length, forwardHash);
-+            *hash_set = true;
 +        }
      } else {
          ret = pcr_get_id(arg, pcrId);
      }
-Index: tpm2-tools/tools/tpm2_sealdata.c
-===================================================================
---- tpm2-tools.orig/tools/tpm2_sealdata.c
-+++ tpm2-tools/tools/tpm2_sealdata.c
+--- a/tools/tpm2_sealdata.c
++++ b/tools/tpm2_sealdata.c
 @@ -102,6 +102,7 @@ execute_tool(int                 argc,
      UINT32 objectAttributes = 0;
      char opuFilePath[PATH_MAX] = {0};
@@ -60,10 +58,8 @@ Index: tpm2-tools/tools/tpm2_sealdata.c
              memcpy(new_pcr->forwardHash, forwardHash, 32);
              memset(forwardHash, 0, 32);
              pcrList[pcrCount] = new_pcr;
-Index: tpm2-tools/lib/pcr.h
-===================================================================
---- tpm2-tools.orig/lib/pcr.h
-+++ tpm2-tools/lib/pcr.h
+--- a/lib/pcr.h
++++ b/lib/pcr.h
 @@ -2,15 +2,17 @@
  #define SRC_PCR_H_
  
@@ -83,10 +79,8 @@ Index: tpm2-tools/lib/pcr.h
  } pcr_struct;
  
  #define SET_PCR_SELECT_BIT( pcrSelection, pcr ) \
-Index: tpm2-tools/tools/tpm2_unsealdata.c
-===================================================================
---- tpm2-tools.orig/tools/tpm2_unsealdata.c
-+++ tpm2-tools/tools/tpm2_unsealdata.c
+--- a/tools/tpm2_unsealdata.c
++++ b/tools/tpm2_unsealdata.c
 @@ -201,7 +201,7 @@ execute_tool(int               argc,
      UINT32 pcr = -1;
      INT32 pcrCount = 0;
@@ -115,10 +109,8 @@ Index: tpm2-tools/tools/tpm2_unsealdata.c
              pcrList[pcrCount] = new_pcr;
              pcrCount++;
              break;
-Index: tpm2-tools/lib/build-policy.c
-===================================================================
---- tpm2-tools.orig/lib/build-policy.c
-+++ tpm2-tools/lib/build-policy.c
+--- a/lib/build-policy.c
++++ b/lib/build-policy.c
 @@ -29,7 +29,6 @@ int build_pcr_policy( TSS2_SYS_CONTEXT *
      UINT32 pcrUpdateCounter;
  


### PR DESCRIPTION
Do not leak previous values on N+1 parse operation.