### PR TITLE
blktap: Amend sanity check.

### DIFF
--- a/recipes-kernel/linux/4.14/patches/blktap2.patch
+++ b/recipes-kernel/linux/4.14/patches/blktap2.patch
@@ -1296,7 +1296,7 @@ PATCHES
 +}
 --- /dev/null
 +++ b/drivers/block/blktap/request.c
-@@ -0,0 +1,419 @@
+@@ -0,0 +1,425 @@
 +#include <linux/mempool.h>
 +#include <linux/spinlock.h>
 +#include <linux/mutex.h>
@@ -1435,16 +1435,22 @@ PATCHES
 +{
 +	struct scatterlist *sg = &request->sg_table[seg];
 +	void *s, *p;
-+	if (!sg || !request) return;
++
++	if (!sg || !request)
++		return;
++
 +	BUG_ON(seg >= request->nr_pages);
-+	
++
 +	s = sg_virt(sg);
-+	p = page_address(request->pages[seg]) + sg->offset;
-+	if (!s || !p) return;
-+	if (write) {
++	p = page_address(request->pages[seg]);
++	if (!s || !p)
++		return;
++
++	p = (uint8_t*)p + sg->offset;
++	if (write)
 +		memcpy(p, s, sg->length);
-+	} else {
-+		memcpy(s, p, sg->length); }
++	else
++		memcpy(s, p, sg->length);
 +}
 +
 +static void


### PR DESCRIPTION
`blktap_request_bounce()` sanity check on the request's page translation
result should not include the sg->offset.

Make the indentation compliant with kernel guidelines.