### PR TITLE
init.root-ro: Remove restorecon /storage

### DIFF
--- a/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient/xenclient-root-ro/init.root-ro
@@ -27,9 +27,6 @@
 . /usr/lib/tpm-scripts/tpm-functions
 
 CONFIG_LV=xenclient-config
-STORAGE_LV=xenclient-storage
-STORAGE_DEV=/dev/mapper/${STORAGE_LV}
-STORAGE_MNT=/storage
 
 SYS_TPM_DIR="/boot/system/tpm"
 
@@ -440,9 +437,6 @@ PCR_DEV=$(find /sys/class -name tpm0)
 
 read_args
 dev_setup
-
-mount "${STORAGE_DEV}" "${STORAGE_MNT}"
-restore_firstboot -r ${STORAGE_MNT}
 
 is_tpm_2_0
 tpm2=$?


### PR DESCRIPTION
mountall.sh already runs a restorecon on /storage, so we don't need to
do it in this init script.

An encrypted /storage will not be mounted during init.root-ro, so we
want restorecon delayed until /storage is actually available.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>