### PR TITLE
OXT-1523: Fix auto-generated key signing race

### DIFF
--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -42,4 +42,7 @@ do_sign_modules() {
 addtask sign_modules after do_install before do_package
 # lockfiles needs to match module.bbclass make_scripts value
 # Otherwise sign-file could disappear from ${STAGING_KERNEL_BUILDDIR}
+# Build-time auto-generated keys sign modules in do_install
+do_install[lockfiles] = "${TMPDIR}/kernel-scripts.lock"
+# Explicit keys sign modules in do_sign_modules
 do_sign_modules[lockfiles] = "${TMPDIR}/kernel-scripts.lock"


### PR DESCRIPTION
We've seen an intermittent issue where xenfb2 doesn't get signed.  The
failure isn't fatal, so it is only detected at runtime.  From the
do_install log:
  INSTALL /home/build/1905/openxt/build/tmp-glibc/work/xenclient_uivm-oe-linux/xenfb2/0+gitAUTOINC+fad222619c-r0/git/linux/xenfb2.ko
/bin/sh: scripts/sign-file: Permission denied
  DEPMOD  4.14.66

log.do_make_scripts shows scripts/sign-file is built.  I would guess we
have a race against another module - maybe v4v?

commit 1b18ae5 fixed a race when using a explicit key to sign modules in
do_sign_modules.  Auto-generated keys are signed by the kernel
modules_install do_install, so they would not have been covered.  It
seems do_install also needs the same lockfile to avoid a race between
do_install and do_make_scripts.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

@jean-edouard , maybe this will help?