### PR TITLE
OXT-1485: Attend build warnings on TSS recipes.

### DIFF
--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -14,10 +14,8 @@ IMAGE_FSTYPES = "cpio.gz"
 IMAGE_INSTALL = " \
     busybox \
     lvm2 \
-    libtss2 \
-    libtctisocket \
-    libtctidevice \
     tpm-tools-sa \
+    tpm2-tss \
     tpm2-tools \
     initramfs-module-lvm \
     initramfs-module-bootfs \

--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -114,9 +114,7 @@ RDEPENDS_${PN} = " \
     linuxfb-surfman-plugin \
     xenmgr \
     xen-xenstore \
-    libtss2 \
-    libtctidevice \
-    libtctisocket \
+    tpm2-tss \
     tpm2-tools \
     ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', 'xen-blktap xen-libblktapctl xen-libvhd', 'blktap3', d)} \
     pesign \

--- a/recipes-core/packagegroups/packagegroup-xenclient-installer.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-installer.bb
@@ -25,9 +25,6 @@ RDEPENDS_${PN} = " \
     grub-efi \
     intel-microcode \
     kernel-modules \
-    libtctidevice \
-    libtctisocket \
-    libtss2 \
     lvm2 \
     ncurses \
     netcat \
@@ -49,6 +46,7 @@ RDEPENDS_${PN} = " \
     syslinux-pxelinux \
     tboot \
     tboot-utils \
+    tpm2-tss \
     tpm2-tools \
     tpm-tools \
     trousers \

--- a/recipes-security/tss2/tpm2-tools_3.1.3.bb
+++ b/recipes-security/tss2/tpm2-tools_3.1.3.bb
@@ -15,14 +15,5 @@ SRC_URI = "git://github.com/01org/tpm2-tools.git;protocol=git;branch=3.X \
 "
 
 S = "${WORKDIR}/git"
-# https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
 
 inherit autotools pkgconfig
-
-do_configure_prepend () {
-	# execute the bootstrap script
-	cd ${S}
-	ACLOCAL="aclocal --system-acdir=${STAGING_DATADIR}/aclocal" ./bootstrap
-	cd -
-	oe_runconf
-}

--- a/recipes-security/tss2/tpm2-tss_2.0.0.bb
+++ b/recipes-security/tss2/tpm2-tss_2.0.0.bb
@@ -17,65 +17,12 @@ S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 
-# https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
-
-PROVIDES = "${PACKAGES}"
-PACKAGES = " \
-    ${PN}-dbg \
-    libtss2 \
-    libtss2-dev \
-    libtss2-staticdev \
-    libtctidevice \
-    libtctidevice-dev \
-    libtctidevice-staticdev \
-    libtctisocket \
-    libtctisocket-dev \
-    libtctisocket-staticdev \
+PACKAGES =+ " \
     resourcemgr \
 "
-
-FILES_libtss2 = " \
-    ${libdir}/libtss2.so.0.0.0 \
-    ${libdir}/libtss2-sys.so.0.0.0 \
-    ${libdir}/libtss2-esys.so.0.0.0 \
-    ${libdir}/libtss2-mu.so.0.0.0 \
+FILES_resourcemgr = " \
+    ${sbindir}/resourcemgr \
 "
