### PR TITLE
[selinux] Allow xenmgr to connect to xenstored socket

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.contrib.xen.diff
@@ -252,7 +252,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  ########################################
  #
-@@ -165,14 +186,20 @@ files_pid_filetrans(evtchnd_t, evtchnd_v
+@@ -165,13 +186,20 @@ files_pid_filetrans(evtchnd_t, evtchnd_v
  
  allow xend_t self:capability { dac_override ipc_lock net_admin setuid sys_admin sys_nice sys_tty_config net_raw sys_resource sys_rawio };
  dontaudit xend_t self:capability { sys_ptrace };
@@ -268,15 +268,15 @@ Index: refpolicy/policy/modules/contrib/xen.te
 +allow xend_t self:netlink_route_socket r_netlink_socket_perms;
  allow xend_t self:packet_socket create_socket_perms;
  allow xend_t self:tun_socket create_socket_perms;
- 
++allow xend_t xenstored_t:unix_stream_socket connectto;
++
 +# XenClient /config files
 +manage_dirs_pattern(xend_t, xend_config_t, xend_config_t)
 +manage_files_pattern(xend_t, xend_config_t, xend_config_t)
-+
+ 
  allow xend_t xen_image_t:dir list_dir_perms;
  manage_dirs_pattern(xend_t, xen_image_t, xen_image_t)
- manage_fifo_files_pattern(xend_t, xen_image_t, xen_image_t)
-@@ -196,6 +223,7 @@ manage_sock_files_pattern(xend_t, xend_v
+@@ -196,6 +224,7 @@ manage_sock_files_pattern(xend_t, xend_v
  manage_fifo_files_pattern(xend_t, xend_var_run_t, xend_var_run_t)
  files_pid_filetrans(xend_t, xend_var_run_t, { file sock_file fifo_file dir })
  
@@ -284,7 +284,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  manage_dirs_pattern(xend_t, xend_var_log_t, xend_var_log_t)
  append_files_pattern(xend_t, xend_var_log_t, xend_var_log_t)
  create_files_pattern(xend_t, xend_var_log_t, xend_var_log_t)
-@@ -203,6 +231,9 @@ setattr_files_pattern(xend_t, xend_var_l
+@@ -203,6 +232,9 @@ setattr_files_pattern(xend_t, xend_var_l
  manage_sock_files_pattern(xend_t, xend_var_log_t, xend_var_log_t)
  logging_log_filetrans(xend_t, xend_var_log_t, { sock_file file dir })
  
@@ -294,7 +294,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  manage_dirs_pattern(xend_t, xend_var_lib_t, xend_var_lib_t)
  manage_files_pattern(xend_t, xend_var_lib_t, xend_var_lib_t)
  manage_sock_files_pattern(xend_t, xend_var_lib_t, xend_var_lib_t)
-@@ -218,6 +249,14 @@ domtrans_pattern(xend_t, xenstored_exec_
+@@ -218,6 +250,14 @@ domtrans_pattern(xend_t, xenstored_exec_
  
  xen_stream_connect_xenstore(xend_t)
  
@@ -309,7 +309,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  kernel_read_kernel_sysctls(xend_t)
  kernel_read_system_state(xend_t)
  kernel_write_xen_state(xend_t)
-@@ -260,6 +299,10 @@ dev_read_urand(xend_t)
+@@ -260,6 +300,10 @@ dev_read_urand(xend_t)
  dev_filetrans_xen(xend_t)
  dev_rw_sysfs(xend_t)
  dev_rw_xen(xend_t)
@@ -320,7 +320,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  domain_dontaudit_read_all_domains_state(xend_t)
  domain_dontaudit_ptrace_all_domains(xend_t)
-@@ -272,6 +315,13 @@ files_etc_filetrans_etc_runtime(xend_t,
+@@ -272,6 +316,13 @@ files_etc_filetrans_etc_runtime(xend_t,
  files_read_usr_files(xend_t)
  files_read_default_symlinks(xend_t)
  files_search_mnt(xend_t)
@@ -334,7 +334,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  fs_getattr_all_fs(xend_t)
  fs_list_auto_mountpoints(xend_t)
-@@ -281,6 +331,24 @@ fs_manage_xenfs_dirs(xend_t)
+@@ -281,6 +332,24 @@ fs_manage_xenfs_dirs(xend_t)
  fs_manage_xenfs_files(xend_t)
  
  storage_read_scsi_generic(xend_t)
@@ -359,7 +359,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  term_setattr_generic_ptys(xend_t)
  term_getattr_all_ptys(xend_t)
-@@ -289,14 +357,24 @@ term_use_generic_ptys(xend_t)
+@@ -289,14 +358,24 @@ term_use_generic_ptys(xend_t)
  term_use_ptmx(xend_t)
  term_getattr_pty_fs(xend_t)
  
@@ -384,7 +384,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  sysnet_domtrans_dhcpc(xend_t)
  sysnet_signal_dhcpc(xend_t)
-@@ -307,6 +385,25 @@ sysnet_read_dhcpc_pid(xend_t)
+@@ -307,6 +386,25 @@ sysnet_read_dhcpc_pid(xend_t)
  sysnet_rw_dhcp_config(xend_t)
  
  userdom_dontaudit_search_user_home_dirs(xend_t)
@@ -410,7 +410,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  tunable_policy(`xen_use_fusefs',`
  	fs_manage_fusefs_dirs(xend_t)
-@@ -360,12 +457,14 @@ optional_policy(`
+@@ -360,12 +458,14 @@ optional_policy(`
  # Xen console local policy
  #
  
@@ -426,7 +426,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_dirs_pattern(xenconsoled_t, xend_var_log_t, xend_var_log_t)
  append_files_pattern(xenconsoled_t, xend_var_log_t, xend_var_log_t)
-@@ -401,10 +500,12 @@ init_use_fds(xenconsoled_t)
+@@ -401,10 +501,12 @@ init_use_fds(xenconsoled_t)
  init_use_script_ptys(xenconsoled_t)
  
  logging_search_logs(xenconsoled_t)
@@ -439,7 +439,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  optional_policy(`
  	ptchown_domtrans(xenconsoled_t)
-@@ -416,7 +517,9 @@ optional_policy(`
+@@ -416,7 +518,9 @@ optional_policy(`
  #
  
  allow xenstored_t self:capability { dac_override ipc_lock sys_resource };
@@ -450,7 +450,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
  manage_dirs_pattern(xenstored_t, xenstored_tmp_t, xenstored_tmp_t)
-@@ -430,6 +533,7 @@ files_pid_filetrans(xenstored_t, xenstor
+@@ -430,6 +534,7 @@ files_pid_filetrans(xenstored_t, xenstor
  manage_dirs_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  append_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  create_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
@@ -458,7 +458,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  setattr_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  manage_sock_files_pattern(xenstored_t, xenstored_var_log_t, xenstored_var_log_t)
  logging_log_filetrans(xenstored_t, xenstored_var_log_t, { sock_file file dir })
-@@ -447,6 +551,11 @@ kernel_read_xen_state(xenstored_t)
+@@ -447,6 +552,11 @@ kernel_read_xen_state(xenstored_t)
  dev_filetrans_xen(xenstored_t)
  dev_rw_xen(xenstored_t)
  dev_read_sysfs(xenstored_t)
@@ -470,7 +470,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  files_read_etc_files(xenstored_t)
  files_read_usr_files(xenstored_t)
-@@ -455,6 +564,7 @@ fs_search_xenfs(xenstored_t)
+@@ -455,6 +565,7 @@ fs_search_xenfs(xenstored_t)
  fs_manage_xenfs_files(xenstored_t)
  
  term_use_generic_ptys(xenstored_t)
@@ -478,7 +478,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  init_use_fds(xenstored_t)
  init_use_script_ptys(xenstored_t)
-@@ -465,6 +575,8 @@ miscfiles_read_localization(xenstored_t)
+@@ -465,6 +576,8 @@ miscfiles_read_localization(xenstored_t)
  
  xen_append_log(xenstored_t)
  
@@ -487,7 +487,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  ########################################
  #
  # xm local policy
-@@ -473,8 +585,8 @@ xen_append_log(xenstored_t)
+@@ -473,8 +586,8 @@ xen_append_log(xenstored_t)
  allow xm_t self:capability { setpcap dac_override ipc_lock sys_nice sys_tty_config };
  allow xm_t self:process { getcap getsched setsched setcap signal };
  allow xm_t self:fifo_file rw_fifo_file_perms;
@@ -498,7 +498,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  
  manage_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
  manage_fifo_files_pattern(xm_t, xend_var_lib_t, xend_var_lib_t)
-@@ -544,6 +656,10 @@ miscfiles_read_localization(xm_t)
+@@ -544,6 +657,10 @@ miscfiles_read_localization(xm_t)
  
  sysnet_dns_name_resolve(xm_t)
  
@@ -509,7 +509,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  tunable_policy(`xen_use_fusefs',`
  	fs_manage_fusefs_dirs(xm_t)
  	fs_manage_fusefs_files(xm_t)
-@@ -601,4 +717,23 @@ optional_policy(`
+@@ -601,4 +718,23 @@ optional_policy(`
  
  	fs_manage_xenfs_dirs(xm_ssh_t)
  	fs_manage_xenfs_files(xm_ssh_t)


### PR DESCRIPTION
Supplemental change for OXT-1287; xenmgr will segfault
on boot without this rule.

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>