### PR TITLE
STABLE-8: OXT-1428, OXT-1429, OXT-1430: Upgrade meta-selinux tracked revision.

### DIFF
--- a/recipes-devtools/e2fsprogs/patches/misc_create_inode.c-label_rootfs.patch
+++ b/recipes-devtools/e2fsprogs/patches/misc_create_inode.c-label_rootfs.patch
@@ -1,0 +1,37 @@
+From: Philip Tricca <flihp@twobit.us>
+To: tytso@mit.edu
+Cc: liezhi.yang@windriver.com
+Date: Sat, 20 Feb 2016 18:58:58 +0000
+Subject: [PATCH] misc/create_inode.c: Copy xattrs from root directory when populating fs.
+
+When copying a file system using the -d option the xattrs from the root
+directory need to be copied before the populate_fs recusion starts.
+
+Signed-off-by: Philip Tricca <flihp@twobit.us>
+---
+ misc/create_inode.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/misc/create_inode.c b/misc/create_inode.c
+index 0de5719..ee21186 100644
+--- a/misc/create_inode.c
++++ b/misc/create_inode.c
+@@ -890,8 +890,15 @@ errcode_t populate_fs(ext2_filsys fs, ext2_ino_t parent_ino,
+ 		return retval;
+ 	}
+ 
++	retval = set_inode_xattr(fs, root, source_dir);
++	if (retval) {
++		com_err(__func__, retval,
++			_("while setting xattrs for \"%s\""), source_dir);
++		goto out;
++	}
+ 	retval = __populate_fs(fs, parent_ino, source_dir, root, &hdlinks);
+ 
++out:
+ 	free(hdlinks.hdl);
+ 	return retval;
+ }
+-- 
+2.1.4
+

--- a/recipes-security/selinux/libsemanage_2.7.bbappend
+++ b/recipes-security/selinux/libsemanage_2.7.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS_${PN}_remove += "python"


### PR DESCRIPTION
- Remove changes pushed upstream.
- `meta-selinux` does not maintain a pyro branch, but we do. Latest meta-selinux e2fsprogs patch-queue does not apply on pyro version, we may still used the previous patch version.