### PR TITLE
OXT-1410: seabios: Remove PREMIRRORS statement.

### DIFF
--- a/recipes-extended/seabios/seabios_1.9.%.bbappend
+++ b/recipes-extended/seabios/seabios_1.9.%.bbappend
@@ -1,10 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}-${PV}:"
-# meta-virtualization recipe for seabios will fetch using the http:// source
-# which is 308 to the https://, throwing the fetcher off.
-# Tarball are now hosted on https://www.seabios.org/downloads/.
-PREMIRRORS_prepend += " \
-    http://code.coreboot.org/p/seabios/downloads/.* https://www.seabios.org/downloads/ \n \
-"
+
 SRC_URI += " \
     file://halt-if-no-bootable.patch \
     file://init-vgahooks-if-optionroms-deployed.patch \


### PR DESCRIPTION
First, PREMIRRORS is a little too strong to be defined at the recipe
level like so. I imagine it is more intended at providing a local.conf
override to fetch sources from a local cache. Having PREMIRRORS_prepend
makes that much more difficult.

Also, in this case, the upstream recipe has been fixed (at least was
yesterday).

This source is quite volatile. It should be recommended to fetch from a
stable mirror.

Maybe put the tarball on mirror.openxt.org and add a {PRE,}MIRRORS
statement in the default configuration file.