### PR TITLE
STABLE-8: installer: Add ttyS0 console back to the cmdline

### DIFF
--- a/recipes-core/images/xenclient-installer-image/grub.cfg
+++ b/recipes-core/images/xenclient-installer-image/grub.cfg
@@ -2,16 +2,16 @@ set timeout=10
 
 menuentry --hotkey=i 'OpenXT Install' {
     set background_color=black
-    linux   /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=/dev/tty2 selinux=0
+    linux   /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=tty2 console=ttyS0,115200n8 selinux=0
     initrd  /isolinux/rootfs.gz
 }
 menuentry --hotkey=v 'OpenXT Install (verbose)' {
     set background_color=black
-    linux   /isolinux/vmlinuz placeholder splash root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=/dev/tty2 selinux=0
+    linux   /isolinux/vmlinuz placeholder splash root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/uefi.ans console=tty2 console=ttyS0,115200n8 selinux=0
     initrd  /isolinux/rootfs.gz
 }
 menuentry --hotkey=a 'OpenXT Install (automatic)' {
     set background_color=black
-    linux   /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/auto-cd.ans console=hvc0 console=/dev/tty2 selinux=0
+    linux   /isolinux/vmlinuz placeholder quiet root=/dev/ram rw start_install=new eject_cdrom=1 answerfile=/install/answers/auto-cd.ans console=tty2 console=ttyS0,115200n8 selinux=0
     initrd  /isolinux/rootfs.gz
 }


### PR DESCRIPTION
The console used to be set on the Xen cmdline. Pass it to Linux.

(cherry picked from commit 2a7bb2774a52b1e94bfd745c7f942cb2be316956)
