### PR TITLE
OXT-1565: base-files: /var/lock -> /run/lock

### DIFF
--- a/recipes-core/base-files/files/fstab.early
+++ b/recipes-core/base-files/files/fstab.early
@@ -13,7 +13,6 @@ tmpfs       /tmp                    tmpfs       defaults,rootcontext=system_u:ob
 
 tmpfs       /var/volatile           tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=2M         0 0
 tmpfs       /var/cache              tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=100M       0 0
-tmpfs       /var/lock               tmpfs       defaults,rootcontext=system_u:object_r:var_lock_t:s0,size=1M    0 0
 
 # OpenXT: modutils.sh loads before mountall.sh, and modutils.sh will load the txt module, which needs this:
-securityfs                     /sys/kernel/security    securityfs  defaults                                                                        0 0
+securityfs  /sys/kernel/security    securityfs  defaults                                                        0 0

--- a/recipes-core/base-files/files/xenclient-dom0/fstab
+++ b/recipes-core/base-files/files/xenclient-dom0/fstab
@@ -13,7 +13,6 @@ tmpfs       /tmp                    tmpfs       defaults,rootcontext=system_u:ob
 
 tmpfs       /var/volatile           tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=2M         0 0
 tmpfs       /var/cache              tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=100M       0 0
-tmpfs       /var/lock               tmpfs       defaults,rootcontext=system_u:object_r:var_lock_t:s0,size=1M    0 0
 
 # OpenXT read-only root:
 # mountall.sh should take care of these.

--- a/recipes-core/base-files/files/xenclient-ndvm/fstab
+++ b/recipes-core/base-files/files/xenclient-ndvm/fstab
@@ -13,7 +13,6 @@ tmpfs       /tmp                    tmpfs       defaults,rootcontext=system_u:ob
 
 tmpfs       /var/volatile           tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=2M         0 0
 tmpfs       /var/cache              tmpfs       defaults,rootcontext=system_u:object_r:var_t:s0,size=100M       0 0
-tmpfs       /var/lock               tmpfs       defaults,rootcontext=system_u:object_r:var_lock_t:s0,size=1M    0 0
 
 # OpenXT read-only root:
 # mountall.sh should take care of these.

--- a/recipes-core/base-files/files/xenclient-uivm/fstab
+++ b/recipes-core/base-files/files/xenclient-uivm/fstab
@@ -20,7 +20,6 @@ tmpfs       /dev/shm                tmpfs       mode=0777,size=1M       0 0
 
 tmpfs       /var/volatile           tmpfs       defaults,size=2M        0 0
 tmpfs       /var/cache              tmpfs       defaults,size=100M      0 0
-tmpfs       /var/lock               tmpfs       defaults,size=1M        0 0
 tmpfs       /var/log                tmpfs       defaults,size=10M       0 0
 tmpfs       /var/lib/dbus           tmpfs       defaults,size=1M        0 0
 

--- a/recipes-core/base-files/files/xenclient-uivm/fstab.early
+++ b/recipes-core/base-files/files/xenclient-uivm/fstab.early
@@ -13,4 +13,3 @@ tmpfs       /tmp                    tmpfs       defaults,size=100M      0 0
 
 tmpfs       /var/volatile           tmpfs       defaults,size=2M        0 0
 tmpfs       /var/cache              tmpfs       defaults,size=100M      0 0
-tmpfs       /var/lock               tmpfs       defaults,size=1M        0 0

--- a/recipes-core/initscripts/initscripts-1.0/udev-volatiles.sh
+++ b/recipes-core/initscripts/initscripts-1.0/udev-volatiles.sh
@@ -1,0 +1,27 @@
+#
+# udev-volatiles.sh
+# Populate early tmpf that may be required by udev.
+#
+
+. /etc/default/rcS
+. /etc/init.d/functions
+
+if [ -f /etc/default/udev-volatiles ]; then
+    . /etc/default/udev-volatiles
+fi
+# Environment.
+
+begin "Populate volatiles for udev..."
+RESTORECON=${RESTORECON:-/sbin/restorecon}
+if [ ! -x "${RESTORECON}" ]; then
+    failure "SELinux \`${RESTORECON}' tool is missing."
+    exit 1
+fi
+
+mkdir -p /run/lock
+if ! ${RESTORECON} -R /run/lock ; then
+    failure "${RESTORECON} failed."
+    exit 1
+fi
+
+success "Udev volatiles ready."

