### PR TITLE
linux: Fix domU build of usbback

### DIFF
--- a/recipes-kernel/linux/4.14/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.14/patches/usbback-base.patch
@@ -816,11 +816,11 @@ PATCHES
 +#include <asm/io.h>
 +#include <asm/setup.h>
 +#include <asm/pgalloc.h>
-+#include <xen/evtchn.h>
 +#include <asm/hypervisor.h>
 +#include <xen/vusb.h>
 +#include <xen/grant_table.h>
 +#include <xen/xenbus.h>
++#include <xen/evtchn.h>
 +
 +
 +#define DPRINTK(_f, _a...)			\
@@ -1139,7 +1139,7 @@ PATCHES
 +#endif /* __USBIF__BACKEND__COMMON_H__ */
 --- /dev/null
 +++ b/drivers/usb/xen-usbback/interface.c
-@@ -0,0 +1,164 @@
+@@ -0,0 +1,165 @@
 +/******************************************************************************
 + *
 + * usb device interface management.
@@ -1173,6 +1173,7 @@ PATCHES
 + */
 +
 +#include <linux/kthread.h>
++#include <xen/interface/xen.h>
 +#include <xen/evtchn.h>
 +#include <xen/events.h>
 +#include <asm/xen/hypercall.h>


### PR DESCRIPTION
We get an error in evtchn.h because domid_t is not defined at the time
of inclusion.  include/xen/xen.h automatically includes
xen/interface/xen.h when CONFIG_DOM0 is defined.  That doesn't happen
when CONFIG_DOM0 is not set leading to the domid_t error.  Rearranging
the headers allows domid_t to be already defined when evtchn.h is
included.  interfaces.c also needs an additional include.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>