### PR TITLE
STABLE-9: shim: switch to upstream + patchqueue

### DIFF
--- a/recipes-bsp/shim/files/0001-Add-KEEP_DISCARDABLE_RELOC-build-option.patch
+++ b/recipes-bsp/shim/files/0001-Add-KEEP_DISCARDABLE_RELOC-build-option.patch
@@ -1,0 +1,65 @@
+From 34290cb8e19e57d3323f29733c5b1d760ff9f983 Mon Sep 17 00:00:00 2001
+From: Tamas K Lengyel <lengyelt@ainfosec.com>
+Date: Tue, 19 Sep 2017 22:52:32 -0400
+Subject: [PATCH 1/6] Add KEEP_DISCARDABLE_RELOC build option
+
+Some efi applications expect the .reloc section to be present even after going
+through the shim (ie. Xen). This option allows building the shim such that it
+keeps it even if it was marked discardable.
+
+Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
+---
+ BUILDING | 4 ++++
+ Makefile | 4 ++++
+ shim.c   | 6 +++++-
+ 3 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/BUILDING b/BUILDING
+index 461b85c..954fd3f 100644
+--- a/BUILDING
++++ b/BUILDING
+@@ -57,5 +57,9 @@ Variables you could set to customize the build:
+ - OSLABEL
+   This is the label that will be put in BOOT$(EFI_ARCH).CSV for your OS.
+   By default this is the same value as EFIDIR .
++- KEEP_DISCARDABLE_RELOC
++  This allows you to decide whether a .reloc section that was marked
++  discardable gets discarded or not. Some efi applications expect it to be
++  present after the shim (ie. Xen). By default it gets discarded.
+ 
+ # vim:filetype=mail:tw=74
+diff --git a/Makefile b/Makefile
+index 9ab1992..48f4e7c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -73,6 +73,10 @@ ifneq ($(origin REQUIRE_TPM), undefined)
+ 	CFLAGS	+= -DREQUIRE_TPM
+ endif
+ 
++ifneq ($(origin KEEP_DISCARDABLE_RELOC), undefined)
++    CFLAGS  += -DKEEP_DISCARDABLE_RELOC
++endif
++
+ ifeq ($(ARCH),x86_64)
+ 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc \
+ 		   -maccumulate-outgoing-args -m64 \
+diff --git a/shim.c b/shim.c
+index 34b819a..94151d5 100644
+--- a/shim.c
++++ b/shim.c
+@@ -1431,7 +1431,11 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+ 			}
+ 		}
+ 
+-		if (Section->Characteristics & EFI_IMAGE_SCN_MEM_DISCARDABLE) {
++		if ( (Section->Characteristics & EFI_IMAGE_SCN_MEM_DISCARDABLE)
++#if defined(KEEP_DISCARDABLE_RELOC)
++            && RelocSection != Section
++#endif
++        ) {
+ 			continue;
+ 		}
+ 
+-- 
+2.1.4
+

--- a/recipes-bsp/shim/files/0002-Make-EFI_INCLUDE-path-configurable-during-make.patch
+++ b/recipes-bsp/shim/files/0002-Make-EFI_INCLUDE-path-configurable-during-make.patch
@@ -1,0 +1,32 @@
+From 899298bab2d469514091a41b2597f898cf7aad2b Mon Sep 17 00:00:00 2001
+From: Tamas K Lengyel <tamas@tklengyel.com>
+Date: Mon, 30 Oct 2017 15:18:12 -0600
+Subject: [PATCH 2/6] Make EFI_INCLUDE path configurable during make
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 48f4e7c..15c2794 100644
+--- a/Makefile
++++ b/Makefile
+@@ -40,7 +40,6 @@ OBJCOPY_GTE224	= $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed '
+ 
+ SUBDIRS		= $(TOPDIR)/Cryptlib $(TOPDIR)/lib
+ 
+-EFI_INCLUDE	:= /usr/include/efi
+ EFI_INCLUDES	= -nostdinc -I$(TOPDIR)/Cryptlib -I$(TOPDIR)/Cryptlib/Include \
+ 		  -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol \
+ 		  -I$(TOPDIR)/include -iquote $(TOPDIR) -iquote $(shell pwd)
+@@ -117,6 +116,7 @@ endif
+ 
+ FORMAT		?= --target efi-app-$(ARCH)
+ EFI_PATH	?= $(LIBDIR)/gnuefi
++EFI_INCLUDE	?= /usr/include/efi
+ 
+ MMSTEM		?= mm$(ARCH_SUFFIX)
+ MMNAME		= $(MMSTEM).efi
+-- 
+2.1.4
+

--- a/recipes-bsp/shim/files/0003-Add-Measure-function-to-the-shim-lock-protocol.patch
+++ b/recipes-bsp/shim/files/0003-Add-Measure-function-to-the-shim-lock-protocol.patch
@@ -1,0 +1,78 @@
+From 2ea4a8559ede6c1cb9da94694a91eb142ffd7448 Mon Sep 17 00:00:00 2001
+From: Tamas K Lengyel <tamas@tklengyel.com>
+Date: Fri, 1 Dec 2017 11:10:27 -0500
+Subject: [PATCH 3/6] Add Measure function to the shim lock protocol
+
+---
+ shim.c | 20 ++++++++++++++++++++
+ shim.h |  9 +++++++++
+ 2 files changed, 29 insertions(+)
+
+diff --git a/shim.c b/shim.c
+index 94151d5..ea186ed 100644
+--- a/shim.c
++++ b/shim.c
+@@ -1843,6 +1843,25 @@ done:
+ 	return status;
+ }
+ 
++EFI_STATUS shim_measure (void *buffer, UINT32 size, UINT8 pcr)
++{
++    EFI_STATUS status;
++    PE_COFF_LOADER_IMAGE_CONTEXT context;
++
++    in_protocol = 1;
++
++    status = read_header(buffer, size, &context);
++    if (status == EFI_SUCCESS) {
++        status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, NULL, pcr);
++    } else {
++        status = tpm_log_event((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, (UINTN)size, pcr, (CHAR8 *)"shim_measure");
++    }
++
++    in_protocol = 0;
++
++    return status;
++}
++
+ static EFI_STATUS shim_hash (char *data, int datasize,
+ 			     PE_COFF_LOADER_IMAGE_CONTEXT *context,
+ 			     UINT8 *sha256hash, UINT8 *sha1hash)
+@@ -2943,6 +2962,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
+ 	shim_lock_interface.Verify = shim_verify;
+ 	shim_lock_interface.Hash = shim_hash;
+ 	shim_lock_interface.Context = shim_read_header;
++    shim_lock_interface.Measure = shim_measure;
+ 
+ 	systab = passed_systab;
+ 	image_handle = global_image_handle = passed_image_handle;
+diff --git a/shim.h b/shim.h
+index 9126253..e314853 100644
+--- a/shim.h
++++ b/shim.h
+@@ -19,6 +19,14 @@ EFI_STATUS
+ 
+ typedef
+ EFI_STATUS
++(*EFI_SHIM_LOCK_MEASURE) (
++	IN VOID *buffer,
++	IN UINT32 size,
++    IN UINT8 pcr
++	);
++
++typedef
++EFI_STATUS
+ (*EFI_SHIM_LOCK_HASH) (
+ 	IN char *data,
+ 	IN int datasize,
+@@ -39,6 +47,7 @@ typedef struct _SHIM_LOCK {
+ 	EFI_SHIM_LOCK_VERIFY Verify;
+ 	EFI_SHIM_LOCK_HASH Hash;
+ 	EFI_SHIM_LOCK_CONTEXT Context;
++	EFI_SHIM_LOCK_MEASURE Measure;
+ } SHIM_LOCK;
+ 
+ extern EFI_STATUS shim_init(void);
+-- 
+2.1.4
+

--- a/recipes-bsp/shim/files/0004-Don-t-overwrite-LoadOptions-if-NULL.patch
+++ b/recipes-bsp/shim/files/0004-Don-t-overwrite-LoadOptions-if-NULL.patch
@@ -1,0 +1,29 @@
+From 6fd9327ccde185c547635279ec2d1211a35e4368 Mon Sep 17 00:00:00 2001
+From: Tamas K Lengyel <tamas@tklengyel.com>
+Date: Sun, 31 Dec 2017 11:03:26 -0700
+Subject: [PATCH 4/6] Don't overwrite LoadOptions if NULL
+
+---
+ shim.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/shim.c b/shim.c
+index ea186ed..7723119 100644
+--- a/shim.c
++++ b/shim.c
+@@ -1501,8 +1501,10 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+ 	li->ImageSize = context.ImageSize;
+ 
+ 	/* Pass the load options to the second stage loader */
+-	li->LoadOptions = load_options;
+-	li->LoadOptionsSize = load_options_size;
++	if ( load_options ) {
++		li->LoadOptions = load_options;
++		li->LoadOptionsSize = load_options_size;
++	}
+ 
+ 	if (!found_entry_point) {
+ 		perror(L"Entry point is not within sections\n");
+-- 
+2.1.4
+

--- a/recipes-bsp/shim/files/0005-Allow-32-bit-images-for-measurement-verification-via.patch
+++ b/recipes-bsp/shim/files/0005-Allow-32-bit-images-for-measurement-verification-via.patch
@@ -1,0 +1,68 @@
+From f7efb591fd7d91fd3803157358f4b316f9b87714 Mon Sep 17 00:00:00 2001
+From: Tamas K Lengyel <tamas@tklengyel.com>
+Date: Fri, 2 Mar 2018 21:17:09 -0700
+Subject: [PATCH 5/6] Allow 32-bit images for measurement/verification via
+ protocol
+
+---
+ Makefile |  5 +++++
+ shim.c   | 20 +++++++++++---------
+ 2 files changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 15c2794..2a19598 100644
+--- a/Makefile
++++ b/Makefile
+@@ -34,6 +34,7 @@ DEBUGSOURCE	?= $(prefix)/src/debug/
+ OSLABEL		?= $(EFIDIR)
+ DEFAULT_LOADER	?= \\\\grub$(ARCH_SUFFIX).efi
+ REQUIRE_TPM	?=
++ALLOW_32BIT_KERNEL_ON_X64 ?=
+ 
+ ARCH		?= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
+ OBJCOPY_GTE224	= $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.*\((.*)\|version\) //g' | cut -f1-2 -d.` \>= 2.24)
+@@ -72,6 +73,10 @@ ifneq ($(origin REQUIRE_TPM), undefined)
+ 	CFLAGS	+= -DREQUIRE_TPM
+ endif
+ 
++ifneq ($(origin ALLOW_32BIT_KERNEL_ON_X64), undefined)
++	CFLAGS	+= -DALLOW_32BIT_KERNEL_ON_X64
++endif
++
+ ifneq ($(origin KEEP_DISCARDABLE_RELOC), undefined)
+     CFLAGS  += -DKEEP_DISCARDABLE_RELOC
+ endif
+diff --git a/shim.c b/shim.c
+index 7723119..0681c8c 100644
+--- a/shim.c
++++ b/shim.c
+@@ -191,15 +191,17 @@ static const UINT16 machine_type =
+ static int
+ image_is_loadable(EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr)
+ {
+-	/* If the machine type doesn't match the binary, bail, unless
+-	 * we're in an allowed 64-on-32 scenario */
+-	if (PEHdr->Pe32.FileHeader.Machine != machine_type) {
+-		if (!(machine_type == IMAGE_FILE_MACHINE_I386 &&
+-		      PEHdr->Pe32.FileHeader.Machine == IMAGE_FILE_MACHINE_X64 &&
+-		      allow_64_bit())) {
+-			return 0;
+-		}
+-	}
++    if ( !in_protocol ) {
++	    /* If the machine type doesn't match the binary, bail, unless
++	     * we're in an allowed 64-on-32 scenario */
++	    if (PEHdr->Pe32.FileHeader.Machine != machine_type) {
++		    if (!(machine_type == IMAGE_FILE_MACHINE_I386 &&
++		        PEHdr->Pe32.FileHeader.Machine == IMAGE_FILE_MACHINE_X64 &&
++		        allow_64_bit())) {
++			    return 0;
++		    }
++	    }
++    }
+ 
+ 	/* If it's not a header type we recognize at all, bail */
+ 	switch (PEHdr->Pe32Plus.OptionalHeader.Magic) {
+-- 
+2.1.4
+

--- a/recipes-bsp/shim/files/0006-Don-t-measure-with-Authenticode.patch
+++ b/recipes-bsp/shim/files/0006-Don-t-measure-with-Authenticode.patch
@@ -1,0 +1,38 @@
+From 3ad44002b7387cbc4ffe0549f37b09d3b77b4333 Mon Sep 17 00:00:00 2001
+From: Tamas K Lengyel <tamas@tklengyel.com>
+Date: Fri, 2 Mar 2018 23:31:27 -0700
+Subject: [PATCH 6/6] Don't measure with Authenticode
+
+On TPM2 devices calculating the Authenticode hash needs to be performed
+by the firmware. However, requesting measurements with PE_COFF_IMAGE flag
+fails on certain firmwares (Dell). For consistency we fall back to measuring
+the images as a whole without parsing the headers.
+---
+ shim.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/shim.c b/shim.c
+index 0681c8c..386601d 100644
+--- a/shim.c
++++ b/shim.c
+@@ -1310,7 +1310,7 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+ 		return efi_status;
+ 
+ 	/* Measure the binary into the TPM */
+-	efi_status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, sha1hash, 4);
++	efi_status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, NULL, 4);
+ #ifdef REQUIRE_TPM
+ 	if (efi_status != EFI_SUCCESS) {
+ 		return efi_status;
+@@ -1831,7 +1831,7 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
+ 		goto done;
+ 
+ 	/* Measure the binary into the TPM */
+-	status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, sha1hash, 4);
++	status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, NULL, 4);
+ #ifdef REQUIRE_TPM
+ 	if (status != EFI_SUCCESS)
+ 		goto done;
+-- 
+2.1.4
+

--- a/recipes-bsp/shim/shim_git.bb
+++ b/recipes-bsp/shim/shim_git.bb
@@ -20,10 +20,16 @@ DEPENDS += "\
 PV = "14+git${SRCPV}"
 
 SRC_URI = " \
-    git://github.com/tklengyel/shim;branch=openxt \
+    git://github.com/rhboot/shim;protocol=https;branch=master \
+    file://0001-Add-KEEP_DISCARDABLE_RELOC-build-option.patch \
+    file://0002-Make-EFI_INCLUDE-path-configurable-during-make.patch \
+    file://0003-Add-Measure-function-to-the-shim-lock-protocol.patch \
+    file://0004-Don-t-overwrite-LoadOptions-if-NULL.patch \
+    file://0005-Allow-32-bit-images-for-measurement-verification-via.patch \
+    file://0006-Don-t-measure-with-Authenticode.patch \
 "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "6c8d08c0af4768c715b79c8ec25141d56e34f8b4"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This is a first step, which switches to the upstream head that was used for the fork.
There shouldn't be any code difference.
Next step is to upgrade to v15.

OXT-1413

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit ab9c700d3a9c04c016a407f021de47eaef75dd1e)
Signed-off-by: Jed <lejosnej@ainfosec.com>