### PR TITLE
STABLE-8: OXT-1365: refpolicy-mcs: give updatemgr overcommit read perm

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/updatemgr.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/updatemgr.te
@@ -57,7 +57,7 @@ files_dontaudit_search_home(updatemgr_t)
 fs_list_inotifyfs(updatemgr_t)
 # openssl reads meminfo
 kernel_read_system_state(updatemgr_t)
-kernel_read_vm_sysctls(updatemgr_t)
+kernel_read_vm_overcommit_sysctl(updatemgr_t)
 logging_send_syslog_msg(updatemgr_t)
 
 dbd_dbus_chat(updatemgr_t)


### PR DESCRIPTION
Use the correct interface to allow read permission on
/proc/sys/vm/overcommit_memory.

While kernel_read_vm_sysctls() will give appropriate permission to find
the overcommit_memory procfs node, that last one is labelled
sysctl_vm_overcommit_t.

kernel.if defines kernel_read_vm_overcommit_sysctl() macro which allow
both kernel_search_vm_syctls() and sysctl_vm_overcommit_t
read_file_perms required by updatemgr.

(cherry picked from commit 31bf8fd5bcd131ae49e95e9d717e611c1e3e1ae6)
