### PR TITLE
OXT-580: Initramfs framework

### DIFF
--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -19,7 +19,11 @@ IMAGE_INSTALL = " \
     libtctidevice \
     tpm-tools-sa \
     tpm2-tools \
-    initramfs-xenclient \
+    initramfs-module-lvm \
+    initramfs-module-bootfs \
+    initramfs-module-tpm \
+    initramfs-module-tpm2 \
+    initramfs-module-selinux \
     xenclient-initramfs-shared-libs \
     kernel-module-tpm \
     kernel-module-tpm-tis \

--- a/recipes-core/initrdscripts/initramfs-framework/bootfs
+++ b/recipes-core/initrdscripts/initramfs-framework/bootfs
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Copyright (C) 2018 Apertus Solutions, LLC
+# Licensed on MIT
+
+bootfs_enabled() {
+    if [ -n "${bootparam_boot}" ]; then
+        info "using boot device ${bootparam_boot}"
+        return 0
+    else
+        debug "no boot device parameter provided"
+        return 1
+    fi
+}
+
+bootfs_run() {
+    BOOTFS_DIR="/${ROOTFS_DIR}/boot/system"
+    if [ ! -d "${BOOTFS_DIR}" ]; then
+        return
+    fi
+
+    debug "No e2fs compatible filesystem has been mounted, mounting ${bootparam_boot}..."
+
+    key=${bootparam_boot%%=*}
+    boot_uuid=${bootparam_boot#*=}
+
+    case ${key} in
+        UUID)
+            bootparam_boot="/dev/disk/by-uuid/${boot_uuid}"
+            ;;
+        PARTUUID)
+            bootparam_boot="/dev/disk/by-partuuid/${boot_uuid}"
+            ;;
+    esac
+
+    if [ -e "${bootparam_boot}" ]; then
+        flags=""
+        if [ -n "${bootparam_bootfstype}" ]; then
+            flags="${flags} -t${bootparam_bootfstype}"
+        fi
+        mount ${flags} ${bootparam_boot} ${BOOTFS_DIR}
+        if [ -d "${BOOTFS_DIR}/grub" ]; then
+            return
+        else
+            info "disk ${bootparam_boot} does not appear to be valid"
+            umount ${BOOTFS_DIR}
+        fi
+    fi
+}

--- a/recipes-core/initrdscripts/initramfs-framework/lvm
+++ b/recipes-core/initrdscripts/initramfs-framework/lvm
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright (C) 2018 Apertus Solutions, LLC
+# Licensed on MIT
+
+lvm_enabled() {
+    if command -v lvm >/dev/null 2>&1; then
+        return 0
+    else
+        debug "lvm doesn't exist"
+        return 1
+    fi
+}
+
+lvm_run() {
+    info "Configuring LVM"
+    lvm vgchange -a y
+    lvm vgscan --mknodes
+}

--- a/recipes-core/initrdscripts/initramfs-framework/selinux
+++ b/recipes-core/initrdscripts/initramfs-framework/selinux
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (C) 2018 Apertus Solutions, LLC
+# Licensed on MIT
+
+selinux_enabled() {
+    return 0
+}
+
+selinux_run() {
+    if [ "${openxt_measured}" = "true" ]; then
+        bootparam_init="/sbin/init.root-ro"
+    fi
+
+    bootparam_init="/sbin/selinux-load.sh ${bootparam_init:-/sbin/init} ${bootparam_runlevel}"
+}

--- a/recipes-core/initrdscripts/initramfs-framework/tpm
+++ b/recipes-core/initrdscripts/initramfs-framework/tpm
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# Copyright (C) 2018 Apertus Solutions, LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+tpm_enabled() {
+    if [ ! -e "${ROOTFS_DIR}/boot/system/tpm/enabled" ]; then
+        return 1
+    fi
+
+    load_kernel_module tpm_tis
+
+    local dev_path="$(find /sys/class -name tpm0)"
+    if [ -z "${dev_path}" ]; then
+        info "could not locate a TPM"
+        return 1
+    fi
+
+    if [ -e "${dev_path}/device/caps" ]; then
+        local v="$(awk '/TCG version:/ { print $3 }' ${dev_path}/device/caps)"
+
+        if [ "${v}" = "1.2" ]; then
+            info "found a TPM 1.2 device"
+            return 0
+        fi
+    fi
+
+    debug "did not find TPM 1.2 device"
+    return 1
+}
+
+tpm_run() {
+    if [ ! -e ${bootparam_root} ]; then
+        info "unable to locate root device: ${bootparam_root}"
+        return
+    fi
+
+    info -n "Measuring rootfs device..."
+    local digest="$(sha1sum $bootparam_root | head -c40)"
+    info "done"
+
+    echo -n ${digest} | TCSD_LOG_OFF=yes tpm_extendpcr_sa -p 15
+    if [ $? -ne 0 ]; then
+        info "PCR-15 extend failed"
+        return
+    fi
+
+    openxt_measured=true
+}

