### PR TITLE
OXT-1403: Signed modules fix

### DIFF
--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -24,9 +24,17 @@ do_sign_modules() {
                         ${STAGING_KERNEL_BUILDDIR}/.config | \
                       cut -d '"' -f 2 )
         [ -z "$SIG_HASH" ] && bbfatal CONFIG_MODULE_SIG_HASH is not set in .config
+
+        # ${B} for kernel, ${STAGING_KERNEL_BUILDDIR} for modules
+        for SIGN_FILE in ${STAGING_KERNEL_BUILDDIR}/scripts/sign-file \
+                         ${B}/scripts/sign-file ; do
+            [ -x "$SIGN_FILE" ] && break
+        done
+        [ -z "$SIGN_FILE" ] && bbfatal "Cannot find scripts/sign-file"
+
         find ${D} -name "*.ko" -print0 | \
-          xargs -0 -n 1 ${STAGING_KERNEL_BUILDDIR}/scripts/sign-file \
-            $SIG_HASH ${KERNEL_MODULE_SIG_KEY} ${KERNEL_MODULE_SIG_CERT}
+          xargs -0 -n 1 $SIGN_FILE $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
+              ${KERNEL_MODULE_SIG_CERT}
     fi
 }
 

--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -23,10 +23,10 @@ do_sign_modules() {
         SIG_HASH=$( grep CONFIG_MODULE_SIG_HASH= \
                         ${STAGING_KERNEL_BUILDDIR}/.config | \
                       cut -d '"' -f 2 )
-        [ -z "$SIGHASH" ] || bbfatal CONFIG_MODULE_SIG_HASH is not set in .config
+        [ -z "$SIG_HASH" ] && bbfatal CONFIG_MODULE_SIG_HASH is not set in .config
         find ${D} -name "*.ko" -print0 | \
           xargs -0 -n 1 ${STAGING_KERNEL_BUILDDIR}/scripts/sign-file \
-            ${SIG_HASH} ${KERNEL_MODULE_SIG_KEY} ${KERNEL_MODULE_SIG_CERT}
+            $SIG_HASH ${KERNEL_MODULE_SIG_KEY} ${KERNEL_MODULE_SIG_CERT}
     fi
 }
 


### PR DESCRIPTION
This fixes module signing on a clean build when
${STAGING_KERNEL_BUILDDIR}/scripts/sign-file isn't populated.

On a clean build, do_sign_modules fails when using a specified
$KERNEL_MODULE_SIG_KEY when it cannot find sign-file.  do_sign_modules
runs before sign-file has been installed into $STAGING_KERNEL_BUILDDIR.
module-base.bbclass provides do_make_scripts which is responsible for
the installation, but that is only run when an out-of-tree module is
built.

module-base cannot be inherited into the kernel build because it creates
a dependency loop.

The kernel build dir ${B} already has sign-file, so just check for it
there in addition to the $STAGING_KERNEL_BUILDDIR.