### PR TITLE
OXT-1409: rsyslog: Use custom format for VM messages

### DIFF
--- a/recipes-extended/rsyslog/files/xenclient-dom0/rsyslog.conf
+++ b/recipes-extended/rsyslog/files/xenclient-dom0/rsyslog.conf
@@ -14,6 +14,7 @@ $ModLoad imklog   # provides kernel logging support (previously done by rklogd)
 #### GLOBAL DIRECTIVES ####
 ###########################
 # Time format
+$template vm_format,"%TIMESTAMP%.%TIMESTAMP:::date-subseconds% VM%msg%\n"
 $template oxt_format,"%TIMESTAMP%.%TIMESTAMP:::date-subseconds% %syslogtag%%msg%\n"
 $ActionFileDefaultTemplate oxt_format
 
@@ -27,8 +28,13 @@ $Umask 0022
 ###############
 #### RULES ####
 ###############
-# Send everything that is not debug to /var/log/messages
 $outchannel log_rotation,/var/log/messages,20971520,/usr/sbin/logrotate-wrapper
+
+# Use custom format for VM messages
+:programname, isequal, "xenconsoled" :omfile:$log_rotation;vm_format
+:programname, isequal, "xenconsoled" ~
+
+# Send everything that is not debug to /var/log/messages
 if $syslogseverity <= 6 then    :omfile:$log_rotation
 
 # Emergencies are sent to everybody logged in.


### PR DESCRIPTION
The current format looks like:
Jan  1 12:34:56.789012 xenconsoled: Network (1): message
This changes the format to:
Jan  1 12:34:56.789012 VM Network (1): message

Which drops 10 characters off each VM line.

OXT-1409

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>