### PR TITLE
openxt_image_types: Support ext4 disk images

### DIFF
--- a/classes/openxt_image_types.bbclass
+++ b/classes/openxt_image_types.bbclass
@@ -6,10 +6,9 @@ IMAGE_CMD_raw() {
 # OpenXT ext3 tweaks.
 # - Disable fscheck.
 # - Run fs check after generation.
-IMAGE_CMD_ext3_append() {
-    ;
-    tune2fs -c -1 -i 0 ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ext3
-    e2fsck -f -y ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ext3
+oe_mkext234fs_append() {
+    tune2fs -c -1 -i 0 ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.$fstype
+    e2fsck -f -y ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.$fstype
 }
 
 # OpenXT vhd.


### PR DESCRIPTION
IMAGE_CMD_ext3 calls oe_mkext234fs and then our _append commands disable
future file system checks.  There is nothing ext3 specific here.

Change the _append from IMAGE_CMD to oe_mkext234fs so any of ext2, 3 & 4
are usable for VM images.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

NOTE: this does not change any disk formats.  I've only tested (successfully) with some custom images and not tried converting any default openxt images.