### PR TITLE
STABLE-8: OXT-1421: XSA-270 Linux netback driver OOB access in hash handling 

### DIFF
--- a/recipes-kernel/linux/4.14/linux-openxt_4.14.66.bb
+++ b/recipes-kernel/linux/4.14/linux-openxt_4.14.66.bb
@@ -44,6 +44,7 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch;patch=1 \
     file://xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch;patch=1 \
+    file://xsa270.patch \
     file://lookup_swap_cache-bandaid.patch \
     file://defconfig \
     "

--- a/recipes-kernel/linux/4.14/patches/xsa270.patch
+++ b/recipes-kernel/linux/4.14/patches/xsa270.patch
@@ -1,0 +1,55 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: xen-netback: fix input validation in xenvif_set_hash_mapping()
+
+Both len and off are frontend specified values, so we need to make
+sure there's no overflow when adding the two for the bounds check. We
+also want to avoid undefined behavior and hence use off to index into
+->hash.mapping[] only after bounds checking. This at the same time
+allows to take care of not applying off twice for the bounds checking
+against vif->num_queues.
+
+It is also insufficient to bounds check copy_op.len, as this is len
+truncated to 16 bits.
+
+This is XSA-270.
+
+Reported-by: Felix Wilhelm <fwilhelm@google.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Paul Durrant <paul.durrant@citrix.com>
+Tested-by: Paul Durrant <paul.durrant@citrix.com>
+---
+The bounds checking against vif->num_queues also occurs too early afaict
+(it should be done after the grant copy). I have patches ready as public
+follow-ups for both this and the (at least latent) issue of the mapping
+array crossing a page boundary.
+
+--- a/drivers/net/xen-netback/hash.c
++++ b/drivers/net/xen-netback/hash.c
+@@ -332,20 +332,22 @@ u32 xenvif_set_hash_mapping_size(struct
+ u32 xenvif_set_hash_mapping(struct xenvif *vif, u32 gref, u32 len,
+ 			    u32 off)
+ {
+-	u32 *mapping = &vif->hash.mapping[off];
++	u32 *mapping = vif->hash.mapping;
+ 	struct gnttab_copy copy_op = {
+ 		.source.u.ref = gref,
+ 		.source.domid = vif->domid,
+-		.dest.u.gmfn = virt_to_gfn(mapping),
+ 		.dest.domid = DOMID_SELF,
+-		.dest.offset = xen_offset_in_page(mapping),
+-		.len = len * sizeof(u32),
++		.len = len * sizeof(*mapping),
+ 		.flags = GNTCOPY_source_gref
+ 	};
+ 
+-	if ((off + len > vif->hash.size) || copy_op.len > XEN_PAGE_SIZE)
++	if ((off + len < off) || (off + len > vif->hash.size) ||
++	    len > XEN_PAGE_SIZE / sizeof(*mapping))
+ 		return XEN_NETIF_CTRL_STATUS_INVALID_PARAMETER;
+ 
++	copy_op.dest.u.gmfn = virt_to_gfn(mapping + off);
++	copy_op.dest.offset = xen_offset_in_page(mapping + off);
++
+ 	while (len-- != 0)
+ 		if (mapping[off++] >= vif->num_queues)
+ 			return XEN_NETIF_CTRL_STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
https://xenbits.xen.org/xsa/advisory-270.html

This is not upstream yet.

OXT-1421

This is on top of https://github.com/OpenXT/xenclient-oe/pull/1032. Once that is merged, it is just a single commit.