--- a/recipes-core/initrdscripts/initramfs-framework/tpm2
+++ b/recipes-core/initrdscripts/initramfs-framework/tpm2
@@ -1,0 +1,94 @@
+#!/bin/sh
+#
+# Copyright (C) 2017 Assured Information Solutions, Inc.
+# Copyright (C) 2018 Apertus Solutions, LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+#listpcrs sample output:
+#Supported Bank/Algorithm: TPM_ALG_SHA1(0x0004) TPM_ALG_SHA256(0x000b)
+#Cuts and for loop isolate "TPM_ALG_<hash_type>" and compare against input
+pcr_bank_exists () {
+    local alg_in=$1
+
+    banks=$(tpm2_pcrlist -s | cut -d ':' -f 2)
+    for bank in $banks; do
+        alg=$(echo $bank | cut -d '(' -f 1)
+        if [ "$alg" = $alg_in ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+tpm2_enabled() {
+    if [ ! -e "${ROOTFS_DIR}/boot/system/tpm/enabled" ]; then
+        return 1
+    fi
+
+    load_kernel_module tpm_tis
+
+    local dev_path="$(find /sys/class -name tpm0)"
+    if [ -z "${dev_path}" ]; then
+        info "could not locate a TPM"
+        return 1
+    fi
+
+    if [ -e "${dev_path}/device/caps" ]; then
+        local v="$(awk '/TCG version:/ { print $3 }' ${dev_path}/device/caps)"
+
+        if [ "${v}" = "1.2" ]; then
+            info "found a TPM 1.2 device looking for a TPM 2.0"
+            return 1
+        fi
+    fi
+
+    # This hits for two reasons:
+    #  1. There is a TPM device but does not export device/caps
+    #  2. There was a device/caps file which did not report being a 1.2 device
+    return 0
+}
+
+tpm2_run() {
+    if [ ! -e ${bootparam_root} ]; then
+        info "unable to locate root device: ${bootparam_root}"
+        return
+    fi
+
+    info -n "Measuring rootfs device..."
+    if pcr_bank_exists "sha256"; then
+        local digest="$(sha256sum $bootparam_root | head -c64)"
+        local algid="0xB"
+    else
+        local digest="$(sha1sum $bootparam_root | head -c40)"
+        local algid="0x4"
+    fi
+    info "done"
+
+    info -n "Extending TPM PCR..."
+    tpm2_extendpcr -c 15 -g ${algid} -s ${digest}
+    if [ $? -ne 0 ]; then
+        info "PCR-15 extend failed"
+        return
+    fi
+    info "done"
+
+    openxt_measured=true
+}

--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,56 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://lvm \
+    file://bootfs \
+    file://tpm \
+    file://tpm2 \
+    file://selinux \
+    "
+
+do_install_append() {
+    install -d ${D}/init.d
+
+    # lvm
+    install -m 0755 ${WORKDIR}/lvm ${D}/init.d/89-lvm
+
+    # bootfs
+    install -m 0755 ${WORKDIR}/bootfs ${D}/init.d/91-bootfs
+
+    # tpm
+    install -m 0755 ${WORKDIR}/tpm ${D}/init.d/92-tpm
+
+    # tpm2
+    install -m 0755 ${WORKDIR}/tpm2 ${D}/init.d/92-tpm2
+
+    # selinux
+    install -m 0755 ${WORKDIR}/selinux ${D}/init.d/93-selinux
+}
+
+PACKAGES += " \
+            initramfs-module-lvm \
+            initramfs-module-bootfs \
+            initramfs-module-tpm \
+            initramfs-module-tpm2 \
+            initramfs-module-selinux \
+            "
+
+SUMMARY_initramfs-module-lvm = "initramfs support for lvm"
+RDEPENDS_initramfs-module-lvm = "${PN}-base lvm2"
+FILES_initramfs-module-lvm = "/init.d/89-lvm"
+
+SUMMARY_initramfs-module-bootfs = "initramfs support for bootfs"
+RDEPENDS_initramfs-module-bootfs = "${PN}-base initramfs-module-rootfs"
+FILES_initramfs-module-bootfs = "/init.d/91-bootfs"
+
+SUMMARY_initramfs-module-tpm = "initramfs support for tpm"
+RDEPENDS_initramfs-module-tpm = "${PN}-base initramfs-module-bootfs tpm-tools-sa"
+FILES_initramfs-module-tpm = "/init.d/92-tpm"
+
+SUMMARY_initramfs-module-tpm2 = "initramfs support for tpm2"
+RDEPENDS_initramfs-module-tpm2 = "${PN}-base initramfs-module-bootfs tpm2-tools"
+FILES_initramfs-module-tpm2 = "/init.d/92-tpm2"
+
+SUMMARY_initramfs-module-selinux = "initramfs support for selinux"
+RDEPENDS_initramfs-module-selinux = "${PN}-base"
+FILES_initramfs-module-selinux = "/init.d/93-selinux"

--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/grub.cfg
@@ -159,7 +159,7 @@ menuentry "XenClient Technical Support Option: console access" {
         set root=lvm/xenclient-root
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD com1=115200,8n1,pci
-        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon 3
+        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon runlevel=3
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
@@ -183,7 +183,7 @@ menuentry "XenClient Technical Support Option: console access with AMT serial" {
         set root=lvm/xenclient-root
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1,vga com1=115200,8n1,amt
-        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon 3
+        module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon runlevel=3
         module /boot/initramfs.gz
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN

--- a/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient/xenclient-dom0-tweaks/openxt.cfg
@@ -24,12 +24,12 @@ xsm=policy.24
 
 [openxt-support-console]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon runlevel=3
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-console-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=no-rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon runlevel=3
 ramdisk=initramfs.gz
 xsm=policy.24


### PR DESCRIPTION
Refactor openxt's custom initramfs init script into modules for OE's initramfs-framework init. As a result adjust grub.cfg to use 'runlevel=' to pass the runlevel to the new init system. Finally move xenclient-initramfs-image to use the new init.

OXT-580

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>