### PR TITLE
refpolicy: Turn global_ssp on

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs_2.%.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_2.%.bbappend
@@ -97,6 +97,7 @@ SRC_URI += " \
 "
 # Patches.
 SRC_URI += " \
+    file://patches/policy.booleans.diff \
     file://patches/remove-xml-doc-gen.patch \
     file://patches/Makefile.diff \
     file://patches/build.conf.diff \


### PR DESCRIPTION
Turn the global_ssp policy boolean on.  SSP - Stack Smashing Protection -
requires reading urandom to get a random cookie value.  Instead of
adding permissions to individual domains, this gives all SELinux domains
permission to read /dev/urandom.

This patch was sitting in-tree but never added to SRC_URI, so never
applied.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>