### PR TITLE
[Stable-9] Uprev the Linux 4.19 kernel from 4.19.32 to 4.19.44

### DIFF
--- a/recipes-kernel/linux/4.19/defconfigs/xenclient-dom0/defconfig
+++ b/recipes-kernel/linux/4.19/defconfigs/xenclient-dom0/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.32 Kernel Configuration
+# Linux/x86 4.19.44 Kernel Configuration
 #
 
 #
@@ -1417,6 +1417,7 @@ CONFIG_NET_CORE=y
 # CONFIG_MACVLAN is not set
 # CONFIG_IPVLAN is not set
 # CONFIG_VXLAN is not set
+# CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
 # CONFIG_TUN is not set
@@ -1714,6 +1715,7 @@ CONFIG_UNIX98_PTYS=y
 # CONFIG_NOZOMI is not set
 # CONFIG_N_GSM is not set
 # CONFIG_TRACE_SINK is not set
+# CONFIG_LDISC_AUTOLOAD is not set
 CONFIG_DEVMEM=y
 # CONFIG_DEVKMEM is not set
 
@@ -3079,6 +3081,7 @@ CONFIG_ACPI_WMI=m
 # CONFIG_MLX_PLATFORM is not set
 # CONFIG_INTEL_TURBO_MAX_3 is not set
 # CONFIG_I2C_MULTI_INSTANTIATE is not set
+# CONFIG_INTEL_ATOMISP2_PM is not set
 CONFIG_PMC_ATOM=y
 # CONFIG_CHROME_PLATFORMS is not set
 # CONFIG_MELLANOX_PLATFORM is not set

--- a/recipes-kernel/linux/4.19/defconfigs/xenclient-ndvm/defconfig
+++ b/recipes-kernel/linux/4.19/defconfigs/xenclient-ndvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.32 Kernel Configuration
+# Linux/x86 4.19.44 Kernel Configuration
 #
 
 #
@@ -1194,6 +1194,7 @@ CONFIG_NET_CORE=y
 # CONFIG_MACVLAN is not set
 # CONFIG_IPVLAN is not set
 # CONFIG_VXLAN is not set
+# CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
 CONFIG_TUN=m
@@ -1655,6 +1656,7 @@ CONFIG_UNIX98_PTYS=y
 # CONFIG_NOZOMI is not set
 # CONFIG_N_GSM is not set
 # CONFIG_TRACE_SINK is not set
+# CONFIG_LDISC_AUTOLOAD is not set
 CONFIG_DEVMEM=y
 # CONFIG_DEVKMEM is not set
 

--- a/recipes-kernel/linux/4.19/defconfigs/xenclient-stubdomain/defconfig
+++ b/recipes-kernel/linux/4.19/defconfigs/xenclient-stubdomain/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.32 Kernel Configuration
+# Linux/x86 4.19.44 Kernel Configuration
 #
 
 #
@@ -970,6 +970,7 @@ CONFIG_NET_CORE=y
 # CONFIG_NET_TEAM is not set
 # CONFIG_MACVLAN is not set
 # CONFIG_VXLAN is not set
+# CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
 CONFIG_TUN=y
@@ -1094,6 +1095,7 @@ CONFIG_UNIX98_PTYS=y
 # CONFIG_NOZOMI is not set
 # CONFIG_N_GSM is not set
 # CONFIG_TRACE_SINK is not set
+# CONFIG_LDISC_AUTOLOAD is not set
 CONFIG_DEVMEM=y
 # CONFIG_DEVKMEM is not set
 

--- a/recipes-kernel/linux/4.19/defconfigs/xenclient-syncvm/defconfig
+++ b/recipes-kernel/linux/4.19/defconfigs/xenclient-syncvm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.32 Kernel Configuration
+# Linux/x86 4.19.44 Kernel Configuration
 #
 
 #
@@ -1115,6 +1115,7 @@ CONFIG_UNIX98_PTYS=y
 # CONFIG_NOZOMI is not set
 # CONFIG_N_GSM is not set
 # CONFIG_TRACE_SINK is not set
+# CONFIG_LDISC_AUTOLOAD is not set
 CONFIG_DEVMEM=y
 # CONFIG_DEVKMEM is not set
 

