### PR TITLE
STABLE-9: module-signing: Re-work sign-file selection

### DIFF
--- a/classes/kernel-module-signing.bbclass
+++ b/classes/kernel-module-signing.bbclass
@@ -1,3 +1,7 @@
+require classes/module-signing.bbclass
+# override value from module-signing to use the in-tree utility
+SIGN_FILE = "${B}/scripts/sign-file"
+
 # Set KERNEL_MODULE_SIG_CERT in local.conf to the filepath of a public key
 # to embed in the kernel to verify signed modules
 export KERNEL_MODULE_SIG_CERT

--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -17,6 +17,9 @@ export KERNEL_MODULE_SIG_KEY
 # build-time keypair will be generated and used for signing and embedding.
 export KERNEL_MODULE_SIG_CERT
 
+# Kernel builds will override this with ${B}/scripts/sign-file
+SIGN_FILE = "${STAGING_KERNEL_BUILDDIR}/scripts/sign-file"
+
 do_sign_modules() {
     if [ -n "${KERNEL_MODULE_SIG_KEY}" ] &&
        grep -q '^CONFIG_MODULE_SIG=y' ${STAGING_KERNEL_BUILDDIR}/.config; then
@@ -25,16 +28,11 @@ do_sign_modules() {
                       cut -d '"' -f 2 )
         [ -z "$SIG_HASH" ] && bbfatal CONFIG_MODULE_SIG_HASH is not set in .config
 
-        # ${B} for kernel, ${STAGING_KERNEL_BUILDDIR} for modules
-        for SIGN_FILE in ${STAGING_KERNEL_BUILDDIR}/scripts/sign-file \
-                         ${B}/scripts/sign-file ; do
-            [ -x "$SIGN_FILE" ] && break
-        done
-        [ -x "$SIGN_FILE" ] || bbfatal "Cannot find scripts/sign-file"
+        [ -x "${SIGN_FILE}" ] || bbfatal "Cannot find scripts/sign-file"
 
         find ${D} -name "*.ko" -print0 | \
           xargs --no-run-if-empty -0 -n 1 \
-              $SIGN_FILE $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
+              ${SIGN_FILE} $SIG_HASH ${KERNEL_MODULE_SIG_KEY} \
                   ${KERNEL_MODULE_SIG_CERT}
     fi
 }

--- a/recipes-kernel/linux/linux-openxt.inc
+++ b/recipes-kernel/linux/linux-openxt.inc
@@ -1,6 +1,5 @@
 require recipes-kernel/linux/linux-openxt-copy-objtool.inc
-require classes/module-signing.bbclass
-require classes/kernel-signing.bbclass
+require classes/kernel-module-signing.bbclass
 
 DEPENDS += "bc-native"
 


### PR DESCRIPTION
On a Linux uprev, module signing can fail on a dirty build when
sign-file is called with a rpath pointing into a modules sysroot.  The
module's sysroot path will be gone, so sign-file fails to run.
/home/build/openxt-master/build/tmp-glibc/work-shared/xenclient-dom0/kernel-build-artifacts/scripts/sign-file: error while loading shared libraries: libcrypto.so.1.0.2: cannot open shared object file: No such file or directory

For a kernel build, we should run ${B}/scripts/sign-file.  Instead of
searching for this at runtime, use a variable to set the the SIGN_FILE
location for modules and override for a kernel build.

While doing this, move 'require classes/module-signing.bbclass' into
kernel-signing.bbclass and rename to kernel-module-signing.bbclass.
That consolidates the functionality required for the kernel in one
place.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 50524913e0b9d8dd5607501cd4a7789780878f25)

Stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1117#event-2269424019