### PR TITLE
S9: OXT-1594: Forward Seal according to /config/config.pcrs

### DIFF
--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
@@ -395,7 +395,7 @@ encrypted_unlock() {
     then
         if pcr_bank_exists "sha256"; then
             local unseal_file=${key_file}
-            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB -r 0 -r 1 -r 2 -r 3 -r 4 -r 5 -r 7 -r 8 -r 15 -r 17 -r 18 -r 19 | cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
+            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB $( < ${unseal_file}.pcrs )| cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
             ret=$?
         fi
     else

--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement_1.0.bb
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement_1.0.bb
@@ -16,5 +16,6 @@ do_install() {
 }
 
 RDEPENDS_${PN} = " \
+    xenclient-tpm-scripts \
     tpm-tools-sa \
 "

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -1,20 +1,8 @@
 #!/bin/bash
 
-. /usr/lib/tpm-scripts/tpm-functions
-[ $? -eq 0 ] || {
-    echo "failed to load tpm-functions"
-    exit 1
-}
-
 . /usr/lib/openxt/ml-functions
 [ $? -eq 0 ] || {
     echo "failed to load ml-functions"
-    exit 1
-}
-
-. /usr/lib/openxt/key-functions
-[ $? -eq 0 ] || {
-    echo "failed to load key-functions"
     exit 1
 }
 

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -46,6 +46,11 @@ Usage: seal-system [-h] [-s|-u|-f] [-ctpgbr path] -[48 object[,objects]]"
 EOF
 }
 
+read_pcr_selection() {
+    # strip out -r/-p to leave just the digits
+    sed -e 's/-[rp]//g' $config_pcrs
+}
+
 # Globals
 TPM_DEV="$(find /sys/class -name tpm0)/device"
 
@@ -56,8 +61,8 @@ tpm2=$?
 operation="seal"
 config_key="/config/keys/config.key"
 sealed_key="/boot/system/tpm/config.tss"
-static_pcrs="0 1 2 3 4 5 7 8"
-dynamic_pcrs="15 17 18 19"
+config_pcrs="/config/config.pcrs"
+pcr_selection="$( read_pcr_selection )"
 hashalg="sha1"
 good_pcrs="/config/good.pcrs"
 bad_pcrs="/boot/system/tpm/bad.pcrs"
@@ -231,10 +236,6 @@ forward)
         pcr_forward[8]=":${pcr8}"
     fi
 
-    for p in ${static_pcrs}; do
-        pcr_params="${pcr_params} -p ${p}${pcr_forward[${p}]}"
-    done
-
     [ -r ${root_dev} ] || err "cannot read root_dev ${root_dev}"
     # During early init, rootfs is hashed and is given to
     # tpm_extend which for tpm1.2 hashes the rootfs hash again and
@@ -249,7 +250,7 @@ forward)
     pcr15=$(hash_extend 0 ${root_hash} ${hashalg}) ||
         err "failed to hash root device"
 
-    pcr_params="${pcr_params} -p 15:${pcr15}"
+    pcr_forward[15]=":${pcr15}"
 
     # Calculate DRTM PCRs if set (ie. PCR17 is not all f)
     if ! contains_only "${pcr17}" "f"; then
@@ -265,10 +266,14 @@ forward)
         pcr18=$(echo $pcrs | awk '{ print $2 }')
         pcr19=$(echo $pcrs | awk '{ print $3 }')
 
-        pcr_params="${pcr_params} -p 17:${pcr17} -p 18:${pcr18} -p 19:${pcr19}"
-    else
-        pcr_params="${pcr_params} -p 17 -p 18 -p 19"
+        pcr_forward[17]=":${pcr17}"
+        pcr_forward[18]=":${pcr18}"
+        pcr_forward[19]=":${pcr19}"
     fi
+
+    for p in ${pcr_selection}; do
+        pcr_params="${pcr_params} -p ${p}${pcr_forward[${p}]}"
+    done
 
     echo "$pcr_params" > /boot/system/tpm/forward_pcr.lst
 
@@ -288,7 +293,7 @@ forward)
     exit 0
 ;;
 unseal)
-    for p in ${static_pcrs} ${dynamic_pcrs}; do
+    for p in ${pcr_selection}; do
         pcr_params="${pcr_params} -p ${p}"
     done
 

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -46,6 +46,18 @@ Usage: seal-system [-h] [-s|-u|-f] [-ctpgbr path] -[48 object[,objects]]"
 EOF
 }
 
