### PR TITLE
xenclient-installer: Make package arch-independent

### DIFF
--- a/recipes-openxt/xenclient/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient/xenclient-installer_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://${OPENXT_GIT_MIRROR}/installer.git;protocol=${OPENXT_GIT_PROTOC
 
 S = "${WORKDIR}/git"
 
-inherit xenclient
+inherit xenclient allarch
 
 PACKAGES += "${PN}-part2"
 


### PR DESCRIPTION
xenclient-installer is arch-independent since it is a bunch of shell
scripts.  Mark it as such by inheriting allarch.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>