### PR TITLE
OXT-1431: Guest UEFI support

### DIFF
--- a/recipes-core/ovmf/ovmf/0003-BaseTools-makefile-adjust-to-build-in-under-bitbake.patch
+++ b/recipes-core/ovmf/ovmf/0003-BaseTools-makefile-adjust-to-build-in-under-bitbake.patch
@@ -1,0 +1,25 @@
+diff --git a/BaseTools/Source/C/Makefiles/header.makefile b/BaseTools/Source/C/Makefiles/header.makefile
+index db436773cf..79e554b790 100644
+--- a/BaseTools/Source/C/Makefiles/header.makefile
++++ b/BaseTools/Source/C/Makefiles/header.makefile
+@@ -68,15 +68,15 @@ $(error Bad HOST_ARCH)
+ endif
+ 
+ INCLUDE = $(TOOL_INCLUDE) -I $(MAKEROOT) -I $(MAKEROOT)/Include/Common -I $(MAKEROOT)/Include/ -I $(MAKEROOT)/Include/IndustryStandard -I $(MAKEROOT)/Common/ -I .. -I . $(ARCH_INCLUDE) 
+-BUILD_CPPFLAGS = $(INCLUDE) -O2
++BUILD_CPPFLAGS += $(INCLUDE) -O2
+ ifeq ($(DARWIN),Darwin)
+ # assume clang or clang compatible flags on OS X
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS += -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -c -g
+ else
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS += -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict -Wno-unused-result -nostdlib -c -g
+ endif
+-BUILD_LFLAGS =
+-BUILD_CXXFLAGS = -Wno-unused-result
++BUILD_LFLAGS = $(LDFLAGS)
++BUILD_CXXFLAGS += -Wno-unused-result
+ 
+ ifeq ($(HOST_ARCH), IA32)
+ #

--- a/recipes-core/ovmf/ovmf_git.bbappend
+++ b/recipes-core/ovmf/ovmf_git.bbappend
@@ -1,0 +1,53 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/ovmf:"
+
+SRC_URI = "git://github.com/tianocore/edk2.git;branch=master \
+    file://0002-ovmf-update-path-to-native-BaseTools.patch \
+    file://0003-BaseTools-makefile-adjust-to-build-in-under-bitbake.patch \
+    "
+
+SRCREV="dd4cae4d82c7477273f3da455084844db5cca0c0"
+
+FILES_${PN} += "\
+    /usr/share/firmware/ovmf.bin \
+    "
+
+# This is mostly a copy-paste from the upstream recipe but we need to force
+# OVMF_ARCH to be X64 and there is no easier way to do that. We omit a bunch
+# of symlinks and SecureBoot related logic that are just not applicable.
+do_compile_class-target() {
+    export LFLAGS="${LDFLAGS}"
+    OVMF_ARCH="X64"
+
+    # The build for the target uses BaseTools/Conf/tools_def.template
+    # from ovmf-native to find the compiler, which depends on
+    # exporting HOST_PREFIX.
+    export HOST_PREFIX="${HOST_PREFIX}"
+
+    # BaseTools/Conf gets copied to Conf, but only if that does not
+    # exist yet. To ensure that an updated template gets used during
+    # incremental builds, we need to remove the copy before we start.
+    rm -f `ls ${S}/Conf/*.txt | grep -v ReadMe.txt`
+
+    # ${WORKDIR}/ovmf is a well-known location where do_install and
+    # do_deploy will be able to find the files.
+    rm -rf ${WORKDIR}/ovmf
+    mkdir ${WORKDIR}/ovmf
+    OVMF_DIR_SUFFIX="X64"
+    FIXED_GCCVER=$(fixup_target_tools ${GCC_VER})
+    bbnote FIXED_GCCVER is ${FIXED_GCCVER}
+    build_dir="${S}/Build/Ovmf$OVMF_DIR_SUFFIX/RELEASE_${FIXED_GCCVER}"
+
+    bbnote "Building without Secure Boot."
+    rm -rf ${S}/Build/Ovmf$OVMF_DIR_SUFFIX
+    ${S}/OvmfPkg/build.sh $PARALLEL_JOBS -a $OVMF_ARCH -b RELEASE -t ${FIXED_GCCVER}
+    ln ${build_dir}/FV/OVMF.fd ${WORKDIR}/ovmf/ovmf.fd
+}
+
+do_install_class-target() {
+    install -d ${D}/usr/share/firmware/
+    install -m 0600 ${WORKDIR}/ovmf/ovmf.fd ${D}/usr/share/firmware/ovmf.bin
+}
+
+do_deploy_class-target() {
+    :
+}

--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -42,6 +42,7 @@ RDEPENDS_${PN} = " \
     iproute2 \
     qemu-dm \
     seabios \
+    ovmf \
     xcpmd \
     vbetool \
     xenclient-toolstack \

--- a/recipes-extended/xen/files/libxl-RFC-6of7-Build-the-domain-with-a-Linux-based-stubdomain.patch
+++ b/recipes-extended/xen/files/libxl-RFC-6of7-Build-the-domain-with-a-Linux-based-stubdomain.patch
@@ -217,7 +217,7 @@ PATCHES
 +                         GCSPRINTF("%s/hvmloader/bios",
 +                                   libxl__xs_get_dompath(gc, guest_domid)),
 +                        "%s",
-+                        libxl_bios_type_to_string(LIBXL_BIOS_TYPE_SEABIOS));
++                        libxl_bios_type_to_string(guest_config->b_info.u.hvm.bios));
 +    }
      ret = xc_domain_set_target(ctx->xch, dm_domid, guest_domid);
      if (ret<0) {

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -39,7 +39,7 @@ PATCHES
 @@ -2100,6 +2100,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                                     libxl__xs_get_dompath(gc, guest_domid)),
                          "%s",
-                         libxl_bios_type_to_string(LIBXL_BIOS_TYPE_SEABIOS));
+                         libxl_bios_type_to_string(guest_config->b_info.u.hvm.bios));
 +        /* OpenXT: We use legacy roms, which is disabled by default in sebios */
 +        libxl__xs_printf(gc, XBT_NULL,
 +                        libxl__sprintf(gc, "%s/hvmloader/seabios-legacy-load-roms",

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -103,8 +103,8 @@ PACKAGECONFIG =+ "hvm"
 S = "${WORKDIR}/git"
 
 #--
-# Override meta-virtualization's path to seabios:
-PACKAGECONFIG[hvm] = "--with-system-seabios="/usr/share/firmware/bios.bin",--disable-seabios,seabios ipxe vgabios,"
+# Override meta-virtualization's path to seabios and add ovmf:
+PACKAGECONFIG[hvm] = "--with-system-seabios="/usr/share/firmware/bios.bin" --with-system-ovmf="/usr/share/firmware/ovmf.bin",--disable-seabios,seabios ipxe vgabios ovmf,"
 
 #--
 # Modifications to the meta-virtualiation configuration (ref: OXT-1016)


### PR DESCRIPTION
Build and install OVMF to support UEFI mode in guests. The OVMF version produced from the upstream openembedded recipe doesn't work with Xen. The version of OVMF tagged by Xen doesn't support recent versions of Windows 10. Because of this we pick a recent revision of OVMF from upstream that is known to work (same revision is picked by Debian buster).

Guest UEFI mode has been tested with Debian Stretch and various version of Windows 10. Booting Windows 10 installer with OVMF may take several minutes during which only the "TianoCore" splash screen is displayed but afterwards Windows installs and boots without any issues.