### PR TITLE
S9: OXT-1581: keymgmt: Getenforce is not in the installer.

### DIFF
--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
@@ -139,8 +139,9 @@ gen_platform_key() {
 
     get-config-key | tr '[:lower:]' '[:upper:]' > ${key_file}
 
-    [ "$(getenforce)" == "Enforcing" ] &&
+    if command -v getenforce >/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
         chcon -t lvm_tmp_t ${key_file} >/dev/null
+    fi
     echo $key_file
 }
 


### PR DESCRIPTION
On fresh installation:
> stages/Install-fresh: line 1: getenforce: not found
> + [  == Enforcing ]

Install-fresh will source the key-functions to setup encryption.

(cherry picked from commit a3b063ba917f6262cf756604487cc1a42a365cb4)