### PR TITLE
OXT-1571: [libxl] Retry on pci add failure for PT GPU

### DIFF
--- a/recipes-extended/xen/files/libxl-retry-qmp-pci-add.patch
+++ b/recipes-extended/xen/files/libxl-retry-qmp-pci-add.patch
@@ -1,0 +1,26 @@
+--- a/tools/libxl/libxl_qmp.c
++++ b/tools/libxl/libxl_qmp.c
+@@ -876,6 +876,7 @@ int libxl__qmp_pci_add(libxl__gc *gc, in
+     libxl__json_object *args = NULL;
+     char *hostaddr = NULL;
+     int rc = 0;
++    int i = 0;
+ 
+     qmp = libxl__qmp_initialize(gc, domid);
+     if (!qmp)
+@@ -907,8 +908,13 @@ int libxl__qmp_pci_add(libxl__gc *gc, in
+     if (pcidev->permissive)
+         qmp_parameters_add_bool(gc, &args, "permissive", true);
+ 
+-    rc = qmp_synchronous_send(qmp, "device_add", args,
+-                              NULL, NULL, qmp->timeout);
++    do {
++        rc = qmp_synchronous_send(qmp, "device_add", args,
++                                  NULL, NULL, qmp->timeout);
++        if (rc)
++            sleep(1);
++    } while (rc && (++i < 15));
++
+     if (rc == 0) {
+         rc = qmp_synchronous_send(qmp, "query-pci", NULL,
+                                   pci_add_callback, pcidev, qmp->timeout);

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -88,6 +88,7 @@ SRC_URI_append = " \
     file://xl-shutdown-wait-for-domain-death.patch \
     file://libxl-allow-save-vnuma.patch \
     file://domain-reboot.patch \
+    file://libxl-retry-qmp-pci-add.patch \
     ${BLKTAP_PATCHQUEUE} \
     file://efi-hardcode-openxt-cfg.patch \
     file://0001-EFI-add-EFI_LOAD_OPTION-support.patch \


### PR DESCRIPTION
  Recent changes in the platform have exposed a race condition
  between libxl and the stubdomain. When libxl sends the qmp command
  for "device_add" to QEMU, pcifront has not yet finished setting
  up the sysfs entries for the passthrough GPU. This causes QEMU
  to fail to find these entries, one example is

  "received an error message from QMP server: Could not open
  '/sys/bus/pci/devices/0000:01:00.0/config': No such file or directory"

  This patch introduces a retry loop with a short timeout to give
  pcifront some time to initialize the sysfs nodes before libxl
  decides to error and completely fail domain creation.

  OXT-1571

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>