### PR TITLE
rpc-proxy: initscript: start rpc-proxy even when SELinux is disabled.

### DIFF
--- a/recipes-openxt/rpc-proxy/rpc-proxy/rpc-proxy.initscript
+++ b/recipes-openxt/rpc-proxy/rpc-proxy/rpc-proxy.initscript
@@ -24,14 +24,23 @@ PIDFILE=/var/run/rpc-proxy.pid
 PIDFILE_GUEST=/var/run/rpc-proxy-guest.pid
 PIDFILE_WEBSOCKETS=/var/run/rpc-proxy-websockets.pid
 
+OPTIONS="-s"
+OPTIONS_GUEST="-i v4v:5556 -n com.citrix.xenclient.guest.uuid_\$UUID --translate-anonymous-dests"
+OPTIONS_WEBSOCKETS="-i v4v:8080 --json-in --websockets-in -n com.citrix.xenclient.guest.uuid_\$UUID --auto-auth"
+
 # Make sure the progam exists
 [ -f /usr/bin/rpc-proxy ] || exit 0
 
 start() {
-	echo "Starting rpc-proxy"    
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec /usr/bin/rpc-proxy -- -s
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE_GUEST --exec /usr/bin/runcon -- -t rpcproxy_guest_t /usr/bin/rpc-proxy -i v4v:5556 -n com.citrix.xenclient.guest.uuid_\$UUID --translate-anonymous-dests
-	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE_WEBSOCKETS --exec /usr/bin/runcon -- -t rpcproxy_websockets_t /usr/bin/rpc-proxy -i v4v:8080 --json-in --websockets-in -n com.citrix.xenclient.guest.uuid_\$UUID --auto-auth
+	echo "Starting rpc-proxy"
+	start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec /usr/bin/rpc-proxy -- $OPTIONS
+	if [ -x /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
+	    start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE_GUEST --exec /usr/bin/runcon -- -t rpcproxy_guest_t /usr/bin/rpc-proxy $OPTIONS_GUEST
+	    start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE_WEBSOCKETS --exec /usr/bin/runcon -- -t rpcproxy_websockets_t /usr/bin/rpc-proxy $OPTIONS_WEBSOCKETS
+	else
+	    start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE_GUEST --exec /usr/bin/rpc-proxy -- $OPTIONS_GUEST
+	    start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE_WEBSOCKETS --exec /usr/bin/rpc-proxy -- $OPTIONS_WEBSOCKETS
+	fi
 }
 stop() {
 	echo "Stopping rpc-proxy"


### PR DESCRIPTION
2 of the 3 rpc-proxy instances are started with runcon, since we want
each process to be in its own SELinux context.
However, runcon fails when SELinux is disabled, and rpc-proxy is not
started in that case.
Fixing this by not running runcon when SELinux is disabled.

OXT-1504

Signed-off-by: Jed <lejosnej@ainfosec.com>