### PR TITLE
Revert "libsemanage: remove runtime dependency on python"

### DIFF
--- a/recipes-security/selinux/libsemanage_2.7.bbappend
+++ b/recipes-security/selinux/libsemanage_2.7.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS_${PN}_remove += "python"


### PR DESCRIPTION
Reverts OpenXT/xenclient-oe#906

This was fixed upstream today:
https://git.yoctoproject.org/cgit/cgit.cgi/meta-selinux/commit/?id=cd46305a0838142ff4b619e8f50a57ece9cebfef