### PR TITLE
OXT-1509: Xterm resizable TrueType fonts

### DIFF
--- a/recipes-graphics/xorg-app/xterm_%.bbappend
+++ b/recipes-graphics/xorg-app/xterm_%.bbappend
@@ -1,3 +1,5 @@
+# Enable TrueType fonts
+PACKAGECONFIG += "xft"
 
 do_configure_prepend() {
 	echo >> ${S}/XTerm.ad

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/xfce4-keyboard-shortcuts.xml
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/xfce4-keyboard-shortcuts.xml
@@ -6,15 +6,15 @@
       <property name="&lt;Alt&gt;F2" type="empty"/>
       <property name="&lt;Control&gt;&lt;Alt&gt;Delete" type="empty"/>
       <property name="XF86Display" type="empty"/>
-      <property name="&lt;Shift&gt;&lt;Control&gt;t" type="string" value="xterm -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
-      <property name="&lt;Shift&gt;&lt;Control&gt;h" type="string" value="xterm -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -geometry 100x36 -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;t" type="string" value="xterm -fa Monospace -fs 10 -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;h" type="string" value="xterm -fa Monospace -fs 10 -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -geometry 100x36 -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
     </property>
     <property name="custom" type="empty">
       <property name="&lt;Alt&gt;F2" type="empty"/>
       <property name="&lt;Control&gt;&lt;Alt&gt;Delete" type="empty"/>
       <property name="XF86Display" type="empty"/>
-      <property name="&lt;Shift&gt;&lt;Control&gt;t" type="string" value="xterm -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
-      <property name="&lt;Shift&gt;&lt;Control&gt;h" type="string" value="xterm -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -geometry 100x36 -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;t" type="string" value="xterm -fa Monospace -fs 10 -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;h" type="string" value="xterm -fa Monospace -fs 10 -bg grey10 -fg gainsboro -title 'Management Terminal' -ls -geometry 100x36 -sl 1000 -sb -rightbar -e /usr/bin/env INET_IS_V4V=1 LD_PRELOAD=/usr/lib/libv4v-1.0.so.0 ssh -x -p 2222 -o StrictHostKeyChecking=false root@dom0"/>
       <property name="override" type="bool" value="true"/>
       <property name="&lt;Shift&gt;&lt;Control&gt;q" type="string" value="killall surf">
     </property>


### PR DESCRIPTION
Font resizing was broken during the pyro upgrade.  xterm was no longer
built with TrueType font support and there were no X fonts installed.
It seems like only the default X fallback font was available to xterm.
Enable TrueType fonts through xft in PACKAGECONFIG to re-enable terminal
font size changing.

I tried installing xorg-minimal-fonts, but that was actively harmful.
With that package installed, any attempt to change the font through
ctrl-right click led to xterm exiting through an abort().

The default font size is set to 10 point.