### PR TITLE
openssh: Packaging fixes

### DIFF
--- a/recipes-connectivity/openssh/openssh_7.%.bbappend
+++ b/recipes-connectivity/openssh/openssh_7.%.bbappend
@@ -11,8 +11,6 @@ SRC_URI += " \
     file://scpv4v \
     file://sshd_check_keys_v4v \
     file://volatiles.99_ssh-keygen \
-"
-SRC_URI_append_xenclient-dom0 += " \
     file://init \
 "
 
@@ -64,18 +62,10 @@ CONFFILES_${PN}-sshd += " \
 "
 
 # sshd-tcp-init
-PACKAGES_prepend_xenclient-dom0 = " ${PN}-sshd-tcp-init "
+PACKAGES =+ "${PN}-sshd-tcp-init"
 FILES_${PN}-sshd-tcp-init = "/etc/init.d/sshd"
 
-INITSCRIPT_PACKAGES_append_xenclient-dom0 = " ${PN}-sshd-tcp-init "
-INITSCRIPT_NAME_${PN}-sshd-tcp-init = "sshd"
-INITSCRIPT_PARAMS_${PN}-sshd-tcp-init = "defaults 9"
-
-SRC_URI_append_openxt-installer = " file://init "
-PACKAGES_prepend_openxt-installer = " ${PN}-sshd-tcp-init "
-FILES_${PN}-sshd-tcp-init = "/etc/init.d/sshd"
-
-INITSCRIPT_PACKAGES_append_openxt-installer = " ${PN}-sshd-tcp-init "
+INITSCRIPT_PACKAGES += "${PN}-sshd-tcp-init"
 INITSCRIPT_NAME_${PN}-sshd-tcp-init = "sshd"
 INITSCRIPT_PARAMS_${PN}-sshd-tcp-init = "defaults 9"
 

--- a/recipes-connectivity/openssh/openssh_7.%.bbappend
+++ b/recipes-connectivity/openssh/openssh_7.%.bbappend
@@ -69,5 +69,6 @@ INITSCRIPT_PACKAGES += "${PN}-sshd-tcp-init"
 INITSCRIPT_NAME_${PN}-sshd-tcp-init = "sshd"
 INITSCRIPT_PARAMS_${PN}-sshd-tcp-init = "defaults 9"
 
-RDEPENDS_${PN}-ssh += "bash"
-RDEPENDS_${PN}-scp += "bash"
+RDEPENDS_${PN}-sshd += "libv4v"
+RDEPENDS_${PN}-ssh += "bash libv4v"
+RDEPENDS_${PN}-scp += "bash libv4v"


### PR DESCRIPTION
The first change makes openssh-sshd-tcp-init get packaged generically.  With it, any VM could potentially install it, and the openxt-installer will use the core2-64 openssh package.  dom0's openssh is still machine specific since it uses a machine override for the sshd_config file.

The second change just adds the RDEPENDS on libv4v to the sshd, ssh & scp sub-packages since they contain the v4v variants - sshv4v, scpv4v, & sshd-v4v.