+pcr_in_selection() {
+    pcr="$1"
+
+    for p in $pcr_selection ; do
+        if [ $p -eq $pcr ] ; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 read_pcr_selection() {
     # strip out -r/-p to leave just the digits
     sed -e 's/-[rp]//g' $config_pcrs
@@ -236,21 +248,26 @@ forward)
         pcr_forward[8]=":${pcr8}"
     fi
 
-    [ -r ${root_dev} ] || err "cannot read root_dev ${root_dev}"
-    # During early init, rootfs is hashed and is given to
-    # tpm_extend which for tpm1.2 hashes the rootfs hash again and
-    # hands that value to the TPM to be extended into PCR 15
+    if pcr_in_selection 15 ; then
+        [ -r ${root_dev} ] || err "cannot read root_dev ${root_dev}"
+        # During early init, rootfs is hashed and is given to
+        # tpm_extend which for tpm1.2 hashes the rootfs hash again and
+        # hands that value to the TPM to be extended into PCR 15
 
-    # Use dd here to perform direct I/O. On some machines in some cases, stale data in
-    # the storage layer, or perhaps the disk cache, causes sha256sum {root_dev} to compute
-    # an incorrect hash, leading to a bad PCR15 value. Direct I/O always computes an accurate hash
-    # so we can correct predict PCR15 during forward seal.
-    root_hash=$(dd status=none if=${root_dev} iflag=direct bs=8M | ${hashalg}sum|cut -f1 -d' ')
-    [ "${tpm2}" -ne 0 ] && root_hash=$(echo -n ${root_hash}|${hashalg}sum|cut -f1 -d' ')
-    pcr15=$(hash_extend 0 ${root_hash} ${hashalg}) ||
-        err "failed to hash root device"
+        # Use dd here to perform direct I/O. On some machines in some cases,
+        # stale data in the storage layer, or perhaps the disk cache, causes
+        # sha256sum {root_dev} to compute an incorrect hash, leading to a bad
+        # PCR15 value. Direct I/O always computes an accurate hash so we can
+        # correct predict PCR15 during forward seal.
+        root_hash=$(dd status=none if=${root_dev} iflag=direct bs=8M | \
+                        ${hashalg}sum|cut -f1 -d' ')
+        [ "${tpm2}" -ne 0 ] && root_hash=$(echo -n ${root_hash} | \
+                                               ${hashalg}sum|cut -f1 -d' ')
+        pcr15=$(hash_extend 0 ${root_hash} ${hashalg}) ||
+                err "failed to hash root device"
 
-    pcr_forward[15]=":${pcr15}"
+        pcr_forward[15]=":${pcr15}"
+    fi
 
     # Calculate DRTM PCRs if set (ie. PCR17 is not all f)
     if ! contains_only "${pcr17}" "f"; then

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -240,6 +240,7 @@ seal()
         clean_old_tpm_files
         if pcr_bank_exists "sha256"; then
             sealout=$(tpm2_sealdata -H 0x81000000 -I ${seal_file} -O ${tss_file}.sha256 -o ${tss_file}.pub.sha256 -g 0xB -G 0x8 -b 0x492 $(cat /config/config.pcrs) 2>&1 )
+            cp /config/config.pcrs ${tss_file}.pcrs
             sealerr=$?
         fi
     else

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -25,6 +25,7 @@
 
 clean_old_tpm_files () {
     [ -e /boot/system/tpm/config.tss ] && rm /boot/system/tpm/config.tss
+    [ -e /boot/system/tpm/config.tss.pcrs ] && rm /boot/system/tpm/config.tss.pcrs
     [ -e /boot/system/tpm/config.tss.sha256 ] && rm /boot/system/tpm/config.tss.sha256
     [ -e /boot/system/tpm/config.tss.pub.sha256 ] && rm /boot/system/tpm/config.tss.pub.sha256
 }
@@ -674,6 +675,10 @@ tpm_seal() {
         pcr_bank_exists "${hashalg}"
         [ $? -eq 0 ] || return 1
 
+        # pcr_params starts with -p or -r, but that's okay because
+        # echo only honors flags -n -e & -E
+        echo "${pcr_params}" > ${tss}.pcrs
+
         case $hashalg in
         sha1)
             sealout=$(tpm2_sealdata -H ${OXT_HANDLE_SHA1} -I ${secret} \
@@ -741,6 +746,9 @@ tpm_forward_seal() {
         seal_file=${key}
         clean_old_tpm_files
         if pcr_bank_exists "sha256"; then
+            # We only want the PCRs numbers and not the forward seal values
+            echo "${pcr_params}" | \
+                sed -e 's/:[0-9a-zA-Z]\{64\}//g' > ${tss}.pcrs
             tpm2_sealdata -H ${OXT_HANDLE_SHA256} -I ${seal_file} \
                           -O ${tss}.sha256 -o ${tss}.pub.sha256 \
                           -g ${TPM_ALG_SHA256} -G ${TPM_ALG_KEYEDHASH} \
@@ -800,13 +808,13 @@ tpm_unseal() {
         sha1)
             tpm2_unsealdata -H ${OXT_HANDLE_SHA1} -n "${tss}.sha1" \
                             -u "${tss}.pub.sha1" -g ${TPM_ALG_SHA1} \
-                            ${pcr_params} 2>/dev/null
+                            $( < ${tss}.pcrs ) 2>/dev/null
             return $?
         ;;
         sha256)
             tpm2_unsealdata -H ${OXT_HANDLE_SHA256} -n "${tss}.sha256" \
                             -u "${tss}.pub.sha256" -g ${TPM_ALG_SHA256} \
-                            ${pcr_params} 2>/dev/null
+                            $( < ${tss}.pcrs ) 2>/dev/null
             return $?
         ;;
         *)

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts_1.0.bb
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts_1.0.bb
@@ -10,6 +10,11 @@ SRC_URI = " \
     file://*-fix.sh \
 "
 
+RDEPENDS_${PN} = " \
+    tpm-tools \
+    tpm2-tools \
+"
+
 FILES_${PN} = "${libdir}/tpm-scripts"
 
 do_install() {


### PR DESCRIPTION
This is the stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1158

This PR is groundwork for OXT-1594. It makes seal-system forward seal according to /config/config.pcrs. It does not change the pcr selection.

It is now flexible and will seal against any selection of PCRs. If the selection set is empty, then seal-system fails (seal-system: forward seal of key failed) since tpm2_sealdata fails (ERROR: Unable to run tpm2_sealdata). We can also drop out PCR 15 which has the rootfs measurement. Is that too flexible?

There are also some other cleanups I noticed along the way.