### PR TITLE
STABLE-9: seal-system: Exit if unable to read rootfs

### DIFF
--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -247,6 +247,7 @@ forward)
         pcr_params="${pcr_params} -p ${p}${pcr_forward[${p}]}"
     done
 
+    [ -r ${root_dev} ] || err "cannot read root_dev ${root_dev}"
     # During early init, rootfs is hashed and is given to
     # tpm_extend which for tpm1.2 hashes the rootfs hash again and
     # hands that value to the TPM to be extended into PCR 15


### PR DESCRIPTION
Stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1134/commits/1a80fbebedae58c0111d3b9610850e3976cf5c90

Running seal-system as sysadm_t does not have proper permission to read
/dev/mapper/xenclient-oe.  However there is no error checking for this
case, so seal-system will continue on and forward seal to an invalid
rootfs.  If we are unable to read the rootfs, abort instead of
clobbering the current sealed blobs.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 1a80fbebedae58c0111d3b9610850e3976cf5c90)