### PR TITLE
syncvm: Specify read-only-rootfs IMAGE_FEATURES

### DIFF
--- a/recipes-core/images/xenclient-syncvm-image.bb
+++ b/recipes-core/images/xenclient-syncvm-image.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = " \
 
 IMAGE_FEATURES += " \
     package-management \
+    read-only-rootfs \
 "
 
 IMAGE_FSTYPES = "ext3.vhd.gz"


### PR DESCRIPTION
The syncvm image is read-only, so specify that.  Most visibly, this
removes a bunch of warnings about populating the udev cache when the
rootfs is read-only.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>