--- a/recipes-kernel/linux/4.19/defconfigs/xenclient-uivm/defconfig
+++ b/recipes-kernel/linux/4.19/defconfigs/xenclient-uivm/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.19.32 Kernel Configuration
+# Linux/x86 4.19.44 Kernel Configuration
 #
 
 #
@@ -958,6 +958,7 @@ CONFIG_UNIX98_PTYS=y
 # CONFIG_SERIAL_NONSTANDARD is not set
 # CONFIG_N_GSM is not set
 # CONFIG_TRACE_SINK is not set
+# CONFIG_LDISC_AUTOLOAD is not set
 CONFIG_DEVMEM=y
 # CONFIG_DEVKMEM is not set
 

--- a/recipes-kernel/linux/4.19/linux-openxt_4.19.44.bb
+++ b/recipes-kernel/linux/4.19/linux-openxt_4.19.44.bb
@@ -50,5 +50,5 @@ SRC_URI_append_xenclient-dom0 = "file://efi-tables-for-dom0.patch \
 	"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
-SRC_URI[kernel.md5sum] = "c5c0838fba5cc5dd4558e7ed27b95fc2"
-SRC_URI[kernel.sha256sum] = "a326d1154324aee3dd9a25ac44bc4ce7242ded097d4ca2e4c131e6f32918e7d9"
+SRC_URI[kernel.md5sum] = "e0b861a1b0293feede66cabaeba95bb2"
+SRC_URI[kernel.sha256sum] = "707642e993775618a5afa039b1058fa49f1c0faada46e8cdcb976241bca6b288"

--- a/recipes-kernel/linux/4.19/patches/acpi-video-delay-init.patch
+++ b/recipes-kernel/linux/4.19/patches/acpi-video-delay-init.patch
@@ -47,7 +47,7 @@ PATCHES
  static int register_count;
  static DEFINE_MUTEX(register_count_mutex);
  static DEFINE_MUTEX(video_list_lock);
-@@ -2226,6 +2229,22 @@ bool acpi_video_handles_brightness_key_p
+@@ -2234,6 +2237,22 @@ bool acpi_video_handles_brightness_key_p
  }
  EXPORT_SYMBOL(acpi_video_handles_brightness_key_presses);
  
