### PR TITLE
OXT-1541: [xen] Make sure xen Kconfig uses the new TXT_OP

### DIFF
--- a/recipes-extended/xen/files/tboot-xen-evtlog-support.patch
+++ b/recipes-extended/xen/files/tboot-xen-evtlog-support.patch
@@ -13,6 +13,8 @@ CHANGELOG
 Written for OpenXT. Feature introduced in the stable-7 release.
 Patch updated for Xen 4.8, 4.9.
 
+ 4/2/2019: Added txt_op config option for Kconfig
+
 ################################################################################
 REMOVAL
 ################################################################################
@@ -285,3 +287,16 @@ PATCHES
  #ifdef CONFIG_COMPAT
  
  extern int
+--- a/xen/common/Kconfig
++++ b/xen/common/Kconfig
+@@ -143,6 +143,10 @@ config XSM_POLICY
+ 
+ 	  If unsure, say Y.
+ 
++config TXT_OP
++	bool "Compile Xen with the txt_op hypercall"
++	default n
++
+ config LATE_HWDOM
+ 	bool "Dedicated hardware domain"
+ 	default n


### PR DESCRIPTION
  The x64 uprev was missing a key patch for xen.  With the txt_op
  hypercall ifdef'd out to support building xen-firmware such as
  the pv-shim, the xen/common/Kconfig needs an entry so we can
  optinally set CONFIG_TXT_OP to true and enable the txt_op
  hypercall.

  OXT-1541

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>