### PR TITLE
xfwm: start as daemon instead of background

### DIFF
--- a/recipes-openxt/xenclient/xenclient-uivm-xsessionconfig/xinitrc
+++ b/recipes-openxt/xenclient/xenclient-uivm-xsessionconfig/xinitrc
@@ -111,7 +111,7 @@ if test x"$DBUS_SESSION_BUS_ADDRESS" = x""; then
     fi
 fi
 
-xfwm4 &
+xfwm4 --daemon
 resized &
 xfsettingsd --no-daemon --replace &
 sleep 1 # Because proper behaviour no longer matter.


### PR DESCRIPTION
Not sure why that changes anything, but this is what xfce does by default,
and it ensures terminals always spawn in the foreground.

Signed-off-by: Jed <lejosnej@ainfosec.com>