### PR TITLE
OXT-1463: xorg: Partially restore former configuration.

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/xenclient-uivm/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/xenclient-uivm/xorg.conf
@@ -1,0 +1,16 @@
+# Xorg configuration for UIVM.
+
+Section "ServerFlags"
+        Option "DontZap"        "true"
+        Option "DontVTSwitch"   "true"
+        Option "BlankTime"      "0"
+        Option "StandbyTime"    "0"
+        Option "SuspendTime"    "0"
+        Option "OffTime"        "0"
+EndSection
+
+Section "Device"
+        Identifier "fbdev0"
+        Driver     "fbdev"
+        Option     "ShadowFB"   "true"
+EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://xorg.conf"


### PR DESCRIPTION
- DontVTSwitch:
    Disable switch to another "virtual terminal" (Ctrl+Alt+Fn) which can
    trigger graphic glitches with xenfb2.
- DontZap:
    Disable XKB action terminating X session (Ctrl+Alt+Backspace).
- BlankTime:
    Set inactivity timeout before blanking the screen, 0 disables the
    phase. This restore past behavior.
- Device/ShadowFB:
    Enable ShadowFB explicitely. It is by default, but left in place as
    it appears to slow down UIVM significantly when disabled.

~- DPMS is not implemented for fbdev, so remove the `StandbyTime`, `SuspendTime`, `OffTime`.~
Actually it is enforced with the fbdev patch... So add back the values to avoid the blanking.

- AutoAddDevices defaults to on and removes the need to set `InputDevice` sections in the configuration based on absolute paths (`/dev/input/eventX`).
- `Device` section for "intel" is legacy.