### PR TITLE
openxt_image_types: Fix .vhd size calculation

### DIFF
--- a/classes/openxt_image_types.bbclass
+++ b/classes/openxt_image_types.bbclass
@@ -14,14 +14,16 @@ IMAGE_CMD_ext3_append() {
 
 # OpenXT vhd.
 # Standard vhd image from an existing filesystem.
-# vhd size must be a multiple of 2 MB.
 CONVERSIONTYPES_append = " vhd"
 
 CONVERSION_CMD_vhd() {
-    local ALIGN=`expr 2 \* 1024 \* 1024`
-    local TARGET_VHD_SIZE=`expr \( \( ${ROOTFS_SIZE} + ${ALIGN} + 1 \) / ${ALIGN} \) \* ${ALIGN}`
-    local TARGET_VHD_SIZE_KB=`expr \( ${TARGET_VHD_SIZE} / 1024 \)`
-    vhd convert ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type} ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.vhd ${TARGET_VHD_SIZE_KB}
+    # Read the size since a .disk.vhd will be larger than ROOTFS_SIZE
+    local TARGET_SIZE_KB=$( du -Lbsk ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type} | cut -f 1 )
+    # vhd size must be a multiple of 2 MB.
+    local ALIGN_KB=`expr 2 \* 1024`
+    local TARGET_VHD_SIZE_KB=`expr \( \( $TARGET_SIZE_KB + ${ALIGN_KB} - 1 \) / ${ALIGN_KB} \) \* ${ALIGN_KB}`
+    local TARGET_VHD_SIZE_MB=`expr \( ${TARGET_VHD_SIZE_KB} / 1024 \)`
+    vhd convert ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type} ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.vhd ${TARGET_VHD_SIZE_MB}
 }
 
 CONVERSION_DEPENDS_vhd = "hkg-vhd-native"


### PR DESCRIPTION
The VHD size calculation was mistakenly using the wrong units.  This
meant that 2GB VHDs were being generated for our images.

ROOTFS_SIZE is in KB, so ALIGN should be 2 * 1024 for 2MB in KB.  The
TARGET_VHD_SIZE_KB was mislabeled since it is really MB which is the
unit that `vhd convert` expects.  Rename the two TARGET_VHD_SIZE*
variables so the units are clear.

Finally, correct the alignment calculation.  We want to add $ALIGN - 1
to force ROOTFS_SIZE up to the next chunk for any partially chunks.
Adding $ALIGN + 1 always forces up one chunk and potentially two.

A .disk partitioned disk image will be larger that ROOTFS_SIZE
kilobytes.  Too handle that, always read the image size of the image in
case it is a .disk.vhd.

Alternative to https://github.com/OpenXT/xenclient-oe/pull/1070