### PR TITLE
STABLE-8: OXT-1448: xen: upgrade to 4.9.3

### DIFF
--- a/recipes-extended/xen/xen-version.inc
+++ b/recipes-extended/xen/xen-version.inc
@@ -1,3 +1,3 @@
-XEN_PV = "4.9.3-pre"
+XEN_PV = "4.9.3"
 XEN_BRANCH = "stable-4.9"
-XEN_SRCREV = "71e51140fdeb98c8fefc3a7067b554212bb61ac9"
+XEN_SRCREV = "RELEASE-4.9.3"


### PR DESCRIPTION
Bump tracked version to latest micro-release.
No change to the patch-queue.

Xen log from original tracked revision:
```
062052a149 update Xen version to 4.9.3
ca65ce2b52 x86: assorted array_index_nospec() insertions
792130b9d2 VT-d/dmar: iommu mem leak fix
a6100f3ede rangeset: make inquiry functions tolerate NULL inputs
09cdeaeb60 x86/setup: Avoid OoB E820 lookup when calculating the L1TF safe address
e9192cd9ac x86/hvm/ioreq: MMIO range checking completely ignores direction flag
1f399b907f x86/vlapic: Bugfixes and improvements to vlapic_{read,write}()
5bb24b2792 x86/vmx: Avoid hitting BUG_ON() after EPTP-related domain_crash()
```