### PR TITLE
OXT-1436: xenclient-idl: Add recipe version

### DIFF
--- a/recipes-openxt/xenclient/xenclient-idl_git.bb
+++ b/recipes-openxt/xenclient/xenclient-idl_git.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "XenClient IDL definitions + rpc stubs generation mechanism"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
+PV = "0+git${SRCPV}"
+
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/idl.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 


### PR DESCRIPTION
xenclient-idl lacked a version since it was a git recipe, so bitbake
assigned it version git-r0.  When idl.git changed, dependency tracking
was thrown off since the version remained the same.  This would break
rebuilds of dependant packages since their sysroots would not be updated
with the newer version.

Set PV so the recipe is versioned and dependencies can be tracked.

OXT-1436

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>