### PR TITLE
lvm udev rules: avoid trying to create bad symlinks

### DIFF
--- a/recipes-support/lvm2/lvm2/test-for-blk-file-before-creating-dm-mapper-symlink.patch
+++ b/recipes-support/lvm2/lvm2/test-for-blk-file-before-creating-dm-mapper-symlink.patch
@@ -1,0 +1,26 @@
+--- a/udev/10-dm.rules.in
++++ b/udev/10-dm.rules.in
+@@ -132,7 +132,11 @@ ENV{DM_SUSPENDED}=="Suspended", ENV{DM_S
+ # VSN 2 - add support for synthesized events
+ ENV{DM_UDEV_RULES_VSN}="2"
+ 
+-ENV{DM_UDEV_DISABLE_DM_RULES_FLAG}!="1", ENV{DM_NAME}=="?*", SYMLINK+="(DM_DIR)/$env{DM_NAME}"
++# OpenXT: at this point, /dev/mapper is already populated with
++#   actual blk nodes, and DM_UDEV_DISABLE_DM_RULES_FLAG is not set.
++#   The symlink creation would fail and error in dmesg.
++#   Only try to create the symlink if there's no blk file there.
++ENV{DM_UDEV_DISABLE_DM_RULES_FLAG}!="1", ENV{DM_NAME}=="?*", PROGRAM="/usr/bin/test ! -b /dev/(DM_DIR)/$env{DM_NAME}", SYMLINK+="(DM_DIR)/$env{DM_NAME}"
+ 
+ # Avoid processing and scanning a DM device in the other (foreign)
+ # rules if it is in suspended state. However, we still keep 'disk'
+--- a/udev/Makefile.in
++++ b/udev/Makefile.in
+@@ -52,7 +52,7 @@ PVSCAN_RULE=RUN\+\=\"$(LVM_EXEC)/lvm pvs
+ endif
+ 
+ %.rules: $(srcdir)/%.rules.in
+-	$(SED) -e "s+(DM_DIR)+$(DM_DIR)+;s+(BLKID_RULE)+$(BLKID_RULE)+;s+(PVSCAN_RULE)+$(PVSCAN_RULE)+;s+(DM_EXEC_RULE)+$(DM_EXEC_RULE)+;s+(DM_EXEC)+$(DM_EXEC)+;s+(LVM_EXEC_RULE)+$(LVM_EXEC_RULE)+;s+(LVM_EXEC)+$(LVM_EXEC)+;" $< >$@
++	$(SED) -e "s+(DM_DIR)+$(DM_DIR)+g;s+(BLKID_RULE)+$(BLKID_RULE)+;s+(PVSCAN_RULE)+$(PVSCAN_RULE)+;s+(DM_EXEC_RULE)+$(DM_EXEC_RULE)+;s+(DM_EXEC)+$(DM_EXEC)+;s+(LVM_EXEC_RULE)+$(LVM_EXEC_RULE)+;s+(LVM_EXEC)+$(LVM_EXEC)+;" $< >$@
+ 
+ %_install: %.rules
+ 	$(INSTALL_DATA) -D $< $(udevdir)/$(<F)

--- a/recipes-support/lvm2/lvm2_%.bbappend
+++ b/recipes-support/lvm2/lvm2_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://yocto-initscripts.patch \
     file://0001-lvmetad-fix-segfault-on-i386.patch \
+    file://test-for-blk-file-before-creating-dm-mapper-symlink.patch \
 "
 
 # meta-oe recipe will already _append the autotools do_install(), and


### PR DESCRIPTION
lvm expects /dev/mapper to be populated with symlinks,
but instead it contains actual blk files.
Remove the rule that creates those symlinks.

OXT-1274

Signed-off-by: Jed <lejosnej@ainfosec.com>