### PR TITLE
OXT-1594: tpm2: Store pcr configuration in ${tss}.pcrs

### DIFF
--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
@@ -395,7 +395,7 @@ encrypted_unlock() {
     then
         if pcr_bank_exists "sha256"; then
             local unseal_file=${key_file}
-            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB -r 0 -r 1 -r 2 -r 3 -r 4 -r 5 -r 7 -r 8 -r 15 -r 17 -r 18 -r 19 | cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
+            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB $( < ${unseal_file}.pcrs )| cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
             ret=$?
         fi
     else

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -240,6 +240,7 @@ seal()
         clean_old_tpm_files
         if pcr_bank_exists "sha256"; then
             sealout=$(tpm2_sealdata -H 0x81000000 -I ${seal_file} -O ${tss_file}.sha256 -o ${tss_file}.pub.sha256 -g 0xB -G 0x8 -b 0x492 $(cat /config/config.pcrs) 2>&1 )
+            cp /config/config.pcrs ${tss_file}.pcrs
             sealerr=$?
         fi
     else

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -25,6 +25,7 @@
 
 clean_old_tpm_files () {
     [ -e /boot/system/tpm/config.tss ] && rm /boot/system/tpm/config.tss
+    [ -e /boot/system/tpm/config.tss.pcrs ] && rm /boot/system/tpm/config.tss.pcrs
     [ -e /boot/system/tpm/config.tss.sha256 ] && rm /boot/system/tpm/config.tss.sha256
     [ -e /boot/system/tpm/config.tss.pub.sha256 ] && rm /boot/system/tpm/config.tss.pub.sha256
 }
@@ -674,6 +675,10 @@ tpm_seal() {
         pcr_bank_exists "${hashalg}"
         [ $? -eq 0 ] || return 1
 
+        # pcr_params starts with -p or -r, but that's okay because
+        # echo only honors flags -n -e & -E
+        echo "${pcr_params}" > ${tss}.pcrs
+
         case $hashalg in
         sha1)
             sealout=$(tpm2_sealdata -H ${OXT_HANDLE_SHA1} -I ${secret} \
@@ -741,6 +746,9 @@ tpm_forward_seal() {
         seal_file=${key}
         clean_old_tpm_files
         if pcr_bank_exists "sha256"; then
+            # We only want the PCRs numbers and not the forward seal values
+            echo "${pcr_params}" | \
+                sed -e 's/:[0-9a-zA-Z]\{64\}//g' > ${tss}.pcrs
             tpm2_sealdata -H ${OXT_HANDLE_SHA256} -I ${seal_file} \
                           -O ${tss}.sha256 -o ${tss}.pub.sha256 \
                           -g ${TPM_ALG_SHA256} -G ${TPM_ALG_KEYEDHASH} \
@@ -800,13 +808,13 @@ tpm_unseal() {
         sha1)
             tpm2_unsealdata -H ${OXT_HANDLE_SHA1} -n "${tss}.sha1" \
                             -u "${tss}.pub.sha1" -g ${TPM_ALG_SHA1} \
-                            ${pcr_params} 2>/dev/null
+                            $( < ${tss}.pcrs ) 2>/dev/null
             return $?
         ;;
         sha256)
             tpm2_unsealdata -H ${OXT_HANDLE_SHA256} -n "${tss}.sha256" \
                             -u "${tss}.pub.sha256" -g ${TPM_ALG_SHA256} \
-                            ${pcr_params} 2>/dev/null
+                            $( < ${tss}.pcrs ) 2>/dev/null
             return $?
         ;;
         *)


### PR DESCRIPTION
This is just the PCR consolidation commit from: https://github.com/OpenXT/xenclient-oe/pull/1108
Including this will not change the PCR selection, but it allows changing the selection.

Instead of hardcoding the pcr configuration into scripts, store the
configuration into the ${tss}.pcrs file.  This way we remove hardcoding
in our scripts.  Also, it will enable the tpm-quirks functionality to
tweak the pcr config.

TPM 1.2 sealing structure incorporates the PCR configuration.  Not sure
why TPM 2.0 does not.  Anyway, it's not sensitive, so it's okay to
store.  If an attacker changes it, they still cannot unseal.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>