### PR TITLE
OXT-1507, OXT-1540 & more: Changes to forward-sealing binaries usage.

### DIFF
--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
@@ -381,6 +381,8 @@ hash_modules() {
 }
 
 check_txt_quirk() {
+    local args
+
     modprobe txt > /dev/null 2>&1
     [ -d /sys/kernel/security/txt ] || return 0
 
@@ -389,6 +391,11 @@ check_txt_quirk() {
     is_tpm_2_0
     if [ $? -eq 0 ]; then
         args="-2 -a sha256 -c"
+
+        # OpenXT 8 and previous eventlog entry.
+        if [ -f "/sys/kernel/security/txt/tpm20_binary_evtlog" ]; then
+            args="${args} -F /sys/kernel/security/txt/tpm20_binary_evtlog -o"
+        fi
     else
         args="-a sha1 -c"
     fi
@@ -408,6 +415,50 @@ check_txt_quirk() {
         return 0
     ;;
     esac
+}
+
+match_acm_legacy() {
+    local root="${1}"
+    local didvid=""
+    local fsbif=""
+    local qpiif=""
+    local acm=""
+
+    eval $(txt-stat |
+        sed -n \
+            -e 's|\s\+FSBIF: \(0x[0-9a-f]\+\)$|fsbif=\1|p' \
+            -e 's|\s\+QPIIF: \(0x[0-9a-f]\+\)$|qpiif=\1|p' \
+            -e 's|\s\+DIDVID: \(0x[0-9a-f]\+\)$|didvid=\1|p')
+
+    if [ -z "${didvid}" -o -z "${fsbif}" -o -z "${qpiif}" ]; then
+        return
+    fi
+
+    fsbif=$((${fsbif} & 0xffffffff))
+    qpiif=$((${qpiif} & 0xffffffff))
+
+    for f in ${root}/boot/*.{bin,BIN}; do
+        if acmmatch -d "${didvid}" -f "${fsbif}" -q "${qpiif}" "${f}" >/dev/null; then
+            acm="${f}"
+            break;
+        fi
+    done
+
+    echo "${acm}"
+}
+
+match_acm() {
+    local root="${1}"
+    local acm=""
+
+    for f in ${root}/boot/*.{bin,BIN}; do
+        if acmmatch "${f}" >/dev/null; then
+            acm="${f}"
+            break;
+        fi
+    done
+
+    echo "${acm}"
 }
 
 calculate_drtm_pcrs() {
@@ -459,12 +510,13 @@ calculate_drtm_pcrs() {
 
         [[ ${quirk} -eq 1 ]] && args="${args} -q"
 
-        for f in ${root}/boot/*.{bin,BIN}; do
-            if acmmatch "${f}" >/dev/null; then
-                acm="${f}"
-                break;
-            fi
-        done
+        # OpenXT 8 to OpenXT 9 forward sealing.
+        if [ -f "/sys/kernel/security/txt/tpm20_binary_evtlog" ]; then
+            acm="$(match_acm_legacy ${root})"
+            args="${args} -F /sys/kernel/security/txt/tpm20_binary_evtlog -o"
+        else
+            acm="$(match_acm ${root})"
+        fi
         if [ -z "${acm}" ]; then
             return 1
         fi

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
@@ -391,11 +391,6 @@ check_txt_quirk() {
     is_tpm_2_0
     if [ $? -eq 0 ]; then
         args="-2 -a sha256 -c"
-
-        # OpenXT 8 and previous eventlog entry.
-        if [ -f "/sys/kernel/security/txt/tpm20_binary_evtlog" ]; then
-            args="${args} -F /sys/kernel/security/txt/tpm20_binary_evtlog -o"
-        fi
     else
         args="-a sha1 -c"
     fi
@@ -513,7 +508,6 @@ calculate_drtm_pcrs() {
         # OpenXT 8 to OpenXT 9 forward sealing.
         if [ -f "/sys/kernel/security/txt/tpm20_binary_evtlog" ]; then
             acm="$(match_acm_legacy ${root})"
-            args="${args} -F /sys/kernel/security/txt/tpm20_binary_evtlog -o"
         else
             acm="$(match_acm ${root})"
         fi

--- a/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
+++ b/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
@@ -3267,7 +3267,7 @@ index 0000000..7cd7e28
 +#endif
 --- /dev/null
 +++ b/pcr-calc/acm.c
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,214 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <errno.h>
@@ -3282,13 +3282,15 @@ index 0000000..7cd7e28
 +#include "acm.h"
 +
 +#ifdef DEBUG
-+# define printd(fmt, ...)					\
-+	if (DEBUG) {						\
++# define DEBUG_PRINTD 1
++#else /* !DEBUG */
++# define DEBUG_PRINTD 0
++#endif /* DEBUG */
++
++#define printd(fmt, ...)					\
++	do { if (DEBUG_PRINTD)					\
 +		fprintf(stdout, fmt "\n", ##__VA_ARGS__);	\
-+	}
-+#else
-+# define printd(fmt, ...)
-+#endif
++	} while (0)
 +
 +static acm_hdr_t *get_acm_header(void *p)
 +{

--- a/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
+++ b/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
@@ -3626,12 +3626,13 @@ index 0000000..7cd7e28
 +#endif /* _ACM_H_ */
 --- /dev/null
 +++ b/pcr-calc/acmmatch.c
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,323 @@
 +#include <errno.h>
 +#include <assert.h>
 +#include <string.h>
 +#include <getopt.h>
 +#include <stdio.h>
++#include <stdlib.h>
 +
 +#include "platform.h"
 +#include "uuid.h"
@@ -3639,6 +3640,46 @@ index 0000000..7cd7e28
 +#include "txt.h"
 +
 +#define printe(fmt, ...)         fprintf(stderr, fmt "\n", ##__VA_ARGS__)
++
++int parse_u32(const char *s, uint32_t *v)
++{
++	size_t len;
++	char *end;
++	unsigned long a;
++
++	len = strnlen(s, 11);   /* 0xVVVVVVVV\0 */
++	if (len >= 11)
++		return -EINVAL;
++
++	a = strtoul(s, &end, 0);
++	if (end != (s + len)) {
++		*v = 0;
++		return -EINVAL;
++	}
++
++	*v = a;
++	return 0;
++}
++
++int parse_u64(const char *s, uint64_t *v)
++{
++	size_t len;
++	char *end;
++	unsigned long long a;
++
++	len = strnlen(s, 19);   /* 0xVVVVVVVVVVVVVVVV\0 */
++	if (len >= 19)
++		return -EINVAL;
++
++	a = strtoull(s, &end, 0);
++	if (end != (s + len)) {
++		*v = 0;
++		return -EINVAL;
++	}
++
++	*v = a;
++	return 0;
++}
 +
 +static int acm_is_debug(const struct acm *acm,
 +		const txt_cr_ver_fsbif_t *fsbif,
@@ -3765,11 +3806,26 @@ index 0000000..7cd7e28
 +	printf("Parse the given ACMs and display which match the current"
 +		" platform on stdout.\n");
 +	printf("    -h  Display this help.\n");
++	printf("    -d didvid   Provide the didvid value to be used (instead of reading TXT public configuration registers).\n");
++	printf("    -f fsbif    Provide the fsbif value to be used (instead of reading TXT public configuration registers).\n");
++	printf("    -q qpiif    Provide the qpiif value to be used (instead of reading TXT public configuration registers).\n");
++	printf("    -p msr-pid  Provide the MSR platform ID value to be used (instead of reading MSR devnodes).\n");
++	printf("    -s cpuid    Provide the cpuid signature value to be used (instead of running CPUID).\n");
 +}
++
++enum {
++	FLAG_DIDVID	= 1 << 0,
++	FLAG_FSBIF	= 1 << 1,
++	FLAG_QPIIF	= 1 << 2,
++	FLAG_CPUID_SIG	= 1 << 3,
++	FLAG_MSR_PID	= 1 << 4,
++};
 +
 +int main(int argc, char *argv[])
 +{
 +	int rc, opt, i, match = 0;
++	uint32_t flags = 0;
++	const uint32_t fmask = FLAG_DIDVID | FLAG_FSBIF | FLAG_QPIIF;
 +	txt_cr_didvid_t didvid = { 0 };
 +	txt_cr_ver_fsbif_t fsbif = { 0 };
 +	txt_cr_ver_qpiif_t qpiif = { 0 };
@@ -3777,13 +3833,54 @@ index 0000000..7cd7e28
 +	msr_ia32_platform_id_t msr;
 +
 +	do {
-+		opt = getopt(argc, argv, "Dh");
++		opt = getopt(argc, argv, "hd:q:f:p:s:");
 +		switch (opt) {
 +			case 'h':
 +				usage(argv[0]);
 +				return 0;
 +			case -1:
 +				continue;
++			case 'd':
++				rc = parse_u64(optarg, &didvid.raw);
++				if (rc < 0) {
++					printe("Invalid DIDVID value provided to -d.");
++					return rc;
++				}
++				flags |= FLAG_DIDVID;
++			break;
++			case 'q':
++				rc = parse_u32(optarg, &qpiif.raw);
++				if (rc < 0) {
++					printe("Invalid QPIIF value provided to -q.");
++					return rc;
++				}
++				flags |= FLAG_QPIIF;
++				break;
++			case 'f':
++				rc = parse_u32(optarg, &fsbif.raw);
++				if (rc < 0) {
++					printe("Invalid FSBIF value provided to -f.");
++					return rc;
++				}
++				flags |= FLAG_FSBIF;
++				break;
++			case 'p':
++				rc = parse_u64(optarg, &msr.raw);
++				if (rc < 0) {
++					printe("Invalid MSR platform ID value provided to -p.");
++					return rc;
++				}
++				flags |= FLAG_MSR_PID;
++				break;
++			case 's':
++				rc = parse_u32(optarg, &sig.raw);
++				if (rc < 0) {
++					printe("Invalid CPUID signature value provided to -s.");
++					return rc;
++				}
++				flags |= FLAG_CPUID_SIG;
++			break;
++
 +			default:
 +				usage(argv[0]);
 +				return EINVAL;
@@ -3796,26 +3893,37 @@ index 0000000..7cd7e28
 +		return EINVAL;
 +	}
 +
-+	if (!access_txt_crs()) {
-+		printe("Cannot access TXT control registers."
-+			" Is module txt loaded?");
-+		return ENOENT;
++	if (!flags || ((flags & fmask) != fmask)) {
++		if (!access_txt_crs()) {
++			printe("Cannot access TXT control registers."
++				" Is module txt loaded?");
++			return ENOENT;
++		}
++
++		if (!(flags & FLAG_DIDVID)) {
++			if (read_txt_cr_didvid(&didvid) < 0)
++				return ENOSYS;
++		}
++		if (!(flags & FLAG_FSBIF)) {
++			if (read_txt_cr_ver_fsbif(&fsbif) < 0)
++				return ENOSYS;
++		}
++		if (!(flags & FLAG_QPIIF)) {
++			if (read_txt_cr_ver_qpiif(&qpiif) < 0)
++				return ENOSYS;
++		}
 +	}
 +
-+	if (!access_msr_devnode()) {
-+		printe("Cannot access MSRs. Is module msr loaded?");
-+		return ENOENT;
++	if (!(flags & FLAG_CPUID_SIG))
++		sig.raw = cpuid_eax(0x1);
++
++	if (!(flags & FLAG_MSR_PID)) {
++		if (!access_msr_devnode()) {
++			printe("Cannot access MSRs. Is module msr loaded?");
++			return ENOENT;
++		}
++		msr.raw = rdmsr(MSR_IA32_PLATFORM_ID);
 +	}
-+
-+	if (read_txt_cr_didvid(&didvid) < 0)
-+		return ENOSYS;
-+	if (read_txt_cr_ver_fsbif(&fsbif) < 0)
-+		return ENOSYS;
-+	if (read_txt_cr_ver_qpiif(&qpiif) < 0)
-+		return ENOSYS;
-+
-+	sig.raw = cpuid_eax(0x1);
-+	msr.raw = rdmsr(MSR_IA32_PLATFORM_ID);
 +
 +	for (i = optind; i < argc; ++i) {
 +		rc = platform_match_acm(argv[i],
@@ -3831,8 +3939,7 @@ index 0000000..7cd7e28
 +						" msr, txt_info.");
 +					return rc;
 +				default:
-+					printe("Error while loading ACM: %s.",
-+						strerror(-rc));
++					printe("Error while loading ACM: %s.", strerror(-rc));
 +					return rc;
 +			}
 +		} else if (!rc) {

--- a/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
+++ b/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
@@ -1623,7 +1623,7 @@ new file mode 100644
 index 0000000..5e638a0
 --- /dev/null
 +++ b/pcr-calc/pcr-calc.c
-@@ -0,0 +1,441 @@
+@@ -0,0 +1,442 @@
 +/*
 + *
 + * Copyright (c) 2017 Daniel P. Smith
@@ -1688,7 +1688,7 @@ index 0000000..5e638a0
 +#define FLAG_EVTLOG_OLD 1<<6
 +
 +#define TPM12_LOG "/sys/kernel/security/txt/tpm12_binary_evtlog"
-+#define TPM20_LOG_OLD "/sys/kernel/security/txt/tpm20_binary_evtlog"
++#define TPM20_LOG_OLD "/sys/kernel/security/txt/tpm20_binary_evtlog_legacy"
 +#define TPM20_LOG "/sys/kernel/security/txt/tpm20_binary_evtlog_tcg"
 +
 +#define error_msg(fmt, ...)         fprintf(stderr, fmt, ##__VA_ARGS__)
@@ -1979,9 +1979,10 @@ index 0000000..5e638a0
 +		if (eventlog == NULL) {
 +			if (!access(TPM20_LOG, R_OK))
 +				eventlog = TPM20_LOG;
-+			else if (!access(TPM20_LOG_OLD, R_OK))
++			else if (!access(TPM20_LOG_OLD, R_OK)) {
 +				eventlog = TPM20_LOG_OLD;
-+			else {
++				flags |= FLAG_EVTLOG_OLD;
++			} else {
 +				error_msg("failed to find TPM 2.0 event log.\n");
 +				goto out;
 +			}

--- a/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
+++ b/recipes-security/tboot/tboot-1.9.9/0006-pcr-calc-Add-pcr-calculator-tool.patch
@@ -1623,7 +1623,7 @@ new file mode 100644
 index 0000000..5e638a0
 --- /dev/null
 +++ b/pcr-calc/pcr-calc.c
-@@ -0,0 +1,442 @@
+@@ -0,0 +1,446 @@
 +/*
 + *
 + * Copyright (c) 2017 Daniel P. Smith
@@ -1688,7 +1688,8 @@ index 0000000..5e638a0
 +#define FLAG_EVTLOG_OLD 1<<6
 +
 +#define TPM12_LOG "/sys/kernel/security/txt/tpm12_binary_evtlog"
-+#define TPM20_LOG_OLD "/sys/kernel/security/txt/tpm20_binary_evtlog_legacy"
++#define TPM20_LOG_OLD "/sys/kernel/security/txt/tpm20_binary_evtlog"
++#define TPM20_LOG_LEGACY "/sys/kernel/security/txt/tpm20_binary_evtlog_legacy"
 +#define TPM20_LOG "/sys/kernel/security/txt/tpm20_binary_evtlog_tcg"
 +
 +#define error_msg(fmt, ...)         fprintf(stderr, fmt, ##__VA_ARGS__)
@@ -1979,7 +1980,10 @@ index 0000000..5e638a0
 +		if (eventlog == NULL) {
 +			if (!access(TPM20_LOG, R_OK))
 +				eventlog = TPM20_LOG;
-+			else if (!access(TPM20_LOG_OLD, R_OK)) {
++			else if (!access(TPM20_LOG_LEGACY, R_OK)) {
++				eventlog = TPM20_LOG_LEGACY;
++				flags |= FLAG_EVTLOG_OLD;
++			} else if (!access(TPM20_LOG_OLD, R_OK)) {
 +				eventlog = TPM20_LOG_OLD;
 +				flags |= FLAG_EVTLOG_OLD;
 +			} else {


### PR DESCRIPTION
OXT-1506 and OXT-1507 introduced non-retro compatible changes that have to be mitigated when performing OTA upgrade.
The running kernel:
1. Does not have the new entries in the sysfs to access the eventlog.
2. Does not have access to he TXT configuration registers through sysfs.

The first point is mitigated by using the previous sysfs entry, this is also useful to determine which capabilities we can expect to do the forward sealing.
The second can be worked around using `txt-stat` that will report the required values to find the ACM that will be loaded upon reboot into the upgraded system. `acmmatch` is modified in consequence to accept value overrides.