### PR TITLE
OXT-1593: [init] Load i915 driver to accommodate multiple

### DIFF
--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -388,6 +388,7 @@ load_modules()
     # A few temp. hacks to get TPM measurement back on track
     modprobe tpm
     modprobe tpm_tis
+    modprobe i915
     # End of hacks
 
     exec 0<&-


### PR DESCRIPTION
  efifb devices.  This successfully shows the ncurses measurement
  failure screens on boot.

  OXT-1593

Signed-off-by: Chris <rogersc@ainfosec.com>