--- a/recipes-core/initscripts/initscripts-1.0/xenclient-dom0/volatiles
+++ b/recipes-core/initscripts/initscripts-1.0/xenclient-dom0/volatiles
@@ -22,6 +22,7 @@
 # a link will be created at /var/test pointing to /tmp/testfile and due to this
 # link the file defined as /var/test will actually be created as /tmp/testfile.
 d root root 1777 /run/lock none
+l root root 1777 /var/lock /run/lock
 d root root 0755 /var/lock/subsys none
 f root root 0644 /var/log/lastlog none
 f root root 0664 /var/run/utmp none

--- a/recipes-core/initscripts/initscripts-1.0/xenclient-ndvm/volatiles
+++ b/recipes-core/initscripts/initscripts-1.0/xenclient-ndvm/volatiles
@@ -24,6 +24,7 @@
 # a link will be created at /var/test pointing to /tmp/testfile and due to this
 # link the file defined as /var/test will actually be created as /tmp/testfile.
 d root root 1777 /run/lock none
+l root root 1777 /var/lock /run/lock
 d root root 0755 /var/volatile/log none
 d root root 1777 /var/volatile/tmp none
 d root root 0755 /var/volatile/etc none

--- a/recipes-core/initscripts/initscripts-1.0/xenclient-uivm/volatiles
+++ b/recipes-core/initscripts/initscripts-1.0/xenclient-uivm/volatiles
@@ -22,6 +22,7 @@
 # a link will be created at /var/test pointing to /tmp/testfile and due to this
 # link the file defined as /var/test will actually be created as /tmp/testfile.
 d root root 1777 /run/lock none
+l root root 1777 /var/lock /run/lock
 d root root 0755 /var/lock/subsys none
 f root root 0644 /var/log/lastlog none
 f root root 0664 /var/run/utmp none

--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -4,6 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
 SRC_URI += " \
     file://mountearly.sh \
+    file://udev-volatiles.sh \
     file://finish.sh \
     file://volatiles \
 "
@@ -41,6 +42,7 @@ do_install () {
 	install -m 0644    ${WORKDIR}/volatiles		${D}${sysconfdir}/default/volatiles/00_core
 	install -m 0755    ${WORKDIR}/finish.sh		${D}${sysconfdir}/init.d
 	install -m 0755    ${WORKDIR}/mountearly.sh	${D}${sysconfdir}/init.d
+	install -m 0755    ${WORKDIR}/udev-volatiles.sh	${D}${sysconfdir}/init.d
 
 #
 # Install device dependent scripts
@@ -64,6 +66,7 @@ do_install () {
 	update-rc.d -r ${D} populate-volatile.sh start 37 S .
 	update-rc.d -r ${D} finish.sh start 99 S .
 	update-rc.d -r ${D} mountearly.sh start 01 S .
+	update-rc.d -r ${D} udev-volatiles.sh start 03 S .
 }
 
 pkg_postinst_${PN}_append() {


### PR DESCRIPTION
In openxt-installer and other MACHINE that do not have a specific /etc/default/volatile:
fstab.early already mounts a tmpfs on /run.
/var/lock is a symlink to /run/lock (created with populate-volatile.sh), so trying to mount a separate tmpfs on /var/lock will fail with:
> Mounting early filesystems...
> mount: mount point /var/lock is a symbolic link to nowhere

Avoid machine specific configuration.

/var/lock used to be a 1M partition, make it a symlink an simplify things.

Keeping /var/lock separated would avoid a rogue software to fill up /run in a DoS attempt, but things that have access to /var/lock probably already have access to /run (or subdirectory) in UGO perms or SELinux policy.