### PR TITLE
Fixup rsyslog.conf packaging

### DIFF
--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -86,6 +86,10 @@ PREFERRED_PROVIDER_jpeg-native = "jpeg-native"
 # xen-xenstored-c is a PROVIDE alias to xen.bb.
 PREFERRED_PROVIDER_xen-xenstored = "xen-xenstored-c"
 
+# Default to rsyslog recipe which RPROVIDES rsyslog-conf
+# Dom0 and Installer install rsyslog-conf-dom0 instead.
+PREFERRED_RPROVIDER_rsyslog-conf = "rsyslog"
+
 # rpcgen staging and install paths.
 require xc-rpcgen.inc
 

--- a/recipes-extended/rsyslog/rsyslog-conf-dom0.bb
+++ b/recipes-extended/rsyslog/rsyslog-conf-dom0.bb
@@ -6,7 +6,8 @@ inherit allarch
 
 SRC_URI = "file://rsyslog.conf"
 
-RPROVIDES_$PN = "rsyslog-conf"
+RPROVIDES_${PN} = "rsyslog-conf"
+RCONFLICTS_${PN} = "rsyslog-conf"
 
 CONFFILES_${PN} = "${sysconfdir}/rsyslog.conf"
 

--- a/recipes-extended/rsyslog/rsyslog_%.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_%.bbappend
@@ -17,8 +17,6 @@ do_install_append() {
 PACKAGES =+ "${PN}-conf"
 RRECOMMENDS_${PN} += "${PN}-conf"
 
-# Only ${PN} expands in ${CONFFILES}_${PN}, so we have to hard code
-#CONFFILES_${PN}-conf += "${CONFFILES}_${PN}"
-CONFFILES_${PN}-conf += "$(sysconfdir}/rsyslog.conf"
-
-FILES_${PN}-conf = "${CONFFILES}_${PN}-conf"
+RSYSLOG_CONF = "${sysconfdir}/rsyslog.conf"
+CONFFILES_${PN}-conf += "${RSYSLOG_CONF}"
+FILES_${PN}-conf = "${RSYSLOG_CONF}"


### PR DESCRIPTION
I had $(sysconfdir} - note the erroneous parenthesis - so it wasn't
expanding the CONFFILES properly.  FILES was also not getting set since
${CONFFILES}_${PN} wasn't getting expanded.  This meant
/etc/rsyslog.conf was still packaged in "rsyslog".

However, /etc/rsyslog.conf was still getting installed from
rsyslog-conf-dom0.  /etc/rsyslog.conf was marked as a CONFFILE even in
the "rsyslog" package.  So when you installed rsyslog-conf-dom0, it
would rename the original to /etc/rsyslog.conf-opkg and then install the
new conf file as /etc/rsyslog.conf.  Dom0 and installer have those extra
-opkg files hanging around.

Adding BAD_RECOMMENDATIONS to both dom0 and installer avoids the *-opkg files hanging around.

NOTE: on a dirty build, I had to do some cleanalls to get rid of linger machine specific rsyslogs that were still hanging around - specifically for the installer.