### PR TITLE
STABLE-9: OXT-1547: [key-functions] Maintain backwards compat

### DIFF
--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
@@ -137,7 +137,7 @@ seed_entropy() {
 gen_platform_key() {
     local key_file=`mktemp -t`
 
-    get-config-key > ${key_file}
+    get-config-key | tr '[:lower:]' '[:upper:]' > ${key_file}
 
     [ "$(getenforce)" == "Enforcing" ] &&
         chcon -t lvm_tmp_t ${key_file} >/dev/null
@@ -179,7 +179,7 @@ gen_device_key() {
 get_platform_key() {
     local key_file=`mktemp -t`
 
-    get-config-key > ${key_file}
+    get-config-key | tr '[:lower:]' '[:upper:]' > ${key_file}
 
     echo $key_file
 }
@@ -374,10 +374,10 @@ platform_unlock() {
     local part="${1}"
     local name="${2}"
 
-    get-config-key | cryptsetup -q -d - -S ${PSLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
+    get-config-key | tr '[:lower:]' '[:upper:]' | cryptsetup -q -d - -S ${PSLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         # fall back and see if platform key will open on any slot
-        get-config-key | cryptsetup -q -d - luksOpen "${part}" "${name}" >/dev/null 2>&1
+        get-config-key | tr '[:lower:]' '[:upper:]' | cryptsetup -q -d - luksOpen "${part}" "${name}" >/dev/null 2>&1
     fi
 
     return $?

--- a/recipes-openxt/xenclient-config-access/xenclient-config-access/config-access.initscript
+++ b/recipes-openxt/xenclient-config-access/xenclient-config-access/config-access.initscript
@@ -32,7 +32,7 @@ sig=$(dd if="/dev/mapper/${CONFIG_LV}" bs=4 count=1 2>/dev/null)
 case "$sig" in
 LUKS)
 	keycmd="get-config-key"
-	eval $keycmd | cryptsetup -q -d - luksOpen \
+	eval $keycmd | tr '[:lower:]' '[:upper:]' | cryptsetup -q -d - luksOpen \
 	    "/dev/mapper/${CONFIG_LV}" config >/dev/null 2>&1 || {
 	    {
 		clear


### PR DESCRIPTION
  In the unmeasured case, the platform uses get-config-key
  to unlock the /config partition.  In stable-8, the uuid output
  is in uppercase, and in stable-9, it's lowercase. This is a
  result of a change to dmidecode's product uuid output. This
  commit maintains support for upgrading from older versions
  of OpenXT where the UUID is uppercase.

  OXT-1547

Signed-off-by: Chris <rogersc@ainfosec.com>