### PR TITLE
OXT-1388: libselinux: Compile with _FILE_OFFSET_BITS=64

### DIFF
--- a/recipes-security/selinux/libselinux/libselinux_2.%.bbappend
+++ b/recipes-security/selinux/libselinux/libselinux_2.%.bbappend
@@ -2,3 +2,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 SRC_URI += " \
      file://libselinux-mount-procfs-before-check.patch;patch=1 \
 "
+
+# We need to support stat on files >2GB in size.
+CFLAGS += "-D_FILE_OFFSET_BITS=64"


### PR DESCRIPTION
restorecon fails with EOVERFLOW (Value too large for defined data type)
when calling lstat on files >2GB in size.  Setting _FILE_OFFSET_BITS=64
makes compilation use 64bit struct stat64 and stat64 behind the scene
without changing the source to avoid file size issues.

This is needed to support restorecon on /storage/xc-reserved and other
large VM image files.

OXT-1388

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

This version changes CFLAGS as opposed to TARGET_CFLAGS in https://github.com/OpenXT/xenclient-oe/pull/981