@@ -70,7 +70,7 @@ PATCHES
  /*
   * This is kind of nasty. Hardware using Intel chipsets may require
   * the video opregion code to be run first in order to initialise
-@@ -2246,6 +2265,9 @@ static int __init acpi_video_init(void)
+@@ -2254,6 +2273,9 @@ static int __init acpi_video_init(void)
  	if (acpi_disabled)
  		return 0;
  
@@ -80,7 +80,7 @@ PATCHES
  	if (intel_opregion_present())
  		return 0;
  
-@@ -2254,6 +2276,9 @@ static int __init acpi_video_init(void)
+@@ -2262,6 +2284,9 @@ static int __init acpi_video_init(void)
  
  static void __exit acpi_video_exit(void)
  {

--- a/recipes-kernel/linux/4.19/patches/blktap2.patch
+++ b/recipes-kernel/linux/4.19/patches/blktap2.patch
@@ -3051,7 +3051,7 @@ PATCHES
  {
 --- a/include/linux/elevator.h
 +++ b/include/linux/elevator.h
-@@ -218,6 +218,8 @@ extern void elv_unregister(struct elevat
+@@ -219,6 +219,8 @@ extern void elv_unregister(struct elevat
  extern ssize_t elv_iosched_show(struct request_queue *, char *);
  extern ssize_t elv_iosched_store(struct request_queue *, const char *, size_t);
  

--- a/recipes-kernel/linux/4.19/patches/bridge-carrier-follow-prio0.patch
+++ b/recipes-kernel/linux/4.19/patches/bridge-carrier-follow-prio0.patch
@@ -8,7 +8,7 @@
  	spin_unlock_bh(&br->lock);
  }
  
-@@ -742,3 +743,28 @@ void br_port_flags_change(struct net_bri
+@@ -741,3 +742,28 @@ void br_port_flags_change(struct net_bri
  	if (mask & BR_NEIGH_SUPPRESS)
  		br_recalculate_neigh_suppress_enabled(br);
  }

--- a/recipes-kernel/linux/4.19/patches/extra-mt-input-devices.patch
+++ b/recipes-kernel/linux/4.19/patches/extra-mt-input-devices.patch
@@ -37,7 +37,7 @@ PATCHES
 ################################################################################
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -1106,6 +1106,7 @@
+@@ -1107,6 +1107,7 @@
  #define USB_DEVICE_ID_TURBOX_KEYBOARD	0x0201
  #define USB_DEVICE_ID_ASUS_MD_5110	0x5110
  #define USB_DEVICE_ID_TURBOX_TOUCHSCREEN_MOSART	0x7100

--- a/recipes-kernel/linux/4.19/patches/pci-pt-flr.patch
+++ b/recipes-kernel/linux/4.19/patches/pci-pt-flr.patch
@@ -43,7 +43,7 @@ PATCHES
 ################################################################################
 --- a/drivers/pci/pci.c
 +++ b/drivers/pci/pci.c
-@@ -4766,7 +4766,12 @@ int pci_probe_reset_function(struct pci_
+@@ -4788,7 +4788,12 @@ int pci_probe_reset_function(struct pci_
  	if (rc != -ENOTTY)
  		return rc;
  

--- a/recipes-kernel/linux/4.19/patches/pci-pt-move-unaligned-resources.patch
+++ b/recipes-kernel/linux/4.19/patches/pci-pt-move-unaligned-resources.patch
@@ -39,7 +39,7 @@ PATCHES
 ################################################################################
 --- a/drivers/pci/pci.c
 +++ b/drivers/pci/pci.c
-@@ -5749,6 +5749,27 @@ resource_size_t __weak pcibios_default_a
+@@ -5771,6 +5771,27 @@ resource_size_t __weak pcibios_default_a
  static char resource_alignment_param[RESOURCE_ALIGNMENT_PARAM_SIZE] = {0};
  static DEFINE_SPINLOCK(resource_alignment_lock);
  
@@ -67,7 +67,7 @@ PATCHES
  /**
   * pci_specified_resource_alignment - get resource alignment specified by user.
   * @dev: the PCI device to get
-@@ -5804,6 +5825,8 @@ static resource_size_t pci_specified_res
+@@ -5826,6 +5847,8 @@ static resource_size_t pci_specified_res
  		}
  		p++;
  	}

--- a/recipes-kernel/linux/4.19/patches/usbback-base.patch
+++ b/recipes-kernel/linux/4.19/patches/usbback-base.patch
@@ -305,7 +305,7 @@ PATCHES
  enum hub_activation_type {
  	HUB_INIT, HUB_INIT2, HUB_INIT3,		/* INITs must come first */
  	HUB_POST_RESET, HUB_RESUME, HUB_RESET_RESUME,
-@@ -5793,7 +5802,7 @@ int usb_reset_device(struct usb_device *
+@@ -5789,7 +5798,7 @@ int usb_reset_device(struct usb_device *
  			struct usb_driver *drv;
  			int unbind = 0;
  
@@ -314,7 +314,7 @@ PATCHES
  				drv = to_usb_driver(cintf->dev.driver);
  				if (drv->pre_reset && drv->post_reset)
  					unbind = (drv->pre_reset)(cintf);
-@@ -5814,7 +5823,12 @@ int usb_reset_device(struct usb_device *
+@@ -5810,7 +5819,12 @@ int usb_reset_device(struct usb_device *
  		for (i = config->desc.bNumInterfaces - 1; i >= 0; --i) {
  			struct usb_interface *cintf = config->interface[i];
  			struct usb_driver *drv;

--- a/recipes-kernel/linux/4.19/patches/xen-txt-add-xen-txt-eventlog-module.patch
+++ b/recipes-kernel/linux/4.19/patches/xen-txt-add-xen-txt-eventlog-module.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] xen-txt: add xen txt eventlog module
 
 --- a/arch/x86/include/asm/xen/hypercall.h
 +++ b/arch/x86/include/asm/xen/hypercall.h
-@@ -436,6 +436,12 @@ HYPERVISOR_dm_op(
+@@ -439,6 +439,12 @@ HYPERVISOR_dm_op(
  	return ret;
  }
  


### PR DESCRIPTION
Signed-off-by: Richard Turner <turnerr@ainfosec.com>
(cherry picked from commit a8bf68a8cf0a7fcc0ba387df35d23456530836c5)

OXT-1605