### PR TITLE
STABLE-8: OXT-1410: seabios: Change source URL

### DIFF
--- a/recipes-extended/seabios/seabios_1.9.%.bbappend
+++ b/recipes-extended/seabios/seabios_1.9.%.bbappend
@@ -1,8 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}-${PV}:"
 # meta-virtualization recipe for seabios will fetch using the http:// source
 # which is 308 to the https://, throwing the fetcher off.
+# Tarball are now hosted on https://www.seabios.org/downloads/.
 PREMIRRORS_prepend += " \
-    http://code.coreboot.org/p/seabios/downloads/.* https://code.coreboot.org/p/seabios/downloads/${PN}-${PV}.tar.gz \
+    http://code.coreboot.org/p/seabios/downloads/.* https://www.seabios.org/downloads/ \n \
 "
 SRC_URI += " \
     file://halt-if-no-bootable.patch \


### PR DESCRIPTION
Change premirror, tarballs are now at:
https://www.seabios.org/downloads/

(cherry picked from commit d125f1c790ebc80bc0f528cb16787946a1a78544)
