### PR TITLE
OXT-1494: [xen] Force synchronous page scrub

### DIFF
--- a/recipes-extended/xen/files/memory-scrub-on-domain-shutdown.patch
+++ b/recipes-extended/xen/files/memory-scrub-on-domain-shutdown.patch
@@ -1,0 +1,83 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Force page scrub after domain shutdown, not during idle loop.
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+In recent Xen versions, page scrubbing has been reworked to occur asynchronously
+during an idle loop. Therefore, it is possible that pages once owned by a guest
+will never have their pages scrubbed if Xen never schedules the loop to run. Xen
+WILL scrub pages before given to a newly booted guest, but during the time the 
+guest is off, it's possible to have unscrubbed pages from previous guests
+hanging about.
+
+So, we reintroduce page scrubbing in free_xenheap_pages and free_domheap_pages,
+so that a guest's pages are scrubbed synchronously when shutdown. We leave
+the idle loop otherwise untouched to reduce the complexity of the patch.
+scrub_free_pages (the logic called from the idle loop) is ultimately called on
+boot when the idle loop is initialized, but after the first run, pages are no
+longer scrubbed from this function.
+
+################################################################################
+CHANGELOG
+################################################################################
+Authors:
+Chris Rogers <rogersc@ainfosec.com>
+
+################################################################################
+REMOVAL
+################################################################################
+Never
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+Expand this patch to use a boot or build time option that turns synchronous
+scrubbing on/off and submit upstream. Making it configurable would support
+both the client usecase and server usecase.
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+
+################################################################################
+PATCHES
+################################################################################
+
+--- a/xen/common/page_alloc.c
++++ b/xen/common/page_alloc.c
+@@ -2211,10 +2211,15 @@ void free_xenheap_pages(void *v, unsigne
+ 
+     pg = virt_to_page(v);
+ 
++
++    /* Scrub the pages here, not in the idle loop */
+     for ( i = 0; i < (1u << order); i++ )
++    {
++        scrub_one_page(&pg[i]);
+         pg[i].count_info &= ~PGC_xen_heap;
++    }
+ 
+-    free_heap_pages(pg, order, true);
++    free_heap_pages(pg, order, false);
+ }
+ 
+ #endif  /* CONFIG_SEPARATE_XENHEAP */
+@@ -2395,8 +2400,13 @@ void free_domheap_pages(struct page_info
+             drop_dom_ref = false;
+             scrub = 1;
+         }
+-
+-        free_heap_pages(pg, order, scrub);
++        /* scrub the pages here, not in the idle loop */
++        if ( unlikely(scrub) ) {
++            for ( i = 0; i < (1 << order); i++ ) {
++                scrub_one_page(&pg[i]);
++            }
++        }
++        free_heap_pages(pg, order, false);
+     }
+ 
+     if ( drop_dom_ref )

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -99,6 +99,7 @@ SRC_URI_append = " \
     file://argo-fix-full-ring-write-bug.patch \
     file://argo-fix-requeue-msg-len-bug.patch \
     file://libxl-seabios-ipxe.patch \
+    file://memory-scrub-on-domain-shutdown.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/grub.cfg
@@ -30,7 +30,7 @@ else
 fi
 
 TBOOT_COMMON_CMD="min_ram=0x2000000 loglvl=all serial=115200,8n1,0x3f8 logging=serial,memory"
-XEN_COMMON_CMD="dom0_mem=min:420M,max:420M,420M mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug ucode=-2 smt=0 argo=yes,mac-permissive=1"
+XEN_COMMON_CMD="dom0_mem=min:420M,max:420M,420M mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug ucode=-2 smt=0 bootscrub=1 argo=yes,mac-permissive=1"
 LINUX_COMMON_CMD="console=hvc0 root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3"
 
 menuentry "XenClient: Normal" {

--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
@@ -5,31 +5,31 @@ sinit=GM45_GS45_PM45_SINIT_51.BIN Q35_SINIT_51.BIN Q45_Q43_SINIT_51.BIN i5_i7_DU
 ucode=microcode_intel.bin
 
 [openxt-normal]
-options=placeholder console=com1 dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 argo=yes,mac-permissive=1
+options=placeholder console=com1 dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 autostart
 ramdisk=initramfs.gz
 xsm=policy.24
  
 [openxt-support-safe-graphics]
-options=console=com1 dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 argo=yes,mac-permissive=1
+options=console=com1 dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 safe-graphic nomodeset
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-amt]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 argo=yes,mac-permissive=1
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-console]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 argo=yes,mac-permissive=1
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-console-amt]
-options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 argo=yes,mac-permissive=1
+options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
 ramdisk=initramfs.gz
 xsm=policy.24


### PR DESCRIPTION
  Recent versions of Xen have reworked page scrubbing so that it
  is now asynchronous, called from the idle loop. For client
  virtualization, this is a concern since it is possible for Xen
  to never schedule the loop to run under the correct conditions,
  leaving unscrubbed pages from old domains hanging about. While
  Xen will scrub pages before giving them to a new domain, this
  in-between state where scrubbing is not guaranteed is a concern.

  This commit reintroduces page scrubbing synchronously when a domain
  is shutdown, and uses the bootscrub=1 flag to scrub pages on
  platform boot.

  OXT-1494

Signed-off-by: Chris <rogersc@ainfosec.com>