### PR TITLE
fix iso hotswap for linux guests

### DIFF
--- a/recipes-extended/xen/files/libxl-disable-vnc-query-when-disabled.patch
+++ b/recipes-extended/xen/files/libxl-disable-vnc-query-when-disabled.patch
@@ -35,7 +35,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_qmp.c
 +++ b/tools/libxl/libxl_qmp.c
-@@ -1203,7 +1203,7 @@ int libxl__qmp_initializations(libxl__gc
+@@ -1204,7 +1204,7 @@ int libxl__qmp_initializations(libxl__gc
          ret = qmp_change(gc, qmp, "vnc", "password", vnc->passwd);
          qmp_write_domain_console_item(gc, domid, "vnc-pass", vnc->passwd);
      }

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -82,7 +82,7 @@ PATCHES
  
 --- a/tools/libxl/libxl_disk.c
 +++ b/tools/libxl/libxl_disk.c
-@@ -670,25 +670,139 @@ int libxl_device_disk_getinfo(libxl_ctx
+@@ -670,25 +670,140 @@ int libxl_device_disk_getinfo(libxl_ctx
      return rc;
  }
  
@@ -175,10 +175,11 @@ PATCHES
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/online", be_path), "%s", "1");
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/state", be_path), "%s", "1");
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/removable", be_path), "%s", "1");
-+        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/mode", be_path), "%s", "1");
++        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/mode", be_path), "%s", "r");
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/frontend-id", be_path), "%u", stubdomid);
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/dev", be_path), "%s", "hdc");
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/tapdisk-params", be_path), "%s", libxl__sprintf(gc, "aio:%s", iso));
++        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/hotplug-status", be_path), "%s", "connected");
 +
 +        roperm[0].id = stubdomid;
 +        roperm[1].id = 0;
@@ -229,7 +230,7 @@ PATCHES
  
      disk_empty.format = LIBXL_DISK_FORMAT_EMPTY;
      disk_empty.vdev = libxl__strdup(NOGC, disk->vdev);
-@@ -729,43 +843,18 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+@@ -729,43 +844,18 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
              break;
          }
      }
@@ -274,7 +275,7 @@ PATCHES
      /* Note: CTX lock is already held at this point so lock hierarchy
       * is maintained.
       */
-@@ -783,85 +872,39 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+@@ -783,85 +873,39 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
          if (rc) goto out;
      }
  
@@ -424,6 +425,14 @@ PATCHES
  int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid,
                              const libxl_device_disk *disk)
  {
+@@ -984,6 +995,7 @@ int libxl__qmp_insert_cdrom(libxl__gc *g
+     QMP_PARAMETERS_SPRINTF(&args, "device", "ide-%i", dev_number);
+ 
+     if (disk->format == LIBXL_DISK_FORMAT_EMPTY) {
++        qmp_parameters_add_bool(gc, &args, "force", true);
+         return qmp_run_command(gc, domid, "eject", args, NULL, NULL);
+     } else {
+         qmp_parameters_add_string(gc, &args, "target", disk->pdev_path);
 --- a/tools/libxl/libxl_utils.c
 +++ b/tools/libxl/libxl_utils.c
 @@ -1383,6 +1383,12 @@ int libxl__random_bytes(libxl__gc *gc, u


### PR DESCRIPTION
OXT-1493

linux guests (ex:Ubuntu, Debian) lock the cdrom hence requiring force eject.
fix iso hotswap associated xenstore nodes:
    -> mode: should be either of 'r' or 'w', here it's 'r'
    -> hotplug-status: being used by upstream blktap3 to establish
		       connection between frontend and backend.

Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>