### PR TITLE
ahci support: provide multiple disk support in case of stubdom

### DIFF
--- a/recipes-extended/xen/files/libxl-RFC-fix-multiple-disks.patch
+++ b/recipes-extended/xen/files/libxl-RFC-fix-multiple-disks.patch
@@ -41,7 +41,22 @@ PATCHES
                  target_path = "/dev/xvdc";
              } else {
                  if (format == NULL) {
-@@ -1605,8 +1605,10 @@ static int libxl__build_device_model_arg
+@@ -1592,6 +1592,14 @@ static int libxl__build_device_model_arg
+                              "qemu-xen doesn't support read-only AHCI disk drivers");
+                         return ERROR_INVAL;
+                     }
++                    if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {
++                        target_path = (char *[]) {"/dev/xvda",
++                                                  "/dev/xvdb",
++                                                  "/dev/xvdc",
++                                                  "/dev/xvdd",
++                                                  "/dev/xvde",
++                                                  "/dev/xvdf",} [disk];
++                    }
+                     flexarray_vappend(dm_args, "-drive",
+                         GCSPRINTF("file=%s,if=none,id=ahcidisk-%d,format=%s,cache=writeback",
+                         target_path, disk, format),
+@@ -1605,8 +1613,10 @@ static int libxl__build_device_model_arg
                          return ERROR_INVAL;
                      }
                      if (b_info->stubdomain_version == LIBXL_STUBDOMAIN_VERSION_LINUX) {

--- a/recipes-extended/xen/files/libxl-atapi-pt.patch
+++ b/recipes-extended/xen/files/libxl-atapi-pt.patch
@@ -101,7 +101,7 @@ PATCHES
              } else {
                  /*
                   * Explicit sd disks are passed through as is.
-@@ -1766,6 +1774,34 @@ static int libxl__build_device_model_arg
+@@ -1774,6 +1782,34 @@ static int libxl__build_device_model_arg
      }
  }
  
@@ -136,7 +136,7 @@ PATCHES
  static void libxl__dm_vifs_from_hvm_guest_config(libxl__gc *gc,
                                      libxl_domain_config * const guest_config,
                                      libxl_domain_config *dm_config)
-@@ -1992,9 +2028,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2000,9 +2036,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.stubdom_cmdline =
          libxl__strdup(gc, guest_config->b_info.stubdom_cmdline);
  

--- a/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
+++ b/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
@@ -30,7 +30,7 @@ Mahantesh Salimath<salimathm@ainfosec.com>
  
      if (ret) {
          LOGD(ERROR, domid, "cannot (re-)build domain: %d", ret);
-@@ -1320,12 +1320,62 @@ static void domcreate_rebuild_done(libxl
+@@ -1323,12 +1323,62 @@ static void domcreate_rebuild_done(libxl
          goto error_out;
      }
  

--- a/recipes-extended/xen/files/libxl-blktap3-support.patch
+++ b/recipes-extended/xen/files/libxl-blktap3-support.patch
@@ -282,7 +282,7 @@ PATCHES
      disk->vdev = xs_read(ctx->xsh, XBT_NULL,
                           GCSPRINTF("%s/dev", libxl_path), &len);
      if (!disk->vdev) {
-@@ -771,6 +782,7 @@ int libxl_cdrom_change(libxl_ctx *ctx, u
+@@ -769,6 +780,7 @@ int libxl_cdrom_change(libxl_ctx *ctx, u
  
      libxl__ao_complete(egc, ao, 0);
  out:

--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -60,7 +60,7 @@ PATCHES
 +                                    char *keydir);
  
  _hidden int libxl__get_tap_minor(libxl__gc *gc, libxl_disk_format format, const char *disk);
- _hidden bool tapdev_is_shared(libxl__gc *gc, const char *params);
+ 
 --- a/tools/libxl/libxl_types.idl
 +++ b/tools/libxl/libxl_types.idl
 @@ -493,6 +493,9 @@ libxl_domain_build_info = Struct("domain

--- a/recipes-extended/xen/files/libxl-disable-json-updates.patch
+++ b/recipes-extended/xen/files/libxl-disable-json-updates.patch
@@ -49,7 +49,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -3444,7 +3444,7 @@ _hidden void libxl__bootloader_run(libxl
+@@ -3443,7 +3443,7 @@ _hidden void libxl__bootloader_run(libxl
          libxl__prepare_ao_device(ao, aodev);                            \
          aodev->action = LIBXL__DEVICE_ACTION_ADD;                       \
          aodev->callback = device_addrm_aocomplete;                      \
@@ -60,7 +60,7 @@ PATCHES
          return AO_INPROGRESS;                                           \
 --- a/tools/libxl/libxl_create.c
 +++ b/tools/libxl/libxl_create.c
-@@ -1689,25 +1689,6 @@ static void domcreate_complete(libxl__eg
+@@ -1699,25 +1699,6 @@ static void domcreate_complete(libxl__eg
  
      bool retain_domain = !rc || rc == ERROR_ABORTED;
  

--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -73,7 +73,7 @@ PATCHES
  
  /* from libxl_dtdev */
  
-@@ -3730,6 +3737,7 @@ struct libxl__destroy_domid_state {
+@@ -3729,6 +3736,7 @@ struct libxl__destroy_domid_state {
      /* private to implementation */
      libxl__devices_remove_state drs;
      libxl__ev_child destroyer;

--- a/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
+++ b/recipes-extended/xen/files/libxl-linux-stubdom-replace-disk-with-initramfs.patch
@@ -37,7 +37,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1893,7 +1893,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1901,7 +1901,6 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      char **args;
      struct xs_permissions perm[2];
      xs_transaction_t t;
@@ -45,7 +45,7 @@ PATCHES
  
      /* convenience aliases */
      libxl_domain_config *const dm_config = &sdss->dm_config;
-@@ -1989,20 +1988,12 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1997,20 +1996,12 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          stubdom_state->pv_ramdisk.path = "";
          break;
      case LIBXL_STUBDOMAIN_VERSION_LINUX:
@@ -71,7 +71,7 @@ PATCHES
          break;
      default:
          abort();
-@@ -2075,10 +2066,7 @@ retry_transaction:
+@@ -2083,10 +2074,7 @@ retry_transaction:
  
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
@@ -83,7 +83,7 @@ PATCHES
      libxl__add_disks(egc, ao, dm_domid, dm_config, &sdss->multidev);
      libxl__multidev_prepared(egc, &sdss->multidev, 0);
  
-@@ -2203,7 +2191,7 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2211,7 +2199,7 @@ static void spawn_stub_launch_dm(libxl__
      sdss->pvqemu.build_state = &sdss->dm_state;
      sdss->pvqemu.callback = spawn_stubdom_pvqemu_cb;
  
@@ -92,7 +92,7 @@ PATCHES
          /* If dom0 qemu not needed, do not launch it */
          spawn_stubdom_pvqemu_cb(egc, &sdss->pvqemu, 0);
      } else {
-@@ -2241,42 +2229,6 @@ out:
+@@ -2249,42 +2237,6 @@ out:
      stubdom_pvqemu_cb(egc, &sdss->multidev, rc);
  }
  
@@ -135,7 +135,7 @@ PATCHES
  static void stubdom_pvqemu_cb(libxl__egc *egc,
                                libxl__multidev *multidev,
                                int rc)
-@@ -2284,7 +2236,6 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2292,7 +2244,6 @@ static void stubdom_pvqemu_cb(libxl__egc
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
      uint32_t dm_domid = sdss->pvqemu.guest_domid;
@@ -143,7 +143,7 @@ PATCHES
  
      libxl__xswait_init(&sdss->xswait);
  
-@@ -2294,16 +2245,7 @@ static void stubdom_pvqemu_cb(libxl__egc
+@@ -2302,16 +2253,7 @@ static void stubdom_pvqemu_cb(libxl__egc
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -62,7 +62,7 @@ PATCHES
          }
          if (!libxl__acpi_defbool_val(b_info)) {
              flexarray_append(dm_args, "-no-acpi");
-@@ -1883,6 +1888,25 @@ char *libxl__stub_dm_name(libxl__gc *gc,
+@@ -1891,6 +1896,25 @@ char *libxl__stub_dm_name(libxl__gc *gc,
      return GCSPRINTF("%s-dm", guest_name);
  }
  
@@ -88,7 +88,7 @@ PATCHES
  void libxl__spawn_stub_dm(libxl__egc *egc, libxl__stub_dm_spawn_state *sdss)
  {
      STATE_AO_GC(sdss->dm.spawn.ao);
-@@ -2018,6 +2042,22 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2026,6 +2050,22 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2077,6 +2077,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2085,6 +2085,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                                     libxl__xs_get_dompath(gc, guest_domid)),
                          "%s",
                          libxl_bios_type_to_string(guest_config->b_info.u.hvm.bios));
@@ -48,7 +48,7 @@ PATCHES
      }
      ret = xc_domain_set_target(ctx->xch, dm_domid, guest_domid);
      if (ret<0) {
-@@ -2101,6 +2106,12 @@ retry_transaction:
+@@ -2109,6 +2114,12 @@ retry_transaction:
          if (errno == EAGAIN)
              goto retry_transaction;
  
@@ -61,7 +61,7 @@ PATCHES
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
      /* OpenXT: Again, no disk for the stubdom itself */
-@@ -2119,7 +2130,6 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2127,7 +2138,6 @@ static void spawn_stub_launch_dm(libxl__
  {
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
@@ -69,7 +69,7 @@ PATCHES
      int i, num_console = STUBDOM_SPECIAL_CONSOLES;
      libxl__device_console *console;
  
-@@ -2169,21 +2179,16 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2177,21 +2187,16 @@ static void spawn_stub_launch_dm(libxl__
  
      for (i = 0; i < num_console; i++) {
          console[i].devid = i;
@@ -95,7 +95,7 @@ PATCHES
                  /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
                   * will be in use */
                  console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
-@@ -2396,6 +2401,17 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2404,6 +2409,17 @@ void libxl__spawn_local_dm(libxl__egc *e
                           b_info->device_model_version==LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL &&
                           !libxl__vnuma_configured(b_info));
          free(path);

--- a/recipes-extended/xen/files/libxl-stubdom-options.patch
+++ b/recipes-extended/xen/files/libxl-stubdom-options.patch
@@ -51,7 +51,7 @@ PATCHES
      ("iomem",            Array(libxl_iomem_range, "num_iomem")),
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1972,6 +1972,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1980,6 +1980,7 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          abort();
      }
      dm_config->b_info.max_memkb += guest_config->b_info.video_memkb;
@@ -59,7 +59,7 @@ PATCHES
      dm_config->b_info.target_memkb = dm_config->b_info.max_memkb;
  
      dm_config->b_info.max_grant_frames = guest_config->b_info.max_grant_frames;
-@@ -1986,6 +1987,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -1994,6 +1995,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
      dm_config->b_info.extra = guest_config->b_info.extra;
      dm_config->b_info.extra_pv = guest_config->b_info.extra_pv;
      dm_config->b_info.extra_hvm = guest_config->b_info.extra_hvm;
@@ -68,7 +68,7 @@ PATCHES
  
      dm_config->disks = guest_config->disks;
      dm_config->num_disks = guest_config->num_disks;
-@@ -2026,6 +2029,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2034,6 +2037,8 @@ void libxl__spawn_stub_dm(libxl__egc *eg
                                libxl__xenfirmwaredir_path());
          stubdom_state->pv_ramdisk.path = libxl__abs_path(gc, "stubdomain-initramfs",
                                                           libxl__xenfirmwaredir_path());

--- a/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
+++ b/recipes-extended/xen/files/libxl-support-hvm-readonly-disks.patch
@@ -49,7 +49,7 @@ PATCHES
          break;
      case LIBXL__COLO_PRIMARY:
          /*
-@@ -1616,11 +1617,6 @@ static int libxl__build_device_model_arg
+@@ -1624,11 +1625,6 @@ static int libxl__build_device_model_arg
                          disk, disk), NULL);
                      continue;
                  } else if (disk < 4) {

--- a/recipes-extended/xen/files/libxl-vif-make-ioemu-and-stubdom-mac-addresses-configurable.patch
+++ b/recipes-extended/xen/files/libxl-vif-make-ioemu-and-stubdom-mac-addresses-configurable.patch
@@ -73,7 +73,7 @@ PATCHES
                  const char *ifname = libxl__device_nic_devname(gc,
                                                  guest_domid, nics[i].devid,
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
-@@ -1764,6 +1770,10 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1772,6 +1778,10 @@ static void libxl__dm_vifs_from_hvm_gues
          if (dm_config->nics[i].ifname)
              dm_config->nics[i].ifname = GCSPRINTF("%s" TAP_DEVICE_SUFFIX,
                                                    dm_config->nics[i].ifname);

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -150,7 +150,7 @@ PATCHES
                  flexarray_append(dm_args, "-netdev");
                  flexarray_append(dm_args,
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
-@@ -1776,6 +1779,9 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -1784,6 +1787,9 @@ static void libxl__dm_vifs_from_hvm_gues
          libxl_device_nic_init(&dm_config->nics[i]);
          libxl_device_nic_copy(ctx, &dm_config->nics[i], &guest_config->nics[i]);
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -170,7 +170,7 @@ PATCHES
  out:
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2123,6 +2123,24 @@ retry_transaction:
+@@ -2131,6 +2131,24 @@ retry_transaction:
      libxl__xs_printf(gc, XBT_NULL,
                       DEVICE_MODEL_XS_PATH(gc, dm_domid, guest_domid, "/xen_extended_power_mgmt"), "2");
  


### PR DESCRIPTION
OXT-1123

By  emulating qemu SATA (hdtype='ahci') disk, it is possible to
add upto 6 disks to a hvm guest (guest should support AHCI).

Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>