### PR TITLE
[RFC] initrdscripts: add openxt framework modules

### DIFF
--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -19,7 +19,11 @@ IMAGE_INSTALL = " \
     libtctidevice \
     tpm-tools-sa \
     tpm2-tools \
-    initramfs-xenclient \
+    initramfs-module-lvm \
+    initramfs-module-bootfs \
+    initramfs-module-tpm \
+    initramfs-module-tpm2 \
+    initramfs-module-selinux \
     xenclient-initramfs-shared-libs \
     kernel-module-tpm \
     kernel-module-tpm-tis \

--- a/recipes-core/initrdscripts/initramfs-framework/bootfs
+++ b/recipes-core/initrdscripts/initramfs-framework/bootfs
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Copyright (C) 2018 Apertus Solutions, LLC
+# Licensed on MIT
+
+bootfs_enabled() {
+	if [ -n "${bootparam_boot}" ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+bootfs_run() {
+	BOOTFS_DIR="/${ROOTFS_DIR}/boot/system"
+        if [ -z "$BOOTFS_DIR" ]; then
+                return
+        fi
+        C=0
+	# will use rootfs' delay and timeout values
+        delay=${bootparam_rootdelay:-1}
+        timeout=${bootparam_roottimeout:-5}
+        while [ ! -d $BOOTFS_DIR/grub ]; do
+                if [ $(( $C * $delay )) -gt $timeout ]; then
+                        fatal "boot '$bootparam_boot' doesn't exist or does not contain a /grub."
+                fi
+
+                if [ -n "$bootparam_boot" ]; then
+                        debug "No e2fs compatible filesystem has been mounted, mounting $bootparam_boot..."
+
+                        if [ "`echo ${bootparam_boot} | cut -c1-5`" = "UUID=" ]; then
+                                boot_uuid=`echo $bootparam_boot | cut -c6-`
+                                bootparam_boot="/dev/disk/by-uuid/$boot_uuid"
+                        fi
+
+                        if [ "`echo ${bootparam_boot} | cut -c1-9`" = "PARTUUID=" ]; then
+                                boot_uuid=`echo $bootparam_boot | cut -c10-`
+                                bootparam_boot="/dev/disk/by-partuuid/$boot_uuid"
+                        fi
+
+                        if [ -e "$bootparam_boot" ]; then
+                                flags=""
+                                if [ -n "$bootparam_bootfstype" ]; then
+                                        flags="$flags -t$bootparam_bootfstype"
+                                fi
+                                mount $flags $bootparam_boot $BOOTFS_DIR
+                                if [ -d $BOOTFS_DIR/grub ]; then
+                                        break
+                                else
+                                        # It is unlikely to change, but keep trying anyway.
+                                        # Perhaps we pick a different device next time.
+                                        umount $BOOTFS_DIR
+				fi
+			fi
+                fi
+                debug "Sleeping for $delay second(s) to wait root to settle..."
+                sleep $delay
+                C=$(( $C + 1 ))
+        done
+}

--- a/recipes-core/initrdscripts/initramfs-framework/init
+++ b/recipes-core/initrdscripts/initramfs-framework/init
@@ -1,0 +1,150 @@
+#!/bin/sh
+# Copyright (C) 2011 O.S. Systems Software LTDA.
+# Licensed on MIT
+#
+# Provides the API to be used by the initramfs modules
+#
+# Modules need to provide the following functions:
+#
+# <module>_enabled : check if the module ought to run (return 1 to skip)
+# <module>_run     : do what is need
+#
+# Boot parameters are available on environment in the as:
+#
+# 'foo=value' as 'bootparam_foo=value'
+# 'foo' as 'bootparam_foo=true'
+# 'foo.bar[=value] as 'foo_bar=[value|true]'
+
+# Register a function to be called before running a module
+# The hook is called as:
+#   <function> pre <module>
+add_module_pre_hook() {
+	MODULE_PRE_HOOKS="$MODULE_PRE_HOOKS $1"
+}
+
+# Register a function to be called after running a module
+# The hook is called as:
+#   <function> post <module>
+add_module_post_hook() {
+	MODULE_POST_HOOKS="$MODULE_POST_HOOKS $1"
+}
+
+# Load kernel module
+load_kernel_module() {
+	if modprobe $1 >/dev/null 2>&1; then
+		info "Loaded module $1"
+	else
+		debug "Failed to load module $1"
+	fi
+}
+
+# Prints information
+msg() {
+	echo "$@" >/dev/console
+}
+
+# Prints information if verbose bootparam is used
+info() {
+	[ -n "$bootparam_verbose" ] && echo "$@" >/dev/console
+}
+
+# Prints information if debug bootparam is used
+debug() {
+	[ -n "$bootparam_debug" ] && echo "DEBUG: $@" >/dev/console
+}
+
+# Prints a message and start a endless loop
+fatal() {
+    echo $1 >/dev/console
+    echo >/dev/console
+
+    if [ -n "$bootparam_init_fatal_sh" ]; then
+        sh
+    else
+	while [ "true" ]; do
+		sleep 3600
+	done
+    fi
+}
+
+# Variables shared amoung modules
+ROOTFS_DIR="/rootfs" # where to do the switch root
+MODULE_PRE_HOOKS=""  # functions to call before running each module
+MODULE_POST_HOOKS="" # functions to call after running each module
+MODULES_DIR=/init.d  # place to look for modules
+
+# make mount stop complaining about missing /etc/fstab
+touch /etc/fstab
+
+# initialize /proc, /sys, /run/lock and /var/lock
+mkdir -p /proc /sys /run/lock /var/lock
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+
+# populate bootparam environment
+for p in `cat /proc/cmdline`; do
+	opt=`echo $p | cut -d'=' -f1`
+	opt=`echo $opt | tr '.-' '__'`
+	if [ "`echo $p | cut -d'=' -f1`" = "$p" ]; then
+		case $opt in
+		[0123456Ss])
+			eval "bootparam_runlevel=\"${opt}\"";;
+		*)
+			eval "bootparam_${opt}=true";;
+		esac
+	else
+		value="`echo $p | cut -d'=' -f2-`"
+		eval "bootparam_${opt}=\"${value}\""
+	fi
+done
+
+# use /dev with devtmpfs
+if grep -q devtmpfs /proc/filesystems; then
+	mkdir -p /dev
+	mount -t devtmpfs devtmpfs /dev
+else
+	if [ ! -d /dev ]; then
+		fatal "ERROR: /dev doesn't exist and kernel doesn't has devtmpfs enabled."
+	fi
+fi
+
+mkdir $ROOTFS_DIR
+
+# Load and run modules
+for m in $MODULES_DIR/*; do
+	# Skip backup files
+	if [ "`echo $m | sed -e 's/\~$//'`" != "$m" ]; then
+		continue
+	fi
+
+	module=`basename $m | cut -d'-' -f 2`
+	debug "Loading module $module"
+
+	# pre hooks
+	for h in $MODULE_PRE_HOOKS; do
+		debug "Calling module hook (pre): $h"
+		eval "$h pre $module"
+		debug "Finished module hook (pre): $h"
+	done
+
+	# process module
+	. $m
+
+	if ! eval "${module}_enabled"; then
+		debug "Skipping module $module"
+		continue
+	fi
+
+	debug "Running ${module}_run"
+	eval "${module}_run"
+
+	# post hooks
+	for h in $MODULE_POST_HOOKS; do
+		debug "Calling module hook (post): $h"
+		eval "$h post $module"
+		debug "Finished module hook (post): $h"
+	done
+done
+
+# Catch all
+fatal "ERROR: Initramfs failed to initialize the system."

--- a/recipes-core/initrdscripts/initramfs-framework/lvm
+++ b/recipes-core/initrdscripts/initramfs-framework/lvm
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Copyright (C) 2018 Apertus Solutions, LLC
+# Licensed on MIT
+
+lvm_enabled() {
+    if command -v lvm >/dev/null 2>&1; then
+        return 0
+    else
+        debug "lvm doesn't exist"
+        return 1
+    fi
+
+}
+
+lvm_run() {
+    info "Configuring LVM"
+    lvm vgchange -a y
+    lvm vgscan --mknodes
+}

--- a/recipes-core/initrdscripts/initramfs-framework/selinux
+++ b/recipes-core/initrdscripts/initramfs-framework/selinux
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (C) 2018 Apertus Solutions, LLC
+# Licensed on MIT
+
+selinux_enabled() {
+    return 0
+}
+
+selinux_run() {
+    if [ ${openxt_measured} = "true" ]; then
+        bootparam_init="/sbin/init.root-ro"
+    fi
+
+    bootparam_init="/sbin/selinux-load.sh ${bootparam_init:-/sbin/init} ${bootparam_runlevel}"
+}

--- a/recipes-core/initrdscripts/initramfs-framework/tpm
+++ b/recipes-core/initrdscripts/initramfs-framework/tpm
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Copyright (C) 2018 Apertus Solutions, LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+tpm_enabled() {
+    if [ ! -e "${ROOTFS_DIR}/boot/system/tpm/enabled" ]; then
+        return 1
+    fi
+
+    load_kernel_module tpm_tis
+
+    local dev_path="$(find /sys/class -name tpm0)"
+    if [ -z "${dev_path}" ]; then
+        info "could not locate a TPM"
+        return 1
+    fi
+
+    if [ -e  "${dev_path}/device/caps" ]; then
+        local v="$(awk '/TCG version:/ { print $3 }' ${dev_path}/device/caps)"
+
+        if [ "${v}" = "1.2" ]; then
+            info "found a TPM 1.2 device"
+            return 0
+        fi
+    fi
+
+    debug "did not find TPM 1.2 device"
+    return 1
+}
+
+tpm_run() {
+    if [ ! -e ${bootparam_root} ]; then
+        info "unable to locate root device: ${bootparam_root}"
+        return
+    fi
+
+    info -n "Measuring rootfs device..."
+    local digest="$(sha1sum $bootparam_root | head -c40)"
+    info "done"
+
+    echo -n ${digest} | TCSD_LOG_OFF=yes tpm_extendpcr_sa -p 15
+    if [ $? -ne 0 ]; then
+        info "PCR-15 extend failed"
+        return
+    fi
+
+    openxt_measured=true
+    bootparam_ro=true
+}

--- a/recipes-core/initrdscripts/initramfs-framework/tpm2
+++ b/recipes-core/initrdscripts/initramfs-framework/tpm2
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+# Copyright (C) 2017 Assured Information Solutions, Inc.
+# Copyright (C) 2018 Apertus Solutions, LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+#listpcrs sample output:
+#Supported Bank/Algorithm: TPM_ALG_SHA1(0x0004) TPM_ALG_SHA256(0x000b)
+#Cuts and for loop isolate "TPM_ALG_<hash_type>" and compare against input
+pcr_bank_exists () {
+    local alg_in=$1
+
+    banks=$(tpm2_listpcrs -s | cut -d ':' -f 2)
+    for bank in $banks; do
+        alg=$(echo $bank | cut -d '(' -f 1)
+        if [ "$alg" = $alg_in ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+tpm2_enabled() {
+    if [ ! -e "${ROOTFS_DIR}/boot/system/tpm/enabled" ]; then
+        return 1
+    fi
+
+    load_kernel_module tpm_tis
+
+    local dev_path="$(find /sys/class -name tpm0)"
+    if [ -z "${dev_path}" ]; then
+        info "could not locate a TPM"
+        return 1
+    fi
+
+    if [ -e  "${dev_path}/device/caps" ]; then
+        local v="$(awk '/TCG version:/ { print $3 }' ${dev_path}/device/caps)"
+
+        if [ "${v}" = "1.2" ]; then
+            info "found a TPM 1.2 device looking for a TPM 2.0"
+            return 1
+        fi
+    fi
+
+    # This hits for two reasons:
+    #  1. There is a TPM device but does not export device/caps
+    #  2. There was a device/caps file which did not report being a 1.2 device
+    return 0
+}
+
+tpm2_run() {
+    if [ ! -e ${bootparam_root} ]; then
+        info "unable to locate root device: ${bootparam_root}"
+        return
+    fi
+
+    info -n "Measuring rootfs device..."
+    if pcr_bank_exists "TPM_ALG_SHA256"; then
+        local digest="$(sha256sum $bootparam_root | head -c64)"
+        local algid="0xB"
+    else
+        local digest="$(sha1sum $bootparam_root | head -c40)"
+        local algid="0x4"
+    fi
+    info "done"
+
+    tpm2_extendpcr -c 15 -g ${algid} -s ${digest}
+    if [ $? -ne 0 ]; then
+        info "PCR-15 extend failed"
+        return
+    fi
+
+    openxt_measured=true
+    bootparam_ro=true
+}

--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,56 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://lvm \
+    file://bootfs \
+    file://tpm \
+    file://tpm2 \
+    file://selinux \
+    "
+
+do_install_append() {
+    install -d ${D}/init.d
+
+    # lvm
+    install -m 0755 ${WORKDIR}/lvm ${D}/init.d/89-lvm
+
+    # bootfs
+    install -m 0755 ${WORKDIR}/bootfs ${D}/init.d/91-bootfs
+
+    # tpm
+    install -m 0755 ${WORKDIR}/tpm ${D}/init.d/92-tpm
+
+    # tpm2
+    install -m 0755 ${WORKDIR}/tpm2 ${D}/init.d/92-tpm2
+
+    # selinux
+    install -m 0755 ${WORKDIR}/selinux ${D}/init.d/93-selinux
+}
+
+PACKAGES += " \
+            initramfs-module-lvm \
+            initramfs-module-bootfs \
+            initramfs-module-tpm \
+            initramfs-module-tpm2 \
+            initramfs-module-selinux \
+            "
+
+SUMMARY_initramfs-module-lvm = "initramfs support for lvm"
+RDEPENDS_initramfs-module-lvm = "${PN}-base lvm2"
+FILES_initramfs-module-lvm = "/init.d/89-lvm"
+
+SUMMARY_initramfs-module-bootfs = "initramfs support for bootfs"
+RDEPENDS_initramfs-module-bootfs = "${PN}-base initramfs-module-rootfs"
+FILES_initramfs-module-bootfs = "/init.d/91-bootfs"
+
+SUMMARY_initramfs-module-tpm = "initramfs support for tpm"
+RDEPENDS_initramfs-module-tpm = "${PN}-base initramfs-module-bootfs tpm-tools-sa"
+FILES_initramfs-module-tpm = "/init.d/92-tpm"
+
+SUMMARY_initramfs-module-tpm2 = "initramfs support for tpm2"
+RDEPENDS_initramfs-module-tpm2 = "${PN}-base initramfs-module-bootfs tpm2-tools"
+FILES_initramfs-module-tpm2 = "/init.d/92-tpm2"
+
+SUMMARY_initramfs-module-selinux = "initramfs support for selinux"
+RDEPENDS_initramfs-module-selinux = "${PN}-base"
+FILES_initramfs-module-selinux = "/init.d/93-selinux"


### PR DESCRIPTION
This PR is to serve as an RFC to allow others to review and test a refactoring of the initramfs init I need to do for a capability under development.

This PR removes the custom monolithic init script for the initramfs image and adopts the modular OE initramfs-framework init. While the intent was to minimize any modifications to upstream, initramfs-framework's init script did not directly support parsing a runlevel from the kernel parameters. As a result, this PR includes an extended version of the init that handles parsing the runlevel. An alternative approach that does not require altering the init script would be to write a module based on how the upstream init parameter parser works. The current parser would have handled the runlevel parameter by creating the variable $bootparam_{N}='true' where {N} would be the runlevel. The runlevel module would have to iterate through all permutations of $bootparam_{N} checking if it is set and setting the $bootparam_runlevel variable to the last {N} found set.

After review, unless otherwise reconsidered, I will close this PR so it will remain the record and do a new PR with that will incorporate all comments. Thanks.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>