### PR TITLE
Quirk to drop PCR1 from sealing set

### DIFF
--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
@@ -395,7 +395,7 @@ encrypted_unlock() {
     then
         if pcr_bank_exists "sha256"; then
             local unseal_file=${key_file}
-            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB -r 0 -r 1 -r 2 -r 3 -r 4 -r 5 -r 7 -r 8 -r 15 -r 17 -r 18 -r 19 | cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
+            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB $( < ${unseal_file}.pcrs )| cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
             ret=$?
         fi
     else

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -240,6 +240,7 @@ seal()
         clean_old_tpm_files
         if pcr_bank_exists "sha256"; then
             sealout=$(tpm2_sealdata -H 0x81000000 -I ${seal_file} -O ${tss_file}.sha256 -o ${tss_file}.pub.sha256 -g 0xB -G 0x8 -b 0x492 $(cat /config/config.pcrs) 2>&1 )
+            cp /config/config.pcrs ${tss_file}.pcrs
             sealerr=$?
         fi
     else

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/pcr1-detect.sh
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/pcr1-detect.sh
@@ -25,5 +25,18 @@ if [ "${VENDOR_ID}" = "8086" ]; then
             MANUFACTURER=$(dmidecode --type 1 | sed -n -re 's/.*Manufacturer: (.*)$/\1/p' | cut -d ' ' -f 1)
             VERSION=$(dmidecode --type 1 | sed -n -re 's/.*Version: (.*)$/\1/p')
             ;;
+        5910)
+            MANUFACTURER=$(dmidecode --type 1 | \
+                           sed -n -re 's/.*Manufacturer: (.*)$/\1/p' | \
+                           cut -d ' ' -f 1)
+            PRODUCT=$(dmidecode --type 1 | \
+                      sed -n -re 's/.*Product Name: (.*)$/\1/p')
+            if [ "$MANUFACTURER" = "Dell" ] && \
+               [ "$PRODUCT" = "Latitude 5580" ] ; then
+                exit 1
+            fi
+            ;;
     esac
 fi
+
+exit 0

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/pcr1-fix.sh
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/pcr1-fix.sh
@@ -25,9 +25,9 @@ config_pcrs="${root}/config/config.pcrs"
     exit 1
 }
 
-grep '\-p 1' "${config_pcrs}"
+grep '\-[rp] 1' "${config_pcrs}"
 case $? in
-    0)  sed -i -e 's&-p 1 &&' "${config_pcrs}"
+    0)  sed -i -e 's&-p 1&&' -e 's&-r 1&&' "${config_pcrs}"
         if [ $? -gt 0 ]; then
             echo "Unable to remove PCR[1] from measurement list." >&2
             exit 1

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -25,6 +25,7 @@
 
 clean_old_tpm_files () {
     [ -e /boot/system/tpm/config.tss ] && rm /boot/system/tpm/config.tss
+    [ -e /boot/system/tpm/config.tss.pcrs ] && rm /boot/system/tpm/config.tss.pcrs
     [ -e /boot/system/tpm/config.tss.sha256 ] && rm /boot/system/tpm/config.tss.sha256
     [ -e /boot/system/tpm/config.tss.pub.sha256 ] && rm /boot/system/tpm/config.tss.pub.sha256
 }
@@ -674,6 +675,10 @@ tpm_seal() {
         pcr_bank_exists "${hashalg}"
         [ $? -eq 0 ] || return 1
 
+        # pcr_params starts with -p or -r, but that's okay because
+        # echo only honors flags -n -e & -E
+        echo "${pcr_params}" > ${tss}.pcrs
+
         case $hashalg in
         sha1)
             sealout=$(tpm2_sealdata -H ${OXT_HANDLE_SHA1} -I ${secret} \
@@ -741,6 +746,9 @@ tpm_forward_seal() {
         seal_file=${key}
         clean_old_tpm_files
         if pcr_bank_exists "sha256"; then
+            # We only want the PCRs numbers and not the forward seal values
+            echo "${pcr_params}" | \
+                sed -e 's/:[0-9a-zA-Z]\{64\}//g' > ${tss}.pcrs
             tpm2_sealdata -H ${OXT_HANDLE_SHA256} -I ${seal_file} \
                           -O ${tss}.sha256 -o ${tss}.pub.sha256 \
                           -g ${TPM_ALG_SHA256} -G ${TPM_ALG_KEYEDHASH} \
@@ -800,13 +808,13 @@ tpm_unseal() {
         sha1)
             tpm2_unsealdata -H ${OXT_HANDLE_SHA1} -n "${tss}.sha1" \
                             -u "${tss}.pub.sha1" -g ${TPM_ALG_SHA1} \
-                            ${pcr_params} 2>/dev/null
+                            $( < ${tss}.pcrs ) 2>/dev/null
             return $?
         ;;
         sha256)
             tpm2_unsealdata -H ${OXT_HANDLE_SHA256} -n "${tss}.sha256" \
                             -u "${tss}.pub.sha256" -g ${TPM_ALG_SHA256} \
-                            ${pcr_params} 2>/dev/null
+                            $( < ${tss}.pcrs ) 2>/dev/null
             return $?
         ;;
         *)


### PR DESCRIPTION
Some devices change PCR1 when booted docked versus undocked.  This PR consolidates storage of the pcr sealings set for TPM2 so we can drop out entries if needed - I'm surprised the TPM2 sealing blob doesn't include the sealing set.  The PCRs are stored in /config/config.pcrs and /boot/system/tpm/config.tss.pcrs.  We need to read them out of the unencrypted /boot/system/tpm/config.tss.pcrs so that we can unseal.  If an attacker modified the file, they would break unsealing.  I think the $( < file.pcrs ) construct is safe from command injection - I haven't been able to perform a command injection - the output seems to be interpreted as just a string by the shell.  A ';' is just passed as an argument and does not end the statement.

Next it fixes up the existing pcr1 quirk to work and cover one Dell laptop model.  This should be expanded to cover move devices, but I don't know what to check for.  There is a dmidecode entry for DOCK/JDOCK1, but I don't know what that actually corresponds to.

The PCR1 measurement changes because BoorOrder changes and a new "USB NIC" boot entry is measured into PCR1.

The PR also converts tpm-scripts to allarch since it's shell scripts, and it deletes the unused tpm-setup script and associated files.

FYI, as the installer is currently written, the PCR1 quirk will only be applied on fresh install.

Is tpm-functions tpm_seal() even used?