### PR TITLE
STABLE-8: OXT-1532: Set SRCREV to last known-good build.

### DIFF
--- a/recipes-support/pesign/pesign_git.bb
+++ b/recipes-support/pesign/pesign_git.bb
@@ -17,7 +17,7 @@ DEPENDS += " \
 
 PV = "git${SRCPV}"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "be25a1be3d1b71bd747065f2b03c5a97e7a4ba20"
 
 SRC_URI = "git://github.com/rhboot/pesign \
     file://0001-Disable-warning.patch \


### PR DESCRIPTION
Last commit will not deal well with OE:
https://github.com/rhboot/pesign/commit/377da9b127b89a30ef2258bc3bfaee6565484611#diff-4500fd79f783c1b3f56209dcdb8a637dR25

pesign will fail to build with:
> | x86_64-oe-linux-gcc: error: recipe-sysroot-ar: No such file or directory
> | x86_64-oe-linux-gcc: error: libdpe.a: No such file or directory

The last pesign release 0.112 was a while ago, so fix the revision to
the last known good until fixed.

(cherry picked from commit 88c78c8d7fa38ece25dfa25d7e761f801ce70de4)

This is required to fix stable-8 builds.