### PR TITLE
Set PV variable

### DIFF
--- a/recipes-openxt/xctools/heimdallr_git.bb
+++ b/recipes-openxt/xctools/heimdallr_git.bb
@@ -3,6 +3,8 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 DEPENDS = "json-c pciutils"
 
+PV = "0+git${SRCPV}"
+
 SRC_URI = "git://github.com/achartier/heimdallr.git;protocol=git \
            file://pci-quirks.json \
            file://fix-json-pkgconfig-name.patch \

--- a/recipes-openxt/xenclient/dbd_git.bb
+++ b/recipes-openxt/xenclient/dbd_git.bb
@@ -7,6 +7,8 @@ DEPENDS = " \
     xenclient-toolstack \
 "
 
+PV = "0+git${SRCPV}"
+
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
     git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \

--- a/recipes-openxt/xenclient/uid_git.bb
+++ b/recipes-openxt/xenclient/uid_git.bb
@@ -8,6 +8,8 @@ DEPENDS = " \
     xenclient-toolstack \
 "
 
+PV = "0+git${SRCPV}"
+
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/uid.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 

--- a/recipes-openxt/xenclient/xenclient-rpcgen_git.bb
+++ b/recipes-openxt/xenclient/xenclient-rpcgen_git.bb
@@ -1,6 +1,8 @@
 RPCGEN_VERSION = "1.0"
 require xenclient-rpcgen.inc
 
+PV = "0+git${SRCPV}"
+
 BBCLASSEXTEND = "native"
 
 S = "${WORKDIR}/git/rpcgen"


### PR DESCRIPTION
We have some git bitbake recipes missing a PV definition.  Without PV, the packages are versioned as "git-r0" and will not change if the git revision changes.  Bitbake cannot properly track dependencies to those packages. and dependent packages may fail to rebuild.

This PR only changes the 4 recipes included in my builds.
recipes-openxt/xctools/heimdallr_git.bb
recipes-openxt/xenclient/xenclient-rpcgen_git.bb
recipes-openxt/xenclient/uid_git.bb
recipes-openxt/xenclient/dbd_git.bb

OVMF is also missing a PV definition, but we only append that one.  It would unconventional to set PV in the bbappend; upstream should be fixed.
recipes-core/ovmf/ovmf_git.bbappend

Other recipes missing PV include:
recipes-devtools/bats/bats_git.bb
recipes-openxt/bats-testsuite/bats-testsuite_git.bb
recipes-openxt/xenclient/debs/deb-libxenstore_git.bb
recipes-openxt/xenclient/essential-target-builddepends_git.bb