### PR TITLE
grub-efi: Don't create grubx64.efi symlink

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.02.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.02.bbappend
@@ -16,9 +16,3 @@ GRUB_BUILDIN = " \
 EXTRA_OECONF += " \
     --enable-efiemu=no \
 "
-
-do_deploy_append() {
-    pushd ${DEPLOYDIR} > /dev/null
-    ln -sf ${GRUB_IMAGE} "grubx64.efi"
-    popd > /dev/null
-}


### PR DESCRIPTION
grubx64.efi is a convenience symlink to grub-efi-bootx64.efi.
Unfortunately, it can get set to grub-efi-bootia32.efi if
grub-efi-native:do_deploy runs after grub-efi.  This breaks the build
with
cp: cannot stat ‘tmp-glibc/deploy/images/openxt-installer/grubx64.efi’: No such file or directory

openxt.git build scripts will copy the actual file, so don't bother
creating a symlink.

OXT-1484

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

This should go in after https://github.com/OpenXT/openxt/pull/334