### PR TITLE
mod-sign: Add dep on later kernel task.

### DIFF
--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -26,7 +26,7 @@ do_sign_modules() {
         SIG_HASH=$( grep CONFIG_MODULE_SIG_HASH= \
                         ${STAGING_KERNEL_BUILDDIR}/.config | \
                       cut -d '"' -f 2 )
-        [ -z "$SIG_HASH" ] && bbfatal CONFIG_MODULE_SIG_HASH is not set in .config
+        [ -z "$SIG_HASH" ] && bbfatal "CONFIG_MODULE_SIG_HASH is not set in .config"
 
         [ -x "${SIGN_FILE}" ] || bbfatal "Cannot find scripts/sign-file"
 
@@ -44,3 +44,6 @@ addtask sign_modules after do_install before do_package
 do_install[lockfiles] = "${TMPDIR}/kernel-scripts.lock"
 # Explicit keys sign modules in do_sign_modules
 do_sign_modules[lockfiles] = "${TMPDIR}/kernel-scripts.lock"
+# If the kernel signed the modules with a new key, out-of-tree ones need to be
+# signed again.
+do_sign_modules[depends] += "virtual/kernel:do_install"


### PR DESCRIPTION
This is mostly noticeable if `KERNEL_MODULE_SIG_KEY` is not provided. Refreshing a patch, or changing kernel revision, will not always have the out-of-tree modules be signed with the new key.

Add a dependency on the kernel `do_install` task to have the new key files present in the shared workdir when running sign_modules and re-run do_sign_modules if `virtual/kernel:do_install` was done since last signing.