### PR TITLE
STABLE-8: OXT-1412: Backport XSA-269, XSA-270, XSA-272

### DIFF
--- a/recipes-extended/xen/files/xsa269-4.10.patch
+++ b/recipes-extended/xen/files/xsa269-4.10.patch
@@ -1,0 +1,122 @@
+From 0653a0598613ea9d7598ad8f9ace89ed7498410c Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 30 Jul 2018 11:01:28 +0100
+Subject: [PATCH] x86/vtx: Fix the checking for unknown/invalid MSR_DEBUGCTL
+ bits
+
+The VPMU_MODE_OFF early-exit in vpmu_do_wrmsr() introduced by c/s
+11fe998e56 bypasses all reserved bit checking in the general case.  As a
+result, a guest can enable BTS when it shouldn't be permitted to, and
+lock up the entire host.
+
+With vPMU active (not a security supported configuration, but useful for
+debugging), the reserved bit checking in broken, caused by the original
+BTS changeset 1a8aa75ed.
+
+From a correctness standpoint, it is not possible to have two different
+pieces of code responsible for different parts of value checking, if
+there isn't an accumulation of bits which have been checked.  A
+practical upshot of this is that a guest can set any value it
+wishes (usually resulting in a vmentry failure for bad guest state).
+
+Therefore, fix this by implementing all the reserved bit checking in the
+main MSR_DEBUGCTL block, and removing all handling of DEBUGCTL from the
+vPMU MSR logic.
+
+This is XSA-269
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/cpu/vpmu_intel.c | 20 --------------------
+ xen/arch/x86/hvm/vmx/vmx.c    | 27 ++++++++++++++++++++-------
+ 2 files changed, 20 insertions(+), 27 deletions(-)
+
+diff --git a/xen/arch/x86/cpu/vpmu_intel.c b/xen/arch/x86/cpu/vpmu_intel.c
+index 207e2e712c..d4444f0d94 100644
+--- a/xen/arch/x86/cpu/vpmu_intel.c
++++ b/xen/arch/x86/cpu/vpmu_intel.c
+@@ -535,27 +535,7 @@ static int core2_vpmu_do_wrmsr(unsigned int msr, uint64_t msr_content,
+     uint64_t *enabled_cntrs;
+ 
+     if ( !core2_vpmu_msr_common_check(msr, &type, &index) )
+-    {
+-        /* Special handling for BTS */
+-        if ( msr == MSR_IA32_DEBUGCTLMSR )
+-        {
+-            supported |= IA32_DEBUGCTLMSR_TR | IA32_DEBUGCTLMSR_BTS |
+-                         IA32_DEBUGCTLMSR_BTINT;
+-
+-            if ( cpu_has(&current_cpu_data, X86_FEATURE_DSCPL) )
+-                supported |= IA32_DEBUGCTLMSR_BTS_OFF_OS |
+-                             IA32_DEBUGCTLMSR_BTS_OFF_USR;
+-            if ( !(msr_content & ~supported) &&
+-                 vpmu_is_set(vpmu, VPMU_CPU_HAS_BTS) )
+-                return 0;
+-            if ( (msr_content & supported) &&
+-                 !vpmu_is_set(vpmu, VPMU_CPU_HAS_BTS) )
+-                printk(XENLOG_G_WARNING
+-                       "%pv: Debug Store unsupported on this CPU\n",
+-                       current);
+-        }
+         return -EINVAL;
+-    }
+ 
+     ASSERT(!supported);
+ 
+diff --git a/xen/arch/x86/hvm/vmx/vmx.c b/xen/arch/x86/hvm/vmx/vmx.c
+index 48d3c54e84..2c490cf62a 100644
+--- a/xen/arch/x86/hvm/vmx/vmx.c
++++ b/xen/arch/x86/hvm/vmx/vmx.c
+@@ -3097,11 +3097,14 @@ void vmx_vlapic_msr_changed(struct vcpu *v)
+ static int vmx_msr_write_intercept(unsigned int msr, uint64_t msr_content)
+ {
+     struct vcpu *v = current;
++    const struct cpuid_policy *cp = v->domain->arch.cpuid;
+ 
+     HVM_DBG_LOG(DBG_LEVEL_MSR, "ecx=%#x, msr_value=%#"PRIx64, msr, msr_content);
+ 
+     switch ( msr )
+     {
++        uint64_t rsvd;
++
+     case MSR_IA32_SYSENTER_CS:
+         __vmwrite(GUEST_SYSENTER_CS, msr_content);
+         break;
+@@ -3117,16 +3120,26 @@ static int vmx_msr_write_intercept(unsigned int msr, uint64_t msr_content)
+         break;
+     case MSR_IA32_DEBUGCTLMSR: {
+         int i, rc = 0;
+-        uint64_t supported = IA32_DEBUGCTLMSR_LBR | IA32_DEBUGCTLMSR_BTF;
+ 
+-        if ( boot_cpu_has(X86_FEATURE_RTM) )
+-            supported |= IA32_DEBUGCTLMSR_RTM;
+-        if ( msr_content & ~supported )
++        rsvd = ~(IA32_DEBUGCTLMSR_LBR | IA32_DEBUGCTLMSR_BTF);
++
++        /* TODO: Wire vPMU settings properly through the CPUID policy */
++        if ( vpmu_is_set(vcpu_vpmu(v), VPMU_CPU_HAS_BTS) )
+         {
+-            /* Perhaps some other bits are supported in vpmu. */
+-            if ( vpmu_do_wrmsr(msr, msr_content, supported) )
+-                break;
++            rsvd &= ~(IA32_DEBUGCTLMSR_TR | IA32_DEBUGCTLMSR_BTS |
++                      IA32_DEBUGCTLMSR_BTINT);
++
++            if ( cpu_has(&current_cpu_data, X86_FEATURE_DSCPL) )
++                rsvd &= ~(IA32_DEBUGCTLMSR_BTS_OFF_OS |
++                          IA32_DEBUGCTLMSR_BTS_OFF_USR);
+         }
++
++        if ( cp->feat.rtm )
++            rsvd &= ~IA32_DEBUGCTLMSR_RTM;
++
++        if ( msr_content & rsvd )
++            goto gp_fault;
++
+         if ( msr_content & IA32_DEBUGCTLMSR_LBR )
+         {
+             const struct lbr_info *lbr = last_branch_msr_get();
+-- 
+2.18.0
+

--- a/recipes-extended/xen/files/xsa272.patch
+++ b/recipes-extended/xen/files/xsa272.patch
@@ -1,0 +1,33 @@
+From: Christian Lindig <christian.lindig@citrix.com>
+Subject: tools/oxenstored: Make evaluation order explicit
+
+In Store.path_write(), Path.apply_modify() updates the node_created
+reference and both the value of apply_modify() and node_created are
+returned by path_write().
+
+At least with OCaml 4.06.1 this leads to the value of node_created being
+returned *before* it is updated by apply_modify().  This in turn leads
+to the quota for a domain not being updated in Store.write().  Hence, a
+guest can create an unlimited number of entries in xenstore.
+
+The fix is to make evaluation order explicit.
+
+This is XSA-272.
+
+Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
+Reviewed-by: Rob Hoes <rob.hoes@citrix.com>
+
+diff --git a/tools/ocaml/xenstored/store.ml b/tools/ocaml/xenstored/store.ml
+index 9f619b8fd5..8b0727f8a8 100644
+--- a/tools/ocaml/xenstored/store.ml
++++ b/tools/ocaml/xenstored/store.ml
+@@ -257,7 +257,8 @@ let path_write store perm path value =
+ 		Node.check_perm store.root perm Perms.WRITE;
+ 		Node.set_value store.root value, false
+ 	) else
+-		Path.apply_modify store.root path do_write, !node_created
++		let root = Path.apply_modify store.root path do_write in
++		root, !node_created
+ 
+ let path_rm store perm path =
+ 	let do_rm node name =

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -18,6 +18,8 @@ SRC_URI_append = " \
     file://xsa265.patch \
     file://xsa266-4.9/0001-libxl-qemu_disk_scsi_drive_string-Break-out-common-p.patch \
     file://xsa266-4.9/0002-libxl-restore-passing-readonly-to-qemu-for-SCSI-disk.patch \
+    file://xsa269-4.10.patch \
+    file://xsa272.patch \
     file://defconfig \
     file://config.patch \
     file://disable-xen-root-check.patch \

--- a/recipes-kernel/linux/4.14/linux-openxt_4.14.57.bb
+++ b/recipes-kernel/linux/4.14/linux-openxt_4.14.57.bb
@@ -8,6 +8,7 @@ PV_MAJOR = "${@"${PV}".split('.', 3)[0]}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:${THISDIR}/defconfigs:"
 SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;name=kernel \
+    file://xsa270.patch;patch=1 \
     file://bridge-carrier-follow-prio0.patch;patch=1 \
     file://privcmd-mmapnocache-ioctl.patch;patch=1 \
     file://xenkbd-tablet-resolution.patch;patch=1 \

--- a/recipes-kernel/linux/4.14/patches/xsa270.patch
+++ b/recipes-kernel/linux/4.14/patches/xsa270.patch
@@ -1,0 +1,55 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: xen-netback: fix input validation in xenvif_set_hash_mapping()
+
+Both len and off are frontend specified values, so we need to make
+sure there's no overflow when adding the two for the bounds check. We
+also want to avoid undefined behavior and hence use off to index into
+->hash.mapping[] only after bounds checking. This at the same time
+allows to take care of not applying off twice for the bounds checking
+against vif->num_queues.
+
+It is also insufficient to bounds check copy_op.len, as this is len
+truncated to 16 bits.
+
+This is XSA-270.
+
+Reported-by: Felix Wilhelm <fwilhelm@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Paul Durrant <paul.durrant@citrix.com>
+Tested-by: Paul Durrant <paul.durrant@citrix.com>
+---
+The bounds checking against vif->num_queues also occurs too early afaict
+(it should be done after the grant copy). I have patches ready as public
+follow-ups for both this and the (at least latent) issue of the mapping
+array crossing a page boundary.
+
+--- a/drivers/net/xen-netback/hash.c
++++ b/drivers/net/xen-netback/hash.c
+@@ -332,20 +332,22 @@ u32 xenvif_set_hash_mapping_size(struct
+ u32 xenvif_set_hash_mapping(struct xenvif *vif, u32 gref, u32 len,
+ 			    u32 off)
+ {
+-	u32 *mapping = &vif->hash.mapping[off];
++	u32 *mapping = vif->hash.mapping;
+ 	struct gnttab_copy copy_op = {
+ 		.source.u.ref = gref,
+ 		.source.domid = vif->domid,
+-		.dest.u.gmfn = virt_to_gfn(mapping),
+ 		.dest.domid = DOMID_SELF,
+-		.dest.offset = xen_offset_in_page(mapping),
+-		.len = len * sizeof(u32),
++		.len = len * sizeof(*mapping),
+ 		.flags = GNTCOPY_source_gref
+ 	};
+ 
+-	if ((off + len > vif->hash.size) || copy_op.len > XEN_PAGE_SIZE)
++	if ((off + len < off) || (off + len > vif->hash.size) ||
++	    len > XEN_PAGE_SIZE / sizeof(*mapping))
+ 		return XEN_NETIF_CTRL_STATUS_INVALID_PARAMETER;
+ 
++	copy_op.dest.u.gmfn = virt_to_gfn(mapping + off);
++	copy_op.dest.offset = xen_offset_in_page(mapping + off);
++
+ 	while (len-- != 0)
+ 		if (mapping[off++] >= vif->num_queues)
+ 			return XEN_NETIF_CTRL_STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
Backport the XSA patches until they make it to the stable-4.9 (or next micro 4.9.3 release).

Other XSA released on 2018-08-14:
- XSA-268: Arm specific
- XSA-269: x86: Incorrect MSR_DEBUGCTL handling lets guests enable BTS
- XSA-271: XAPI specific
- XSA-272: oxenstored does not apply quota-maxentity (not built by default in OpenXT)