### PR TITLE
Xen 4.11 Read-only IDE fix

### DIFF
--- a/recipes-extended/xen/files/libxl-atapi-pt.patch
+++ b/recipes-extended/xen/files/libxl-atapi-pt.patch
@@ -72,7 +72,7 @@ PATCHES
      if ((sscanf(virtpath, "d%ip%i%n", &disk, &partition, &chrused)  >= 2
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1558,13 +1558,21 @@ static int libxl__build_device_model_arg
+@@ -1561,13 +1561,21 @@ static int libxl__build_device_model_arg
              }
  
              if (disks[i].is_cdrom) {
@@ -101,7 +101,7 @@ PATCHES
              } else {
                  /*
                   * Explicit sd disks are passed through as is.
-@@ -1763,6 +1771,34 @@ static int libxl__build_device_model_arg
+@@ -1766,6 +1774,34 @@ static int libxl__build_device_model_arg
      }
  }
  
@@ -136,7 +136,7 @@ PATCHES
  static void libxl__dm_vifs_from_hvm_guest_config(libxl__gc *gc,
                                      libxl_domain_config * const guest_config,
                                      libxl_domain_config *dm_config)
-@@ -1989,9 +2025,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1992,9 +2028,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.stubdom_cmdline =
          libxl__strdup(gc, guest_config->b_info.stubdom_cmdline);
  

--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -135,7 +135,7 @@ PATCHES
      if (!err) {
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1543,7 +1543,7 @@ static int libxl__build_device_model_arg
+@@ -1546,7 +1546,7 @@ static int libxl__build_device_model_arg
                   */
                  if (disks[i].backend == LIBXL_DISK_BACKEND_TAP)
                      target_path = libxl__blktap_devpath(gc, disks[i].pdev_path,

--- a/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
+++ b/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
@@ -49,40 +49,6 @@ PATCHES
          break;
      case LIBXL__COLO_PRIMARY:
          /*
-@@ -869,13 +870,13 @@ static char *qemu_disk_ide_drive_string(
-          *  vote-threshold=1
-          */
-         drive = GCSPRINTF(
--            "if=ide,index=%d,media=disk,cache=writeback,driver=quorum,"
-+            "if=ide,index=%d,media=disk,readonly=%s,cache=writeback,driver=quorum,"
-             "id=%s,"
-             "children.0.file.filename=%s,"
-             "children.0.driver=%s,"
-             "read-pattern=fifo,"
-             "vote-threshold=1",
--             unit, exportname, target_path, format);
-+            unit, disk->readwrite ? "off" : "on", exportname, target_path, format);
-         break;
-     case LIBXL__COLO_SECONDARY:
-         /*
-@@ -889,7 +890,7 @@ static char *qemu_disk_ide_drive_string(
-          *  file.backing.backing=exportname,
-          */
-         drive = GCSPRINTF(
--            "if=ide,index=%d,id=top-colo,media=disk,cache=writeback,"
-+            "if=ide,index=%d,id=top-colo,media=disk,readonly=%s,cache=writeback,"
-             "driver=replication,"
-             "mode=secondary,"
-             "top-id=top-colo,"
-@@ -898,7 +899,7 @@ static char *qemu_disk_ide_drive_string(
-             "file.backing.driver=qcow2,"
-             "file.backing.file.filename=%s,"
-             "file.backing.backing=%s",
--            unit, active_disk, hidden_disk, exportname);
-+            unit, disk->readwrite ? "off" : "on", active_disk, hidden_disk, exportname);
-         break;
-     default:
-          abort();
 @@ -1616,11 +1617,6 @@ static int libxl__build_device_model_arg
                          disk, disk), NULL);
                      continue;

--- a/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
+++ b/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
@@ -31,16 +31,25 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -850,8 +850,6 @@ static char *qemu_disk_ide_drive_string(
+@@ -850,13 +850,14 @@ static char *qemu_disk_ide_drive_string(
      const char *active_disk = disk->active_disk;
      const char *hidden_disk = disk->hidden_disk;
  
 -    assert(disk->readwrite); /* should have been checked earlier */
--
++    // OpenXT allows read-only IDE drives
++    //assert(disk->readwrite); /* should have been checked earlier */
+ 
      switch (colo_mode) {
      case LIBXL__COLO_NONE:
          drive = GCSPRINTF
-@@ -869,13 +867,13 @@ static char *qemu_disk_ide_drive_string(
+-            ("file=%s,if=ide,index=%d,media=disk,format=%s,cache=writeback",
+-             target_path, unit, format);
++            ("file=%s,if=ide,index=%d,media=disk,format=%s,readonly=%s,cache=writeback",
++             target_path, unit, format, disk->readwrite ? "off" : "on");
+         break;
+     case LIBXL__COLO_PRIMARY:
+         /*
+@@ -869,13 +870,13 @@ static char *qemu_disk_ide_drive_string(
           *  vote-threshold=1
           */
          drive = GCSPRINTF(
@@ -56,7 +65,7 @@ PATCHES
          break;
      case LIBXL__COLO_SECONDARY:
          /*
-@@ -889,7 +887,7 @@ static char *qemu_disk_ide_drive_string(
+@@ -889,7 +890,7 @@ static char *qemu_disk_ide_drive_string(
           *  file.backing.backing=exportname,
           */
          drive = GCSPRINTF(
@@ -65,7 +74,7 @@ PATCHES
              "driver=replication,"
              "mode=secondary,"
              "top-id=top-colo,"
-@@ -898,7 +896,7 @@ static char *qemu_disk_ide_drive_string(
+@@ -898,7 +899,7 @@ static char *qemu_disk_ide_drive_string(
              "file.backing.driver=qcow2,"
              "file.backing.file.filename=%s,"
              "file.backing.backing=%s",
@@ -74,7 +83,7 @@ PATCHES
          break;
      default:
           abort();
-@@ -1616,11 +1614,6 @@ static int libxl__build_device_model_arg
+@@ -1616,11 +1617,6 @@ static int libxl__build_device_model_arg
                          disk, disk), NULL);
                      continue;
                  } else if (disk < 4) {

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -134,7 +134,7 @@ PATCHES
                                     libxl__device_backend_path(gc, device)),
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1253,9 +1253,12 @@ static int libxl__build_device_model_arg
+@@ -1256,9 +1256,12 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
                  flexarray_append(dm_args,
@@ -150,7 +150,7 @@ PATCHES
                  flexarray_append(dm_args, "-netdev");
                  flexarray_append(dm_args,
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
-@@ -1773,6 +1776,9 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1776,6 +1779,9 @@ static void libxl__dm_vifs_from_hvm_gues
          libxl_device_nic_init(&dm_config->nics[i]);
          libxl_device_nic_copy(ctx, &dm_config->nics[i], &guest_config->nics[i]);
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;


### PR DESCRIPTION
This PR fixes libxl-support-hvm-readonly-disks.patch after the 4.11 uprev for read-only IDE support.  You can see this with HVM NDVM.

It also cleans up the patch to drop the changes to COLO since we don't use or support that functionality.