### PR TITLE
OXT-1452: uefi/tboot: Load microcode from MBI2 modules.

### DIFF
--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
@@ -5,31 +5,31 @@ sinit=GM45_GS45_PM45_SINIT_51.BIN Q35_SINIT_51.BIN Q45_Q43_SINIT_51.BIN i5_i7_DU
 ucode=microcode_intel.bin
 
 [openxt-normal]
-options=placeholder console=com1 dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0
+options=placeholder console=com1 dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 autostart
 ramdisk=initramfs.gz
 xsm=policy.24
  
 [openxt-support-safe-graphics]
-options=console=com1 dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0
+options=console=com1 dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 safe-graphic nomodeset
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-amt]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-console]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-console-amt]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24


### PR DESCRIPTION
This should be considered a work-around for now, until further discussion.
- Another way to do this would be to pass the microcode module through the xenmbi structure. It seems hackish to me as it adds to the existing Xen interfaces to handle the microcode and the microcode is always the last module in this case.
- Yet another possibility would be to load the microcode in the first Xen instance, but then TBoot will not measure the loaded microcode.
- This change just instruct the later Xen to find it in the last module using the cmdline argument.

During UEFI/TBoot boostrap, xen.efi will fetch the microcode using the
openxt.cfg configuration file and write the binary blob in the last MBI
[module](https://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=xen/arch/x86/efi/efi-boot.h;h=5789d2cb70726a556785e823ee4eafcdb514aa6c;hb=HEAD#l287), then passes everything to TBoot.

Once TBoot is done, the new measured instance of Xen starts and boots
from the MBI2 information. The remaining modules include the microcode,
but the current Xen cmdline does not point which one is the
microcode.

Add ucode=-1, the microcode being guaranteed to be the last module.