### PR TITLE
module-signing: Prefer the build-tree sign-file

### DIFF
--- a/classes/kernel-module-signing.bbclass
+++ b/classes/kernel-module-signing.bbclass
@@ -1,3 +1,7 @@
+require classes/module-signing.bbclass
+# override value from module-signing to use the in-tree utility
+SIGN_FILE = "${B}/scripts/sign-file"
+
 # Set KERNEL_MODULE_SIG_CERT in local.conf to the filepath of a public key
 # to embed in the kernel to verify signed modules
 export KERNEL_MODULE_SIG_CERT

--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -17,6 +17,9 @@ export KERNEL_MODULE_SIG_KEY
 # build-time keypair will be generated and used for signing and embedding.
 export KERNEL_MODULE_SIG_CERT
 
+# Kernel builds will override this with ${B}/scripts/sign-file
+SIGN_FILE = "${STAGING_KERNEL_BUILDDIR}/scripts/sign-file"
+
 do_sign_modules() {
     if [ -n "${KERNEL_MODULE_SIG_KEY}" ] &&
        grep -q '^CONFIG_MODULE_SIG=y' ${STAGING_KERNEL_BUILDDIR}/.config; then
@@ -25,16 +28,11 @@ do_sign_modules() {
                       cut -d '"' -f 2 )
         [ -z "$SIG_HASH" ] && bbfatal CONFIG_MODULE_SIG_HASH is not set in .config
 
-        # ${B} for kernel, ${STAGING_KERNEL_BUILDDIR} for modules
-        for SIGN_FILE in ${STAGING_KERNEL_BUILDDIR}/scripts/sign-file \
-                         ${B}/scripts/sign-file ; do
-            [ -x "$SIGN_FILE" ] && break
-        done
-        [ -x "$SIGN_FILE" ] || bbfatal "Cannot find scripts/sign-file"
+        [ -x "${SIGN_FILE}" ] || bbfatal "Cannot find scripts/sign-file"
 
         find ${D} -name "*.ko" -print0 | \
           xargs --no-run-if-empty -0 -n 1 \
-              $SIGN_FILE $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
+              ${SIGN_FILE} $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
                   ${KERNEL_MODULE_SIG_CERT}
     fi
 }

--- a/recipes-kernel/linux/linux-openxt.inc
+++ b/recipes-kernel/linux/linux-openxt.inc
@@ -1,6 +1,5 @@
 require recipes-kernel/linux/linux-openxt-copy-objtool.inc
-require classes/module-signing.bbclass
-require classes/kernel-signing.bbclass
+require classes/kernel-module-signing.bbclass
 
 DEPENDS += "bc-native"
 


### PR DESCRIPTION
My first build after the 4.19 uprev, I saw do_sign_modules fail for the
linux-openxt recipe:
/home/build/openxt-master/build/tmp-glibc/work-shared/xenclient-dom0/kernel-build-artifacts/scripts/sign-file: error while loading shared libraries: libcrypto.so.1.0.2: cannot open shared object file: No such file or directory

sign-file's path is
build/tmp-glibc/work-shared/xenclient-dom0/kernel-build-artifacts/scripts/sign-file - note there is no version, so it is from 4.14.  And it's rpath is:
/home/build/openxt-master/build/tmp-glibc/work/xenclient_dom0-oe-linux/v4v-module/gitAUTOINC+3f8a139271-r0/recipe-sysroot-native/usr/lib:/home/build/openxt-master/build/tmp-glibc/work/xenclient_dom0-oe-linux/v4v-module/gitAUTOINC+3f8a139271-r0/recipe-sysroot-native/lib

The v4v-module temp dir has been cleaned, so recipe-sysroot-native no
longer exists.

Order ${B} first so that a kernel build prefers the sign-file in its own
build directory over ${STAGING_KERNEL_BUILDDIR}.  That way, we won't try
to use a stale sign-file that has an rpath into some module's
recipe-sysroot-native.  Modules won't find sign-file in ${B}, so they'll
use ${STAGING_KERNEL_BUILDDIR}.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>