### PR TITLE
openxt-main: Remove nfs from DISTRO_FEATURES

### DIFF
--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -18,12 +18,12 @@
 
 # openembedded-core sets a default list of DISTRO_FEATURES that do not match
 # OpenXT's machine needs.
-# See: openembedded-core/meta/conf/distro/include/default-distrovars.inc 
+# See: openembedded-core/meta/conf/distro/include/default-distrovars.inc
 # Another way would be hard setting DISTRO_FEATURES.
-# Another way wouwld be to redefine DISTRO_FEATURES_DEFAULT.
+# Another way would be to redefine DISTRO_FEATURES_DEFAULT.
 # Down the road this should probably be a machine config thing so it is possible
 # to have images that do not include selinux
-DISTRO_FEATURES_remove = "zeroconf"
+DISTRO_FEATURES_remove = "zeroconf nfs"
 DISTRO_FEATURES_append += "pam selinux multiarch"
 
 # Use OpenXT Linux patched kernel.


### PR DESCRIPTION
packagegroup-base creates a subpackage packagegroup-base-nfs when nfs is
set in DISTRO_FEATURES.  This installs and runs rpcbind in all the
OpenXT images since nfs is set in DISTRO_FEATURES_DEFAULT.

Drop nfs from DISTRO_FEATURES to omit rpcbind from the images.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>