### PR TITLE
STABLE-9: logrotate: Amend recipe typos.

### DIFF
--- a/recipes-extended/logrotate/logrotate_%.bbappend
+++ b/recipes-extended/logrotate/logrotate_%.bbappend
@@ -11,7 +11,7 @@ CONFFILES_${PN} = " \
     "
 # ... also install our configuration and wrapper (for rsyslog).
 do_install_append() {
-    rm -f $-lD}${localstatedir}/lib/logrorate.status
+    rm -f ${D}${localstatedir}/lib/logrotate.status
     install -p -m 644 ${WORKDIR}/logrotate.conf ${D}${sysconfdir}/logrotate.conf
     install -p -m 755 ${WORKDIR}/logrotate-wrapper ${D}${sbindir}/logrotate-wrapper
 }


### PR DESCRIPTION
Don't ship the logrotate.status as intended.

(cherry picked from commit f495a5db1addc85ad9bb77eea02b9ff227a50fee)