### PR TITLE
dom0: disable auto-loading of a couple modules

### DIFF
--- a/recipes-kernel/modules/modules-1.0/xenclient-dom0/modules
+++ b/recipes-kernel/modules/modules-1.0/xenclient-dom0/modules
@@ -1,8 +1,6 @@
 psmouse
 v4v
-xen-netback
 xen-netfront
-wacom
 hid_multitouch
 fbtap
 txt


### PR DESCRIPTION
dom0 doesn't provide network backends in OpenXT, ndvm does, so xen-netback is not needed.
The wacom module isn't even built for dom0.

Signed-off-by: Jed <lejosnej@ainfosec.com>