-FILES_libtss2-dev = " \
-    ${includedir}/tss2 \
-    #${libdir}/libmarshal.so* \
-    ${libdir}/libtss2.so* \
-    ${libdir}/libtss2-sys.so* \
-    ${libdir}/libtss2-esys.so* \
-    ${libdir}/libtss2-mu.so* \
-    ${libdir}/pkgconfig/tss2.pc \
-    ${libdir}/pkgconfig/tss2-sys.pc \
-    ${libdir}/pkgconfig/tss2-esys.pc \
-    ${libdir}/pkgconfig/tss2-mu.pc \
-"
-FILES_libtss2-staticdev = " \
-    #${libdir}/libmarshal.a \
-    #${libdir}/libmarshal.la \
-    ${libdir}/libtss2.a \
-    ${libdir}/libtss2.la \
-    ${libdir}/libtss2-sys.a \
-    ${libdir}/libtss2-esys.a \
-    ${libdir}/libtss2-mu.a \
-"
-FILES_libtctidevice = "${libdir}/libtss2-tcti-device.so.0.0.0"
-FILES_libtctidevice-dev = " \
-    ${includedir}/tss2/tss2_tcti_device.h \
-    ${libdir}/libtss2-tcti-device.so* \
-    ${libdir}/pkgconfig/tss2-tcti-device.pc \
-"
-FILES_libtctidevice-staticdev = "${libdir}/libtss2-tcti-device.*a"
-FILES_libtctisocket = "${libdir}/libtss2-tcti-mssim.so.0.0.0"
-FILES_libtctisocket-dev = " \
-    ${includedir}/tss2/tss2_tcti_mssim.h \
-    ${libdir}/libtss2-tcti-mssim.so* \
-    ${libdir}/pkgconfig/tss2-tcti-mssim.pc \
-"
-FILES_libtctisocket-staticdev = "${libdir}/libtss2-tcti-mssim.*a"
-FILES_resourcemgr = "${sbindir}/resourcemgr"
 
 do_configure_prepend () {
     # Creates the src_vars.mk file used by automake to handle source-files for

--- a/recipes-security/tss2/tpm2-tss_2.0.0.bb
+++ b/recipes-security/tss2/tpm2-tss_2.0.0.bb
@@ -11,9 +11,11 @@ SRCREV = "ced20c209397f58d81da79810f49976ba2d36566"
 
 SRC_URI = " \
     git://github.com/01org/tpm2-tss.git;protocol=git;branch=master \
-    "
+"
 
 S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig
 
 # https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
 
@@ -75,12 +77,10 @@ FILES_libtctisocket-dev = " \
 FILES_libtctisocket-staticdev = "${libdir}/libtss2-tcti-mssim.*a"
 FILES_resourcemgr = "${sbindir}/resourcemgr"
 
-inherit autotools pkgconfig
-
 do_configure_prepend () {
-	# execute the bootstrap script
-	currentdir=$(pwd)
-	cd ${S}
-	ACLOCAL="aclocal --system-acdir=${STAGING_DATADIR}/aclocal" ./bootstrap
-	cd ${currentdir}
+    # Creates the src_vars.mk file used by automake to handle source-files for
+    # each component. Modified to not call autotools and let OE handle that.
+    pushd ${S}
+    AUTORECONF=true ./bootstrap
+    popd
 }


### PR DESCRIPTION
Noticed on a recent build:
```
WARNING: tpm2-tss-2.0.0-r0 do_package: QA Issue: tpm2-tss: Files/directories were installed but not shipped in any package:
  /usr/share
  /usr/share/man
  /usr/share/man/man7
  /usr/share/man/man3
  /usr/share/man/man7/tss2-tcti-mssim.7
  /usr/share/man/man7/tss2-tcti-device.7
  /usr/share/man/man3/Tss2_Tcti_Mssim_Init.3
  /usr/share/man/man3/Tss2_Tcti_Device_Init.3
  /usr/lib/udev
  /usr/lib/udev/rules.d
  /usr/lib/udev/rules.d/tpm-udev.rules
```

After reading the recipes, it seems they could be simplified and brought more inline with Bitbake/OE:
- Use `tpm2-tss` `./bootstrap` script only to generate the source list for `automake`.
- Do not use `tpm2-tools` `./boostrap` script at all since it calls `autoconf` without OE configuration
- Aggregate `tpm2-tss` library packages under `tpm2-tss` since they are all installed together.
- Let OE package `${libdir}`, `${docdir}` and `${libdir}/udev`