### PR TITLE
OXT-1441: libxl patch cleanup

### DIFF
--- a/recipes-extended/xen/files/libxl-atapi-pt.patch
+++ b/recipes-extended/xen/files/libxl-atapi-pt.patch
@@ -72,7 +72,7 @@ PATCHES
      if ((sscanf(virtpath, "d%ip%i%n", &disk, &partition, &chrused)  >= 2
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1555,13 +1555,21 @@ static int libxl__build_device_model_arg
+@@ -1562,13 +1562,21 @@ static int libxl__build_device_model_arg
              }
  
              if (disks[i].is_cdrom) {
@@ -101,7 +101,7 @@ PATCHES
              } else {
                  /*
                   * Explicit sd disks are passed through as is.
-@@ -1752,6 +1760,34 @@ static int libxl__build_device_model_arg
+@@ -1759,6 +1767,34 @@ static int libxl__build_device_model_arg
      }
  }
  
@@ -136,7 +136,7 @@ PATCHES
  static void libxl__dm_vifs_from_hvm_guest_config(libxl__gc *gc,
                                      libxl_domain_config * const guest_config,
                                      libxl_domain_config *dm_config)
-@@ -1978,9 +2014,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1985,9 +2021,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.stubdom_cmdline =
          libxl__strdup(gc, guest_config->b_info.stubdom_cmdline);
  

--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -135,7 +135,7 @@ PATCHES
      if (!err) {
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1540,7 +1540,7 @@ static int libxl__build_device_model_arg
+@@ -1547,7 +1547,7 @@ static int libxl__build_device_model_arg
                   */
                  if (disks[i].backend == LIBXL_DISK_BACKEND_TAP)
                      target_path = libxl__blktap_devpath(gc, disks[i].pdev_path,

--- a/recipes-extended/xen/files/libxl-display-manager-support.patch
+++ b/recipes-extended/xen/files/libxl-display-manager-support.patch
@@ -46,7 +46,7 @@ PATCHES
  static int
  libxl__xc_device_get_rdm(libxl__gc *gc,
                           uint32_t flags,
-@@ -922,6 +930,7 @@ static int libxl__build_device_model_arg
+@@ -929,6 +937,7 @@ static int libxl__build_device_model_arg
      const int num_disks = guest_config->num_disks;
      const int num_nics = guest_config->num_nics;
      const libxl_vnc_info *vnc = libxl__dm_vnc(guest_config);
@@ -54,7 +54,7 @@ PATCHES
      const libxl_sdl_info *sdl = dm_sdl(guest_config);
      const char *keymap = dm_keymap(guest_config);
      char *machinearg;
-@@ -1036,11 +1045,6 @@ static int libxl__build_device_model_arg
+@@ -1043,11 +1052,6 @@ static int libxl__build_device_model_arg
          flexarray_append(dm_args, vncarg);
      } /* OpenXT: no else here, we don't support "-vnc none" */
  
@@ -66,7 +66,7 @@ PATCHES
      if (sdl && !is_stubdom) {
          flexarray_append(dm_args, "-sdl");
          if (sdl->display)
-@@ -1098,6 +1102,13 @@ static int libxl__build_device_model_arg
+@@ -1105,6 +1109,13 @@ static int libxl__build_device_model_arg
          if (libxl_defbool_val(b_info->u.hvm.nographic) && (!sdl && !vnc)) {
              flexarray_append(dm_args, "-nographic");
          } else {

--- a/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
+++ b/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
@@ -143,7 +143,7 @@ PATCHES
  static void stubdom_pvqemu_cb(libxl__egc *egc,
                                libxl__multidev *multidev,
                                int rc)
-@@ -2296,7 +2301,6 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2280,7 +2231,6 @@ static void stubdom_pvqemu_cb(libxl__egc
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
      uint32_t dm_domid = sdss->pvqemu.guest_domid;
@@ -151,7 +151,7 @@ PATCHES
  
      libxl__xswait_init(&sdss->xswait);
  
-@@ -2300,16 +2251,7 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2290,16 +2240,7 @@ static void stubdom_pvqemu_cb(libxl__egc
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
+++ b/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
@@ -143,7 +143,15 @@ PATCHES
  static void stubdom_pvqemu_cb(libxl__egc *egc,
                                libxl__multidev *multidev,
                                int rc)
-@@ -2290,16 +2241,7 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2296,7 +2301,6 @@ static void stubdom_pvqemu_cb(libxl__egc
+     libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
+     STATE_AO_GC(sdss->dm.spawn.ao);
+     uint32_t dm_domid = sdss->pvqemu.guest_domid;
+-    libxl__xswait_state *xswait = &sdss->pvqemu.spawn.xswait;
+ 
+     libxl__xswait_init(&sdss->xswait);
+ 
+@@ -2300,16 +2251,7 @@ static void stubdom_pvqemu_cb(libxl__egc
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-move-extra-qemu-args-to-the-end.patch
+++ b/recipes-extended/xen/files/libxl-move-extra-qemu-args-to-the-end.patch
@@ -39,7 +39,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -641,8 +641,6 @@ static int libxl__build_device_model_arg
+@@ -648,8 +648,6 @@ static int libxl__build_device_model_arg
      if (state->saved_state) {
          flexarray_vappend(dm_args, "-loadvm", state->saved_state, NULL);
      }
@@ -48,7 +48,7 @@ PATCHES
      flexarray_append(dm_args, "-M");
      switch (b_info->type) {
      case LIBXL_DOMAIN_TYPE_PVH:
-@@ -659,6 +657,8 @@ static int libxl__build_device_model_arg
+@@ -666,6 +664,8 @@ static int libxl__build_device_model_arg
      default:
          abort();
      }
@@ -57,7 +57,7 @@ PATCHES
      flexarray_append(dm_args, NULL);
      *args = (char **) flexarray_contents(dm_args);
      flexarray_append(dm_envs, NULL);
-@@ -1420,8 +1420,6 @@ static int libxl__build_device_model_arg
+@@ -1427,8 +1427,6 @@ static int libxl__build_device_model_arg
          flexarray_append(dm_args, "-incoming");
          flexarray_append(dm_args, GCSPRINTF("fd:%d",*dm_state_fd));
      }
@@ -66,7 +66,7 @@ PATCHES
  
      flexarray_append(dm_args, "-machine");
      switch (b_info->type) {
-@@ -1716,6 +1714,8 @@ end_search:
+@@ -1723,6 +1721,8 @@ end_search:
              flexarray_append(dm_args, user);
          }
      }

--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -54,14 +54,6 @@ PATCHES
  static const char *libxl_tapif_script(libxl__gc *gc,
                                        const libxl_domain_build_info *info)
  {
-@@ -565,6 +569,7 @@ static int libxl__build_device_model_arg
-         }
-         if (b_info->u.hvm.soundhw) {
-             flexarray_vappend(dm_args, "-soundhw", b_info->u.hvm.soundhw, NULL);
-+            need_audio_helper = true;
-         }
-         if (libxl__acpi_defbool_val(b_info)) {
-             flexarray_append(dm_args, "-acpi");
 @@ -1215,6 +1220,7 @@ static int libxl__build_device_model_arg
          }
          if (b_info->u.hvm.soundhw) {

--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -54,7 +54,7 @@ PATCHES
  static const char *libxl_tapif_script(libxl__gc *gc,
                                        const libxl_domain_build_info *info)
  {
-@@ -1215,6 +1220,7 @@ static int libxl__build_device_model_arg
+@@ -1215,6 +1219,7 @@ static int libxl__build_device_model_arg
          }
          if (b_info->u.hvm.soundhw) {
              flexarray_vappend(dm_args, "-soundhw", b_info->u.hvm.soundhw, NULL);
@@ -62,7 +62,7 @@ PATCHES
          }
          if (!libxl__acpi_defbool_val(b_info)) {
              flexarray_append(dm_args, "-no-acpi");
-@@ -1878,6 +1884,25 @@ char *libxl__stub_dm_name(libxl__gc *gc,
+@@ -1878,6 +1883,25 @@ char *libxl__stub_dm_name(libxl__gc *gc,
      return GCSPRINTF("%s-dm", guest_name);
  }
  
@@ -88,7 +88,7 @@ PATCHES
  void libxl__spawn_stub_dm(libxl__egc *egc, libxl__stub_dm_spawn_state *sdss)
  {
      STATE_AO_GC(sdss->dm.spawn.ao);
-@@ -2013,6 +2038,22 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2013,6 +2037,22 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
+++ b/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
@@ -6,7 +6,6 @@ LibXL QEMU argument fixes to match the version used by OpenXT.
 ################################################################################
 LONG DESCRIPTION:
 ################################################################################
-* Fix the path to qemu-ifup
 * Don't use "-vnc none" or "-net none", our version of QEMU doesn't support it
 * More QEMU option changes to satisfy our version
 
@@ -37,19 +36,6 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -34,10 +34,10 @@ static const char *libxl_tapif_script(li
- {
- #if defined(__linux__) || defined(__FreeBSD__)
-     if (info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX)
--        return GCSPRINTF("/etc/qemu-ifup%s", "");
-+        return GCSPRINTF("/etc/qemu/qemu-ifup%s", "");
-     return libxl__strdup(gc, "no");
- #else
--    return GCSPRINTF("%s/qemu-ifup", libxl__xen_script_dir_path());
-+    return GCSPRINTF("%s/qemu/qemu-ifup", libxl__xen_script_dir_path());
- #endif
- }
- 
 @@ -950,17 +942,15 @@ static int libxl__build_device_model_arg
                        "-xen-domid",
                        GCSPRINTF("%d", guest_domid), NULL);

--- a/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
+++ b/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -950,17 +942,15 @@ static int libxl__build_device_model_arg
+@@ -949,17 +949,15 @@ static int libxl__build_device_model_arg
                        "-xen-domid",
                        GCSPRINTF("%d", guest_domid), NULL);
  
@@ -60,7 +60,7 @@ PATCHES
      }
  
      for (i = 0; i < guest_config->num_channels; i++) {
-@@ -1002,7 +992,7 @@ static int libxl__build_device_model_arg
+@@ -1001,7 +999,7 @@ static int libxl__build_device_model_arg
      }
  
      if (c_info->name) {
@@ -69,7 +69,7 @@ PATCHES
      }
  
      if (vnc && !is_stubdom) {
-@@ -1044,17 +1034,12 @@ static int libxl__build_device_model_arg
+@@ -1043,17 +1041,12 @@ static int libxl__build_device_model_arg
          }
  
          flexarray_append(dm_args, vncarg);
@@ -90,7 +90,7 @@ PATCHES
  
      if (sdl && !is_stubdom) {
          flexarray_append(dm_args, "-sdl");
-@@ -1112,6 +1097,9 @@ static int libxl__build_device_model_arg
+@@ -1111,6 +1104,9 @@ static int libxl__build_device_model_arg
  
          if (libxl_defbool_val(b_info->u.hvm.nographic) && (!sdl && !vnc)) {
              flexarray_append(dm_args, "-nographic");
@@ -100,7 +100,7 @@ PATCHES
          }
  
          if (libxl_defbool_val(b_info->u.hvm.spice.enable) && !is_stubdom) {
-@@ -1224,6 +1212,9 @@ static int libxl__build_device_model_arg
+@@ -1223,6 +1219,9 @@ static int libxl__build_device_model_arg
          }
          if (!libxl__acpi_defbool_val(b_info)) {
              flexarray_append(dm_args, "-no-acpi");
@@ -110,7 +110,7 @@ PATCHES
          }
          if (b_info->max_vcpus > 1) {
              flexarray_append(dm_args, "-smp");
-@@ -1249,7 +1240,7 @@ static int libxl__build_device_model_arg
+@@ -1248,7 +1247,7 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
                  flexarray_append(dm_args,
@@ -119,7 +119,7 @@ PATCHES
                               nics[i].model, nics[i].devid,
                               nics[i].devid, smac));
                  flexarray_append(dm_args, "-netdev");
-@@ -1400,11 +1391,9 @@ static int libxl__build_device_model_arg
+@@ -1399,11 +1398,9 @@ static int libxl__build_device_model_arg
  #undef APPEND_COLO_SOCK_CLIENT
              }
          }
@@ -134,7 +134,7 @@ PATCHES
      } else {
          if (!sdl && !vnc) {
              flexarray_append(dm_args, "-nographic");
-@@ -1518,7 +1507,7 @@ static int libxl__build_device_model_arg
+@@ -1517,7 +1514,7 @@ static int libxl__build_device_model_arg
              } else if ((disks[i].is_cdrom) && (b_info->stubdomain_version ==
                                                 LIBXL_STUBDOMAIN_VERSION_LINUX))
              {

--- a/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
+++ b/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
@@ -100,15 +100,6 @@ PATCHES
          }
  
          if (libxl_defbool_val(b_info->u.hvm.spice.enable) && !is_stubdom) {
-@@ -1156,7 +1144,7 @@ static int libxl__build_device_model_arg
- 
-         if (b_info->u.hvm.boot) {
-             flexarray_vappend(dm_args, "-boot",
--                    GCSPRINTF("order=%s", b_info->u.hvm.boot), NULL);
-+                    GCSPRINTF("%s", b_info->u.hvm.boot), NULL);
-         }
-         if (libxl_defbool_val(b_info->u.hvm.usb)
-             || b_info->u.hvm.usbdevice
 @@ -1224,6 +1212,9 @@ static int libxl__build_device_model_arg
          }
          if (!libxl__acpi_defbool_val(b_info)) {

--- a/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
+++ b/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
@@ -8,7 +8,6 @@ LONG DESCRIPTION:
 ################################################################################
 * Fix the path to qemu-ifup
 * Don't use "-vnc none" or "-net none", our version of QEMU doesn't support it
-* Replace "-std-vga" with "-vga std"
 * More QEMU option changes to satisfy our version
 
 ################################################################################
@@ -51,45 +50,6 @@ PATCHES
  #endif
  }
  
-@@ -461,14 +461,7 @@ static int libxl__build_device_model_arg
-         if (libxl_defbool_val(vnc->findunused)) {
-             flexarray_append(dm_args, "-vncunused");
-         }
--    } else
--        /*
--         * VNC is not enabled by default by qemu-xen-traditional,
--         * however passing -vnc none causes SDL to not be
--         * (unexpectedly) enabled by default. This is overridden by
--         * explicitly passing -sdl below as required.
--         */
--        flexarray_append_pair(dm_args, "-vnc", "none");
-+    } /* OpenXT: no else here, we don't support "-vnc none" */
- 
-     if (sdl) {
-         flexarray_append(dm_args, "-sdl");
-@@ -527,7 +520,7 @@ static int libxl__build_device_model_arg
- 
-         switch (b_info->u.hvm.vga.kind) {
-         case LIBXL_VGA_INTERFACE_TYPE_STD:
--            flexarray_append(dm_args, "-std-vga");
-+            flexarray_append_pair(dm_args, "-vga", "std");
-             break;
-         case LIBXL_VGA_INTERFACE_TYPE_CIRRUS:
-             break;
-@@ -612,10 +605,9 @@ static int libxl__build_device_model_arg
-                 ioemu_nics++;
-             }
-         }
--        /* If we have no emulated nics, tell qemu not to create any */
--        if ( ioemu_nics == 0 ) {
--            flexarray_vappend(dm_args, "-net", "none", NULL);
--        }
-+
-+        /* OpenXT: We don't support -net none, adding nothing if there's 0 nic */
-+
-         if (libxl_defbool_val(b_info->u.hvm.gfx_passthru)) {
-             switch (b_info->u.hvm.gfx_passthru_kind) {
-             case LIBXL_GFX_PASSTHRU_KIND_DEFAULT:
 @@ -950,17 +942,15 @@ static int libxl__build_device_model_arg
                        "-xen-domid",
                        GCSPRINTF("%d", guest_domid), NULL);

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2065,6 +2065,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2072,6 +2072,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                                     libxl__xs_get_dompath(gc, guest_domid)),
                          "%s",
                          libxl_bios_type_to_string(guest_config->b_info.u.hvm.bios));
@@ -48,7 +48,7 @@ PATCHES
      }
      ret = xc_domain_set_target(ctx->xch, dm_domid, guest_domid);
      if (ret<0) {
-@@ -2089,6 +2094,12 @@ retry_transaction:
+@@ -2096,6 +2101,12 @@ retry_transaction:
          if (errno == EAGAIN)
              goto retry_transaction;
  
@@ -61,7 +61,7 @@ PATCHES
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
      /* OpenXT: Again, no disk for the stubdom itself */
-@@ -2107,7 +2118,6 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2114,7 +2125,6 @@ static void spawn_stub_launch_dm(libxl__
  {
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
@@ -69,7 +69,7 @@ PATCHES
      int i, num_console = STUBDOM_SPECIAL_CONSOLES;
      libxl__device_console *console;
  
-@@ -2157,21 +2167,16 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2164,21 +2174,16 @@ static void spawn_stub_launch_dm(libxl__
  
      for (i = 0; i < num_console; i++) {
          console[i].devid = i;
@@ -95,7 +95,7 @@ PATCHES
                  /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
                   * will be in use */
                  console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
-@@ -2385,6 +2389,17 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2391,6 +2396,17 @@ void libxl__spawn_local_dm(libxl__egc *e
                           b_info->device_model_version==LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL &&
                           !libxl__vnuma_configured(b_info));
          free(path);

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -95,14 +95,6 @@ PATCHES
                  /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
                   * will be in use */
                  console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
-@@ -2261,7 +2266,6 @@ static void stubdom_pvqemu_cb(libxl__egc
-     libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
-     STATE_AO_GC(sdss->dm.spawn.ao);
-     uint32_t dm_domid = sdss->pvqemu.guest_domid;
--    libxl__xswait_state *xswait = &sdss->pvqemu.spawn.xswait;
- 
-     libxl__xswait_init(&sdss->xswait);
- 
 @@ -2385,6 +2389,17 @@ void libxl__spawn_local_dm(libxl__egc *e
                           b_info->device_model_version==LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL &&
                           !libxl__vnuma_configured(b_info));

--- a/recipes-extended/xen/files/libxl-stubdom-options.patch
+++ b/recipes-extended/xen/files/libxl-stubdom-options.patch
@@ -51,7 +51,7 @@ PATCHES
      ("iomem",            Array(libxl_iomem_range, "num_iomem")),
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1960,6 +1960,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1967,6 +1967,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          abort();
      }
      dm_config->b_info.max_memkb += guest_config->b_info.video_memkb;
@@ -59,7 +59,7 @@ PATCHES
      dm_config->b_info.target_memkb = dm_config->b_info.max_memkb;
  
      dm_config->b_info.max_grant_frames = guest_config->b_info.max_grant_frames;
-@@ -1974,6 +1975,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1981,6 +1982,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.extra = guest_config->b_info.extra;
      dm_config->b_info.extra_pv = guest_config->b_info.extra_pv;
      dm_config->b_info.extra_hvm = guest_config->b_info.extra_hvm;
@@ -68,7 +68,7 @@ PATCHES
  
      dm_config->disks = guest_config->disks;
      dm_config->num_disks = guest_config->num_disks;
-@@ -2014,6 +2017,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2021,6 +2024,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                                libxl__xenfirmwaredir_path());
          stubdom_state->pv_ramdisk.path = libxl__abs_path(gc, "stubdomain-initramfs",
                                                           libxl__xenfirmwaredir_path());

--- a/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
+++ b/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
@@ -31,7 +31,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -858,14 +858,13 @@ static char *qemu_disk_ide_drive_string(
+@@ -865,14 +865,13 @@ static char *qemu_disk_ide_drive_string(
      const char *exportname = disk->colo_export;
      const char *active_disk = disk->active_disk;
      const char *hidden_disk = disk->hidden_disk;
@@ -49,7 +49,7 @@ PATCHES
          break;
      case LIBXL__COLO_PRIMARY:
          /*
-@@ -878,13 +877,13 @@ static char *qemu_disk_ide_drive_string(
+@@ -885,13 +884,13 @@ static char *qemu_disk_ide_drive_string(
           *  vote-threshold=1
           */
          drive = GCSPRINTF(
@@ -65,7 +65,7 @@ PATCHES
          break;
      case LIBXL__COLO_SECONDARY:
          /*
-@@ -898,7 +897,7 @@ static char *qemu_disk_ide_drive_string(
+@@ -905,7 +904,7 @@ static char *qemu_disk_ide_drive_string(
           *  file.backing.backing=exportname,
           */
          drive = GCSPRINTF(
@@ -74,7 +74,7 @@ PATCHES
              "driver=replication,"
              "mode=secondary,"
              "top-id=top-colo,"
-@@ -907,7 +906,7 @@ static char *qemu_disk_ide_drive_string(
+@@ -914,7 +913,7 @@ static char *qemu_disk_ide_drive_string(
              "file.backing.driver=qcow2,"
              "file.backing.file.filename=%s,"
              "file.backing.backing=%s",
@@ -83,7 +83,7 @@ PATCHES
          break;
      default:
           abort();
-@@ -1604,11 +1603,6 @@ static int libxl__build_device_model_arg
+@@ -1611,11 +1610,6 @@ static int libxl__build_device_model_arg
                          disk, disk), NULL);
                      continue;
                  } else if (disk < 4) {

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -107,7 +107,7 @@ PATCHES
                                     libxl__device_backend_path(gc, device)),
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1250,9 +1250,12 @@ static int libxl__build_device_model_arg
+@@ -1257,9 +1257,12 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
                  flexarray_append(dm_args,
@@ -123,7 +123,7 @@ PATCHES
                  flexarray_append(dm_args, "-netdev");
                  flexarray_append(dm_args,
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
-@@ -1762,6 +1765,9 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1769,6 +1772,9 @@ static void libxl__dm_vifs_from_hvm_gues
          libxl_device_nic_init(&dm_config->nics[i]);
          libxl_device_nic_copy(ctx, &dm_config->nics[i], &guest_config->nics[i]);
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -170,7 +170,7 @@ PATCHES
  out:
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2111,6 +2111,20 @@ retry_transaction:
+@@ -2118,6 +2118,20 @@ retry_transaction:
      libxl__xs_printf(gc, XBT_NULL,
                       DEVICE_MODEL_XS_PATH(gc, dm_domid, guest_domid, "/xen_extended_power_mgmt"), "2");
  

--- a/recipes-openxt/qemu-dm/qemu-dm-stubdom_2.12.0.bb
+++ b/recipes-openxt/qemu-dm/qemu-dm-stubdom_2.12.0.bb
@@ -13,7 +13,7 @@ EXTRA_OECONF += " --audio-drv-list=openxt --enable-openxt-stubdom "
 
 do_install_append(){
     install -m 0755 -d ${D}${sysconfdir}/qemu
-    install -m 0755 ${WORKDIR}/qemu-ifup-stubdom ${D}${sysconfdir}/qemu/qemu-ifup
+    install -m 0755 ${WORKDIR}/qemu-ifup-stubdom ${D}${sysconfdir}/qemu-ifup
 }
 
 PR = "${INC_PR}.9"


### PR DESCRIPTION
There are some unneccesary changes to tools/libxl/libxl_dm.c. This removes them.  We only use qemu-xen, so we don't need to touch libxl__build_device_model_args_old used by qemu-traditional.