### PR TITLE
OXT-1346: xen: Fetch from git stable branch.

### DIFF
--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -1,10 +1,11 @@
 LIC_FILES_CHKSUM := "file://COPYING;md5=bbb4b1bdc2c3b6743da3c39d03249095"
 
-PV = "${XEN_VERSION}"
+require xen-version.inc
 
-SRC_URI := "${XEN_SRC_URI}"
-SRC_URI[md5sum] := "${XEN_SRC_MD5SUM}"
-SRC_URI[sha256sum] := "${XEN_SRC_SHA256SUM}"
+PV = "${XEN_PV}"
+
+SRCREV = "${XEN_SRCREV}"
+SRC_URI = "git://xenbits.xen.org/xen.git;branch=${XEN_BRANCH}"
 
 # XSA patches take precedence and belong at the head of the queue.
 # This ensures that any collisions with other patches get addressed
@@ -99,7 +100,7 @@ COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'
 PACKAGECONFIG =+ "xsm"
 PACKAGECONFIG =+ "hvm"
 
-S = "${WORKDIR}/xen-${PV}"
+S = "${WORKDIR}/git"
 
 #--
 # Override meta-virtualization's path to seabios:

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -29,6 +29,8 @@ python () {
     d.appendVar("FILES_xen-xl", " /etc/init.d/xen-init-dom0")
 }
 
+FLASK_POLICY_FILE = "xenpolicy-${XEN_PV}"
+
 DEPENDS += " \
     util-linux \
     xen \
@@ -80,6 +82,9 @@ FILES_${PN}-dbg += " \
     ${libdir}/.debug \
     /usr/src/debug \
 "
+FILES_${PN}-misc += "\
+    ${sbindir}/xen-diag \
+"
 
 CFLAGS_prepend += "${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', '', '-I${STAGING_INCDIR}/blktap',d)}"
 
@@ -107,8 +112,8 @@ INITSCRIPT_PARAMS_xen-xl = "defaults 21"
 
 do_configure_prepend() {
 	#remove optimizations in the config files
-	sed -i 's/-O2//g' ${WORKDIR}/xen-${XEN_VERSION}/Config.mk
-	sed -i 's/-O2//g' ${WORKDIR}/xen-${XEN_VERSION}/config/StdGNU.mk
+	sed -i 's/-O2//g' ${S}/Config.mk
+	sed -i 's/-O2//g' ${S}/config/StdGNU.mk
 
 	cp "${WORKDIR}/defconfig" "${B}/xen/.config"
 }

--- a/recipes-extended/xen/xen-version.inc
+++ b/recipes-extended/xen/xen-version.inc
@@ -1,0 +1,3 @@
+XEN_PV = "4.10.0-pre"
+XEN_BRANCH = "stable-4.10"
+XEN_SRCREV = "RELEASE-4.10.0"

--- a/recipes-extended/xen/xen-xsm-policy_git.bb
+++ b/recipes-extended/xen/xen-xsm-policy_git.bb
@@ -6,7 +6,9 @@ PROVIDES = "xen-xsm-policy"
 
 S = "${WORKDIR}/git"
 
-PV = "${XEN_VERSION}+git${SRCPV}"
+require xen-version.inc
+
+PV = "${XEN_PV}+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/xsm-policy.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"


### PR DESCRIPTION
With the .meta files releases with XSAs, maintainance overhead is
greatly reduced if tracking stable-X.Y staging branches until the
RELEASE-X.Y.Z tag is announced.

Xen's build system does some fetching on its own when building certain
components (QEMU, firwares, mini-os, vtpm, etc). This would have to be
dealt with in time, these receipes should not need this yet.

##### Depends on:
- https://github.com/OpenXT/openxt/pull/321