### PR TITLE
linux: Don't set tty0 as preferred console for pv.

### DIFF
--- a/recipes-kernel/linux/4.19/linux-openxt_4.19.32.bb
+++ b/recipes-kernel/linux/4.19/linux-openxt_4.19.32.bb
@@ -37,6 +37,7 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://netback-vwif-support.patch \
     file://gem-foreign.patch \
     file://xen-txt-add-xen-txt-eventlog-module.patch \
+    file://xenpv-no-tty0-as-default-console.patch \
     file://xsa-155-qsb-023-add-RING_COPY_RESPONSE.patch \
     file://xsa-155-qsb-023-xen-blkfront-make-local-copy-of-response-before-usin.patch \
     file://xsa-155-qsb-023-xen-blkfront-prepare-request-locally-only-then-put-i.patch \

--- a/recipes-kernel/linux/4.19/patches/xenpv-no-tty0-as-default-console.patch
+++ b/recipes-kernel/linux/4.19/patches/xenpv-no-tty0-as-default-console.patch
@@ -1,0 +1,54 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Do not add tty0 to the preferred consoles.
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Preferred consoles behavior used to not affect dom0 until:
+47b02f4c621c x86/xen: add tty0 and hvc0 as preferred consoles for dom0
+71dc05635983 x86/Xen: further refine add_preferred_console() invocations
+
+Since these changes, PV guests will always output on tty0 and hvc0 regardless
+of console= parameter. This makes some noise at boot.
+
+None of the PV kernels used in OpenXT rely on that, yet silencing the loglevel
+is not desired as the serial output is often used to debug boot issues. This
+change temporarily does _not_ add tty0 as a default preferred console.
+
+console_set_on_cmdline is not usable at this stage unfortunately since the
+cmdline has not been parsed yet.
+
+################################################################################
+REMOVAL
+################################################################################
+Once a better alternative is available, this patch should be removed.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+None.
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+None.
+
+################################################################################
+PATCHES
+################################################################################
+--- a/arch/x86/xen/enlighten_pv.c
++++ b/arch/x86/xen/enlighten_pv.c
+@@ -1397,11 +1397,7 @@ asmlinkage __visible void __init xen_sta
+ 		xen_boot_params_init_edd();
+ 	}
+ 
+-	if (!boot_params.screen_info.orig_video_isVGA)
+-		add_preferred_console("tty", 0, NULL);
+ 	add_preferred_console("hvc", 0, NULL);
+-	if (boot_params.screen_info.orig_video_isVGA)
+-		add_preferred_console("tty", 0, NULL);
+ 
+ #ifdef CONFIG_PCI
+ 	/* PCI BIOS service won't work from a PV guest. */


### PR DESCRIPTION
None of the PV kernels used in OpenXT rely on that, yet silencing the loglevel is not desired as the serial output is often used to debug boot issues. This change does _not_ add tty0 as a default preferred console.