### PR TITLE
STABLE-9: OXT-1538: refpolicy: Silence mount AVC

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/blktap-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/blktap-interfaces.diff
@@ -64,11 +64,9 @@ Index: refpolicy/policy/modules/system/lvm.te
  	bootloader_rw_tmp_files(lvm_t)
  ')
  
-Index: refpolicy/policy/modules/system/mount.te
-===================================================================
---- refpolicy.orig/policy/modules/system/mount.te
-+++ refpolicy/policy/modules/system/mount.te
-@@ -179,6 +179,10 @@ tunable_policy(`allow_mount_anyfile',`
+--- a/policy/modules/system/mount.te
++++ b/policy/modules/system/mount.te
+@@ -181,6 +181,10 @@ tunable_policy(`allow_mount_anyfile',`
  ')
  
  optional_policy(`

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/input-server-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/input-server-interfaces.diff
@@ -73,11 +73,9 @@ Index: refpolicy/policy/modules/system/lvm.te
  # dontaudit FDs leaked by input-server
  optional_policy(`
  	kernel_dontaudit_read_xen_state(lvm_t)
-Index: refpolicy/policy/modules/system/mount.te
-===================================================================
---- refpolicy.orig/policy/modules/system/mount.te
-+++ refpolicy/policy/modules/system/mount.te
-@@ -250,6 +250,10 @@ optional_policy(`
+--- a/policy/modules/system/mount.te
++++ b/policy/modules/system/mount.te
+@@ -252,6 +252,10 @@ optional_policy(`
  	unconfined_run_to(unconfined_mount_t, mount_exec_t)
  ')
  

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.mount.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.mount.diff
@@ -1,11 +1,12 @@
 --- a/policy/modules/system/mount.te
 +++ b/policy/modules/system/mount.te
-@@ -81,6 +81,13 @@ dev_dontaudit_getattr_memory_dev(mount_t
+@@ -81,6 +81,14 @@ dev_dontaudit_getattr_memory_dev(mount_t
  dev_getattr_sound_dev(mount_t)
  # Early devtmpfs, before udev relabel
  dev_dontaudit_rw_generic_chr_files(mount_t)
 +dev_getattr_generic_blk_files(mount_t)
 +dev_getattr_fs(mount_t)
++dontaudit mount_t device_t:blk_file read;
 +
 +xen_dontaudit_rw_unix_stream_sockets(mount_t)
 +files_read_mnt_symlinks(mount_t)
@@ -14,7 +15,7 @@
  
  domain_use_interactive_fds(mount_t)
  
-@@ -101,7 +108,9 @@ files_dontaudit_write_all_mountpoints(mo
+@@ -101,7 +109,9 @@ files_dontaudit_write_all_mountpoints(mo
  files_dontaudit_setattr_all_mountpoints(mount_t)
  
  fs_getattr_xattr_fs(mount_t)
@@ -24,7 +25,7 @@
  fs_mount_all_fs(mount_t)
  fs_unmount_all_fs(mount_t)
  fs_remount_all_fs(mount_t)
-@@ -110,10 +119,14 @@ fs_rw_tmpfs_chr_files(mount_t)
+@@ -110,10 +120,14 @@ fs_rw_tmpfs_chr_files(mount_t)
  fs_read_tmpfs_symlinks(mount_t)
  fs_dontaudit_write_tmpfs_dirs(mount_t)
  
@@ -39,7 +40,7 @@
  
  storage_raw_read_fixed_disk(mount_t)
  storage_raw_write_fixed_disk(mount_t)
-@@ -141,6 +154,11 @@ selinux_getattr_fs(mount_t)
+@@ -141,6 +155,11 @@ selinux_getattr_fs(mount_t)
  
  userdom_use_all_users_fds(mount_t)
  
@@ -51,7 +52,7 @@
  ifdef(`distro_redhat',`
  	optional_policy(`
  		auth_read_pam_console_data(mount_t)
-@@ -218,7 +236,6 @@ optional_policy(`
+@@ -218,7 +237,6 @@ optional_policy(`
  optional_policy(`
  	samba_run_smbmount(mount_t, mount_roles)
  ')
@@ -59,7 +60,7 @@
  ########################################
  #
  # Unconfined mount local policy
-@@ -227,4 +244,11 @@ optional_policy(`
+@@ -227,4 +245,11 @@ optional_policy(`
  optional_policy(`
  	files_etc_filetrans_etc_runtime(unconfined_mount_t, file)
  	unconfined_domain(unconfined_mount_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/statusreport-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/statusreport-interfaces.diff
@@ -72,11 +72,9 @@ Index: refpolicy/policy/modules/system/lvm.te
  	rpm_manage_script_tmp_files(lvm_t)
  ')
  
-Index: refpolicy/policy/modules/system/mount.te
-===================================================================
---- refpolicy.orig/policy/modules/system/mount.te
-+++ refpolicy/policy/modules/system/mount.te
-@@ -259,3 +259,8 @@ optional_policy(`
+--- a/policy/modules/system/mount.te
++++ b/policy/modules/system/mount.te
+@@ -261,3 +261,8 @@ optional_policy(`
  	kernel_dontaudit_read_xen_state(mount_t)
  	kernel_dontaudit_write_xen_state(mount_t)
  ')

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/updatemgr-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/updatemgr-interfaces.diff
@@ -56,10 +56,8 @@ Index: refpolicy/policy/modules/system/lvm.te
 +	updatemgr_dontaudit_rw_stream_sockets(lvm_t)
 +	updatemgr_dontaudit_search_storage(lvm_t)
 +')
-Index: refpolicy/policy/modules/system/mount.te
-===================================================================
---- refpolicy.orig/policy/modules/system/mount.te
-+++ refpolicy/policy/modules/system/mount.te
+--- a/policy/modules/system/mount.te
++++ b/policy/modules/system/mount.te
 @@ -36,6 +36,12 @@ files_tmp_file(mount_tmp_t)
  type unconfined_mount_t;
  application_domain(unconfined_mount_t, mount_exec_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/xc-files-interfaces.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/xc-files-interfaces.patch
@@ -276,11 +276,9 @@ Index: refpolicy/policy/modules/system/lvm.te
  ')
  
  optional_policy(`
-Index: refpolicy/policy/modules/system/mount.te
-===================================================================
---- refpolicy.orig/policy/modules/system/mount.te
-+++ refpolicy/policy/modules/system/mount.te
-@@ -270,3 +270,7 @@ optional_policy(`
+--- a/policy/modules/system/mount.te
++++ b/policy/modules/system/mount.te
+@@ -272,3 +272,7 @@ optional_policy(`
  	statusreport_write_storage_files(mount_t)
  	statusreport_getattr_storage_files(mount_t)
  ')


### PR DESCRIPTION
Stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1149

The changes for xenmgr to use losetup has triggered an AVC when calling
mount on /dev/loop0p1:

audit: type=1400 audit(1556562031.429:4): avc: denied { read } for pid=1200 comm="mount" name="loop0p1" dev="devtmpfs" ino=14478 scontext=system_u:system_r:mount_t:s0-s0:c0.c1023 tcontext=system_u:object_r:device_t:s0 tclass=blk_file permissive=0

This seems to be a race with udev labeling loop0p1 to
fixed_disk_device_t, but mount succeeds anyway.

Add a dontaudit to eliminate the noise. mount already has a few rules
to deal with device_t devtmpfs files. There isn't an existing interface to
dontaudit device_t:blk_file, so I just open-coded it.

To minimize churn, only the mount.te portions of the refpolicy-mcs patchqueue were refreshed. This means the patches have a combination of default Quilt and OpenXT Quilt formats. I can refresh the entire patches if desired.

OXT-1538

Fixes AVC from: https://github.com/OpenXT/manager/pull/140