### PR TITLE
module-signing: Handle no module case

### DIFF
--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -33,8 +33,9 @@ do_sign_modules() {
         [ -x "$SIGN_FILE" ] || bbfatal "Cannot find scripts/sign-file"
 
         find ${D} -name "*.ko" -print0 | \
-          xargs -0 -n 1 $SIGN_FILE $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
-              ${KERNEL_MODULE_SIG_CERT}
+          xargs --no-run-if-empty -0 -n 1 \
+              $SIGN_FILE $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
+                  ${KERNEL_MODULE_SIG_CERT}
     fi
 }
 


### PR DESCRIPTION
With an external signing key, do_sign_modules will fail when there are
no modules.
| DEBUG: Executing shell function do_sign_modules
| Usage: scripts/sign-file [-dp] <hash algo> <key> <x509> <module> [<dest>]
|        scripts/sign-file -s <raw sig> <hash algo> <x509> <module> [<dest>]

If there are no modules, we don't have to run sign-file.  Have xargs
skip running the command in that case.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>