### PR TITLE
OXT-1514, OXT-1515, OXT-1516, OXT-1517: xen/xl: Misc fixes and refactoring in xl/libxl.

### DIFF
--- a/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
+++ b/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
@@ -26,59 +26,75 @@ Mahantesh Salimath<salimathm@ainfosec.com>
      /* convenience aliases */
      const uint32_t domid = dcs->guest_domid;
 -    libxl_domain_config *const d_config = dcs->guest_config;
-+    libxl_domain_config *d_config = dcs->guest_config;
++    libxl_domain_type type = dcs->guest_config->c_info.type;
  
      if (ret) {
          LOGD(ERROR, domid, "cannot (re-)build domain: %d", ret);
-@@ -1325,11 +1325,51 @@ static void domcreate_rebuild_done(libxl
+@@ -1320,12 +1320,62 @@ static void domcreate_rebuild_done(libxl
+         goto error_out;
+     }
  
-     store_libxl_entry(gc, domid, &d_config->b_info);
+-    store_libxl_entry(gc, domid, &d_config->b_info);
++    store_libxl_entry(gc, domid, &dcs->guest_config->b_info);
  
-+    /* Below quirk is to prevent the creation of useless vbd nodes
-+     * in xenstore.
-+     */
-+    if(d_config->c_info.type == LIBXL_DOMAIN_TYPE_HVM) {
-+        libxl_domain_config domain_config;
-+        int i = 0;
-+        int j = 0;
-+        bool has_stub;
+-    libxl__multidev_begin(ao, &dcs->multidev);
+-    dcs->multidev.callback = domcreate_launch_dm;
+-    libxl__add_disks(egc, ao, domid, d_config, &dcs->multidev);
+-    libxl__multidev_prepared(egc, &dcs->multidev, 0);
++    /* Work-around to avoid exposing broken vbd in Xenstore. */
++    switch (type) {
++        case LIBXL_DOMAIN_TYPE_HVM: {
++            libxl_domain_config d_config;
++            bool stubdomain;
++            unsigned int i = 0;
 +
-+        has_stub = libxl_defbool_val(d_config->b_info.device_model_stubdomain);
-+        libxl_domain_config_copy(CTX, &domain_config, dcs->guest_config);
-+        d_config = &domain_config;
++            libxl_domain_config_copy(CTX, &d_config, dcs->guest_config);
++            stubdomain = libxl_defbool_val(d_config.b_info.device_model_stubdomain);
 +
-+        for( ; i < d_config->num_disks; i++) {
-+            if(d_config->disks[i].is_cdrom) {
++            /*
++             * Cache the domain configuration for disk creation, then look for
++             * ATAPI-PT or cdrom, for guests with stubdomain, devices and
++             * remove them to hide them from libxl__add_disks().
++             *
++             * If it seems like this should be done in device_disk_add() (and
++             * it does), try answering "is this domid we want to add a disk to
++             * a stubdom?" over there.
++             */
++            while (i < d_config.num_disks)
++                if (d_config.disks[i].is_cdrom &&
++                    (stubdomain ||
++                     !strcmp(d_config.disks[i].vdev, "atapi-pt"))) {
 +
-+                /* No atapi-pt vbd nodes */
-+                if(!strncmp(d_config->disks[i].vdev, "atapi-pt", 9))
-+                    continue;
++                    libxl_device_disk_dispose(&d_config.disks[i]);
++                    if (i != d_config.num_disks - 1)
++                        libxl_device_disk_copy(CTX,
++                            &d_config.disks[i],
++                            &d_config.disks[d_config.num_disks - 1]);
++                    --d_config.num_disks;
++                } else ++i;
 +
-+                /* No emulated cdroms for guests that have stubdom */
-+                if(has_stub)
-+                    continue;
++            d_config.disks =
++                libxl__realloc(
++                    NOGC, d_config.disks,
++                    d_config.num_disks * sizeof (d_config.disks[0]));
 +
-+            }
-+            if(j != i)
-+                    libxl_device_disk_copy(CTX,
-+                                           &d_config->disks[j],
-+                                           &d_config->disks[i]);
-+            j++;
++            libxl__multidev_begin(ao, &dcs->multidev);
++            dcs->multidev.callback = domcreate_launch_dm;
++            libxl__add_disks(egc, ao, domid, &d_config, &dcs->multidev);
++            libxl__multidev_prepared(egc, &dcs->multidev, 0);
++
++            libxl_domain_config_dispose(&d_config);
++
++            break;
 +        }
-+        d_config->num_disks = j;
-+        d_config->disks = libxl__realloc(NOGC,
-+                                         d_config->disks,
-+                                         sizeof(*(d_config->disks)) * j);
++
++        default:
++            libxl__multidev_begin(ao, &dcs->multidev);
++            dcs->multidev.callback = domcreate_launch_dm;
++            libxl__add_disks(egc, ao, domid, dcs->guest_config, &dcs->multidev);
++            libxl__multidev_prepared(egc, &dcs->multidev, 0);
++            break;
 +    }
-+
-     libxl__multidev_begin(ao, &dcs->multidev);
-     dcs->multidev.callback = domcreate_launch_dm;
-     libxl__add_disks(egc, ao, domid, d_config, &dcs->multidev);
-     libxl__multidev_prepared(egc, &dcs->multidev, 0);
  
-+    if(d_config != dcs->guest_config)
-+        libxl_domain_config_dispose(d_config);
-+
      return;
  
-  error_out:

--- a/recipes-extended/xen/files/libxl-blktap3-do-not-destroy-in-use-tapdevs.patch
+++ b/recipes-extended/xen/files/libxl-blktap3-do-not-destroy-in-use-tapdevs.patch
@@ -1,6 +1,6 @@
 --- a/tools/libxl/libxl_blktap3.c
 +++ b/tools/libxl/libxl_blktap3.c
-@@ -105,7 +105,33 @@ char *libxl__blktap_devpath(libxl__gc *g
+@@ -105,12 +105,44 @@ char *libxl__blktap_devpath(libxl__gc *g
      return NULL;
  }
  
@@ -35,15 +35,14 @@
  {
      char *type, *disk;
      int err;
-@@ -126,6 +152,11 @@ int libxl__device_destroy_tapdisk(libxl_
-         LOGEV(ERROR, -err, "Unable to find type %s disk %s", type, disk);
-         return ERROR_FAIL;
-     }
+     struct tap_list tap;
+ 
 +    /* We're using the tapdev. If anybody else also is, we can't destroy it! */
 +    if (tapdev_is_shared(gc, params)) {
 +        LOG(DEBUG, "Not destroying tapdev%d, another VM uses it", tap.minor);
 +        return 0;
 +    }
- 
-     err = tap_ctl_destroy(tap.pid, tap.minor, 0, NULL);
-     if (err < 0) {
++
+     type = libxl__strdup(gc, params);
+     disk = strchr(type, ':');
+     if (!disk) {

--- a/recipes-extended/xen/files/libxl-blktap3-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-blktap3-iso-hotswap.patch
@@ -18,12 +18,3 @@
  char *libxl__blktap_devpath(libxl__gc *gc, const char *disk,
  		libxl_disk_format format,
  		char *keydir)
-@@ -105,7 +116,7 @@ char *libxl__blktap_devpath(libxl__gc *g
-     return NULL;
- }
- 
--static bool tapdev_is_shared(libxl__gc *gc, const char *params)
-+bool tapdev_is_shared(libxl__gc *gc, const char *params)
- {
-     char **domids, **vbds;
-     char *tp;

--- a/recipes-extended/xen/files/libxl-do-not-destroy-in-use-tapdevs.patch
+++ b/recipes-extended/xen/files/libxl-do-not-destroy-in-use-tapdevs.patch
@@ -38,7 +38,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_blktap2.c
 +++ b/tools/libxl/libxl_blktap2.c
-@@ -51,8 +51,33 @@ char *libxl__blktap_devpath(libxl__gc *g
+@@ -51,13 +51,44 @@ char *libxl__blktap_devpath(libxl__gc *g
      return NULL;
  }
  
@@ -64,18 +64,16 @@ PATCHES
 +            }
 +        }
 +    }
-+
-+    return false;
-+}
  
 -int libxl__device_destroy_tapdisk(libxl__gc *gc, const char *params)
++    return false;
++}
++
 +int libxl__device_destroy_tapdisk(libxl__gc *gc, const char *params, uint32_t domid)
  {
      char *type, *disk;
      int err;
-@@ -75,6 +100,12 @@ int libxl__device_destroy_tapdisk(libxl_
-         return ERROR_FAIL;
-     }
+     tap_list_t tap;
  
 +    /* We're using the tapdev. If anybody else also is, we can't destroy it! */
 +    if (tapdev_is_shared(gc, params)) {
@@ -83,9 +81,9 @@ PATCHES
 +        return 0;
 +    }
 +
-     err = tap_ctl_destroy(tap.id, tap.minor);
-     if (err < 0) {
-         LOGEV(ERROR, -err, "Failed to destroy tap device id %d minor %d",
+     type = libxl__strdup(gc, params);
+ 
+     disk = strchr(type, ':');
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
 @@ -795,7 +795,7 @@ int libxl__device_destroy(libxl__gc *gc,

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -60,15 +60,6 @@ PATCHES
  char *libxl__blktap_devpath(libxl__gc *gc,
                              const char *disk,
                              libxl_disk_format format)
-@@ -51,7 +63,7 @@ char *libxl__blktap_devpath(libxl__gc *g
-     return NULL;
- }
- 
--static bool tapdev_is_shared(libxl__gc *gc, const char *params)
-+bool tapdev_is_shared(libxl__gc *gc, const char *params)
- {
-     char **domids, **vbds;
-     char *tp;
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
 @@ -18,7 +18,7 @@
@@ -82,7 +73,7 @@ PATCHES
  
 --- a/tools/libxl/libxl_disk.c
 +++ b/tools/libxl/libxl_disk.c
-@@ -666,25 +666,140 @@ int libxl_device_disk_getinfo(libxl_ctx
+@@ -666,25 +666,138 @@ int libxl_device_disk_getinfo(libxl_ctx
      return rc;
  }
  
@@ -158,9 +149,7 @@ PATCHES
 +        libxl__xs_rm_checked(gc, t, fe_path);
 +    } while (xs_transaction_end(ctx->xsh, t, false) == false && errno == EAGAIN);
 +
-+    /* cleanup old tap if it's not shared with anyone else */
-+    if(!tapdev_is_shared(gc, tmp))
-+        libxl__device_destroy_tapdisk(gc, tmp, stubdomid);
++    libxl__device_destroy_tapdisk(gc, tmp, stubdomid);
 +
 +    /*write new device */
 +    do {
@@ -230,7 +219,7 @@ PATCHES
  
      disk_empty.format = LIBXL_DISK_FORMAT_EMPTY;
      disk_empty.vdev = libxl__strdup(NOGC, disk->vdev);
-@@ -725,43 +840,18 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+@@ -725,43 +838,18 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
              break;
          }
      }
@@ -275,7 +264,7 @@ PATCHES
      /* Note: CTX lock is already held at this point so lock hierarchy
       * is maintained.
       */
-@@ -779,85 +869,39 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+@@ -779,85 +867,39 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
          if (rc) goto out;
      }
  
@@ -387,17 +376,16 @@ PATCHES
  _hidden char *libxl__domain_device_frontend_path(libxl__gc *gc, uint32_t domid, uint32_t devid,
                                                   libxl__device_kind device_kind);
  _hidden char *libxl__device_backend_path(libxl__gc *gc, libxl__device *device);
-@@ -1780,6 +1781,9 @@ _hidden char *libxl__blktap_devpath(libx
+@@ -1780,6 +1781,8 @@ _hidden char *libxl__blktap_devpath(libx
                                      const char *disk,
                                      libxl_disk_format format);
  
 +_hidden int libxl__get_tap_minor(libxl__gc *gc, libxl_disk_format format, const char *disk);
-+_hidden bool tapdev_is_shared(libxl__gc *gc, const char *params);
 +
  /* libxl__device_destroy_tapdisk:
   *   Destroys any tapdisk process associated with the backend represented
   *   by be_path.
-@@ -1848,6 +1852,7 @@ _hidden int libxl__qmp_restore(libxl__gc
+@@ -1848,6 +1851,7 @@ _hidden int libxl__qmp_restore(libxl__gc
  /* Set dirty bitmap logging status */
  _hidden int libxl__qmp_set_global_dirty_log(libxl__gc *gc, int domid, bool enable);
  _hidden int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid, const libxl_device_disk *disk);

--- a/recipes-extended/xen/files/libxl-syslog.patch
+++ b/recipes-extended/xen/files/libxl-syslog.patch
@@ -194,9 +194,9 @@ PATCHES
 +    /*         fileline, func&&file?":":"", func?func:"", func||file?": ":"", */
 +    /*         domain, base); */
 +    /* OpenXT: we use syslog */
-+    syslog(LOG_USER | xtl_level_to_syslog_level(msglevel), "%s%s%s%s%s%s",
-+           fileline, func&&file?":":"", func?func:"", func||file?": ":"",
-+           domain, base);
++    syslog(LOG_USER | xtl_level_to_syslog_level(msglevel), "[%d] %s%s%s%s%s%s",
++           getpid(), fileline, func&&file?":":"", func?func:"",
++           func||file?":":"", domain, base);
 +
      if (base != enomem) free(base);
      errno = esave;
@@ -245,7 +245,29 @@ PATCHES
  
 --- a/tools/xl/xl_utils.c
 +++ b/tools/xl/xl_utils.c
-@@ -250,7 +250,6 @@ void print_bitmap(uint8_t *map, int mapl
+@@ -20,6 +20,7 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <syslog.h>
+ 
+ #include <libxl.h>
+ #include <libxl_utils.h>
+@@ -36,10 +37,12 @@ void dolog(const char *file, int line, c
+     va_start(ap, fmt);
+     rc = vasprintf(&s, fmt, ap);
+     va_end(ap);
+-    if (rc >= 0)
++    if (rc >= 0) {
+         /* we ignore write errors since we have no way to report them;
+          * the alternative would be to abort the whole program */
+         libxl_write_exactly(NULL, logfile, s, rc, NULL, NULL);
++        syslog(LOG_USER | LOG_INFO, "[%d] %s", getpid(), s);
++    }
+     free(s);
+ }
+ 
+@@ -250,7 +253,6 @@ void print_bitmap(uint8_t *map, int mapl
  
  int do_daemonize(char *name, const char *pidfile)
  {
@@ -253,7 +275,7 @@ PATCHES
      pid_t child1;
      int nullfd, ret = 0;
  
-@@ -264,22 +263,10 @@ int do_daemonize(char *name, const char
+@@ -264,22 +266,10 @@ int do_daemonize(char *name, const char
  
      postfork();
  

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -170,22 +170,26 @@ PATCHES
  out:
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2123,6 +2123,20 @@ retry_transaction:
+@@ -2123,6 +2123,24 @@ retry_transaction:
      libxl__xs_printf(gc, XBT_NULL,
                       DEVICE_MODEL_XS_PATH(gc, dm_domid, guest_domid, "/xen_extended_power_mgmt"), "2");
  
 +    /* OpenXT: We wait on xenmgr writing v4v-firewall-ready.
 +     *         xenmgr waits on us writing image/device-model-domid
 +     */
-+    int32_t timeout = 0;
-+    char * ready = NULL;
++    unsigned int timeout;
++    char *ready = NULL;
++    const char *firewall_path =
++        GCSPRINTF("%s/v4v-firewall-ready",
++                  libxl__xs_get_dompath(gc, guest_domid));
 +    /* Block and wait for v4v firewall rules */
-+    while (timeout < 30) {
-+        ready = libxl__xs_read(gc, XBT_NULL, GCSPRINTF("%s/v4v-firewall-ready", libxl__xs_get_dompath(gc, guest_domid)));
-+        if(ready)
++    for (timeout = 0; !ready && timeout < 4; ++timeout) {
++        ready = xs_read(ctx->xsh, XBT_NULL, firewall_path, NULL);
++        if (ready) {
++            free(ready);
 +            break;
++        }
 +        sleep(1);
-+        timeout++;
 +    }
 +
      libxl__multidev_begin(ao, &sdss->multidev);


### PR DESCRIPTION
* xen/xl: Fix memory fault in libxl create domain.
Triggered on 64bit dom0. Refactor `libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch` while at it.

* xen/xl: Refactor `tapdev_is_shared` callsites.
Multiple patches seem to have accumulated some churn, try to avoid multiple calls to `tapdev_is_shared`. It seems that it should be called in the blktap{2,3} implementations.

* xen/xl: Add pid to syslog() redirections for xl.
Amend the patches redirecting logs to `syslog()` to catch more logs from `xl`. Also add the pid of the process prepended to log lines. It can be useful to identify the daemon process.

* xen/xl: Refactor xenmgr sync for firewall rules.
Reduce the timeout spent waiting for `xenmgr` to notify `xl` through Xenstore that the V4V firewall rules are applied before starting the stubdomain. The current timeout will trigger the dm timeout. Also be more conservative with garbage collected allocations by removing them from the active loop.