### PR TITLE
OXT-1626: Update Xen with current Linux's list macros

### DIFF
--- a/recipes-extended/xen/files/unfork-linux-lists.patch
+++ b/recipes-extended/xen/files/unfork-linux-lists.patch
@@ -1,0 +1,2738 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Replace Xen's list macros that were forked from Linux a long time ago with same
+from current Linux where they have been actively maintained.
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+
+################################################################################
+CHANGELOG
+################################################################################
+Patch written by Christopher Clark for OpenXT 9.0.
+Developed against upstream staging (pre-Xen 4.13) and cherry-picked to Xen 4.12.
+
+################################################################################
+REMOVAL
+################################################################################
+Only if upstreamed. Do not remove.
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+This change belongs in upstream Xen.
+Applied to OpenXT to enable inclusion in the 9.0 release.
+
+If the list macro files change in Linux, this patch should track the changes:
+Linux is the correct upstream for these list macros.
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+None.
+
+################################################################################
+PATCHES
+################################################################################
+From 82d068fbe05af0ef76f720db312bdf61b36bb80b Mon Sep 17 00:00:00 2001
+From: Christopher Clark <christopher.w.clark@gmail.com>
+Date: Wed, 12 Jun 2019 18:16:50 -0700
+Subject: [PATCH] Update Xen to use the current versions of Linux's list.h and
+ rculist.h
+
+Xen's list headers were forked from Linux a long time ago and at this point
+are missing significant updates. Bring in the current Linux files and apply
+only the minimum necessary changes to them to enable use within Xen.
+
+This change separates out the RCU list functions into a separate header,
+rculist.h, as per Linux. Likewise the poison values are moved into a
+separate header, as per Linux, so that they are available to both list.h
+and rculist.h.
+
+Xen's unique additions to its version of list.h are moved into a
+new separate header, xenlist.h, in order to simplify keeping the contents
+of Xen's list.h exactly in sync with Linux's list.h.
+
+Necessary macros are imported from Linux's compiler.h into Xen's, with
+minor changes, to avoid ratholing into causing further imports.
+
+Linux removed the list_for_each_rcu macro, replacing all uses of it with
+list_for_each_entry_rcu, so do the same to the one call site Xen has
+within arch/x86/mm/mem_sharing.c.
+
+The hlist macros also changed to drop an unnecessary argument, so
+apply that change too -- only affects xsm/flask/avc.c.
+
+Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
+---
+ xen/arch/x86/hvm/mtrr.c       |    1 +
+ xen/arch/x86/hvm/vmsi.c       |    1 +
+ xen/arch/x86/mm/mem_sharing.c |    7 +-
+ xen/common/livepatch.c        |    1 +
+ xen/common/virtual_region.c   |    1 +
+ xen/include/xen/compiler.h    |   74 +++
+ xen/include/xen/list.h        | 1207 +++++++++++++++++++----------------------
+ xen/include/xen/poison.h      |   14 +
+ xen/include/xen/rculist.h     |  715 ++++++++++++++++++++++++
+ xen/include/xen/rcupdate.h    |   62 ++-
+ xen/include/xen/xenlist.h     |   26 +
+ xen/xsm/flask/avc.c           |   20 +-
+ 12 files changed, 1448 insertions(+), 681 deletions(-)
+ create mode 100644 xen/include/xen/poison.h
+ create mode 100644 xen/include/xen/rculist.h
+ create mode 100644 xen/include/xen/xenlist.h
+
+diff --git a/xen/arch/x86/hvm/mtrr.c b/xen/arch/x86/hvm/mtrr.c
+index 7ccd85b..4b494b7 100644
+--- a/xen/arch/x86/hvm/mtrr.c
++++ b/xen/arch/x86/hvm/mtrr.c
+@@ -17,6 +17,7 @@
+  */
+ 
+ #include <xen/domain_page.h>
++#include <xen/rculist.h>
+ #include <asm/e820.h>
+ #include <asm/iocap.h>
+ #include <asm/paging.h>
+diff --git a/xen/arch/x86/hvm/vmsi.c b/xen/arch/x86/hvm/vmsi.c
+index aeb5a70..93b75e4 100644
+--- a/xen/arch/x86/hvm/vmsi.c
++++ b/xen/arch/x86/hvm/vmsi.c
+@@ -28,6 +28,7 @@
+ #include <xen/mm.h>
+ #include <xen/xmalloc.h>
+ #include <xen/lib.h>
++#include <xen/rculist.h>
+ #include <xen/errno.h>
+ #include <xen/sched.h>
+ #include <xen/softirq.h>
+diff --git a/xen/arch/x86/mm/mem_sharing.c b/xen/arch/x86/mm/mem_sharing.c
+index 5ac9d8f..3978e5c 100644
+--- a/xen/arch/x86/mm/mem_sharing.c
++++ b/xen/arch/x86/mm/mem_sharing.c
+@@ -27,6 +27,7 @@
+ #include <xen/mm.h>
+ #include <xen/grant_table.h>
+ #include <xen/sched.h>
++#include <xen/rculist.h>
+ #include <xen/rcupdate.h>
+ #include <xen/guest_access.h>
+ #include <xen/vm_event.h>
+@@ -418,22 +419,20 @@ static int audit(void)
+     int errors = 0;
+     unsigned long count_expected;
+     unsigned long count_found = 0;
+-    struct list_head *ae;
++    struct page_sharing_info *pg_shared_info;
+ 
+     count_expected = atomic_read(&nr_shared_mfns);
+ 
+     rcu_read_lock(&shr_audit_read_lock);
+ 
+-    list_for_each_rcu(ae, &shr_audit_list)
++    list_for_each_entry_rcu(pg_shared_info, &shr_audit_list, entry)
+     {
+-        struct page_sharing_info *pg_shared_info;
+         unsigned long nr_gfns = 0;
+         struct page_info *pg;
+         mfn_t mfn;
+         gfn_info_t *g;
+         struct rmap_iterator ri;
+ 
+-        pg_shared_info = list_entry(ae, struct page_sharing_info, entry);
+         pg = pg_shared_info->pg;
+         mfn = page_to_mfn(pg);
+ 
+diff --git a/xen/common/livepatch.c b/xen/common/livepatch.c
+index d6eaae6..af3ecc4 100644
+--- a/xen/common/livepatch.c
++++ b/xen/common/livepatch.c
+@@ -11,6 +11,7 @@
+ #include <xen/lib.h>
+ #include <xen/list.h>
+ #include <xen/mm.h>
++#include <xen/rculist.h>
+ #include <xen/sched.h>
+ #include <xen/smp.h>
+ #include <xen/softirq.h>
+diff --git a/xen/common/virtual_region.c b/xen/common/virtual_region.c
+index aa23918..7ff8026 100644
+--- a/xen/common/virtual_region.c
++++ b/xen/common/virtual_region.c
+@@ -4,6 +4,7 @@
+ 
+ #include <xen/init.h>
+ #include <xen/kernel.h>
++#include <xen/rculist.h>
+ #include <xen/rcupdate.h>
+ #include <xen/spinlock.h>
+ #include <xen/virtual_region.h>
+diff --git a/xen/include/xen/compiler.h b/xen/include/xen/compiler.h
+index ff6c0f5..b32acf0 100644
+--- a/xen/include/xen/compiler.h
++++ b/xen/include/xen/compiler.h
+@@ -132,4 +132,78 @@
+ # define CLANG_DISABLE_WARN_GCC_COMPAT_END
+ #endif
+ 
++#include <xen/types.h>
++
++#define __READ_ONCE_SIZE                                        \
++({                                                              \
++    switch (size) {                                             \
++    case 1: *(__u8 *)res = *(volatile __u8 *)p; break;          \
++    case 2: *(__u16 *)res = *(volatile __u16 *)p; break;        \
++    case 4: *(__u32 *)res = *(volatile __u32 *)p; break;        \
++    case 8: *(__u64 *)res = *(volatile __u64 *)p; break;        \
++    default:                                                    \
++        barrier();                                              \
++        __builtin_memcpy((void *)res, (const void *)p, size);   \
++        barrier();                                              \
++    }                                                           \
++})
++
++static always_inline
++void __read_once_size(const volatile void *p, void *res, int size)
++{
++    __READ_ONCE_SIZE;
++}
++
++static always_inline void __write_once_size(volatile void *p, void *res, int size)
++{
++    switch (size) {
++    case 1: *(volatile __u8 *)p = *(__u8 *)res; break;
++    case 2: *(volatile __u16 *)p = *(__u16 *)res; break;
++    case 4: *(volatile __u32 *)p = *(__u32 *)res; break;
++    case 8: *(volatile __u64 *)p = *(__u64 *)res; break;
++    default:
++        barrier();
++        __builtin_memcpy((void *)p, (const void *)res, size);
++        barrier();
++    }
++}
++
++/*
++ * Prevent the compiler from merging or refetching reads or writes. The
++ * compiler is also forbidden from reordering successive instances of
++ * READ_ONCE and WRITE_ONCE, but only when the compiler is aware of some
++ * particular ordering. One way to make the compiler aware of ordering is to
++ * put the two invocations of READ_ONCE or WRITE_ONCE in different C
++ * statements.
++ *
++ * These two macros will also work on aggregate data types like structs or
++ * unions. If the size of the accessed data type exceeds the word size of
++ * the machine (e.g., 32 bits or 64 bits) READ_ONCE() and WRITE_ONCE() will
++ * fall back to memcpy(). There's at least two memcpy()s: one for the
++ * __builtin_memcpy() and then one for the macro doing the copy of variable
++ * - '__u' allocated on the stack.
++ *
++ * Their two major use cases are: (1) Mediating communication between
++ * process-level code and irq/NMI handlers, all running on the same CPU,
++ * and (2) Ensuring that the compiler does not fold, spindle, or otherwise
++ * mutilate accesses that either do not require ordering or that interact
++ * with an explicit memory barrier or atomic instruction that provides the
++ * required ordering.
++ */
++
++#define READ_ONCE(x) \
++({                                                                       \
++    union { typeof(x) __val; char __c[1]; } __u;                         \
++    __read_once_size(&(x), __u.__c, sizeof(x));                          \
++    __u.__val;                                                           \
++})
++
++#define WRITE_ONCE(x, val) \
++({                          \
++    union { typeof(x) __val; char __c[1]; } __u =   \
++        { .__val = (__force typeof(x)) (val) }; \
++    __write_once_size(&(x), __u.__c, sizeof(x));    \
++    __u.__val;                  \
++})
++
+ #endif /* __LINUX_COMPILER_H */
+diff --git a/xen/include/xen/list.h b/xen/include/xen/list.h
+index 1387abb..01ed3eb 100644
+--- a/xen/include/xen/list.h
++++ b/xen/include/xen/list.h
+@@ -1,24 +1,20 @@
+-/******************************************************************************
+- * list.h
+- * 
+- * Useful linked-list definitions taken from the Linux kernel (2.6.18).
+- */
+-
+-#ifndef __XEN_LIST_H__
+-#define __XEN_LIST_H__
+-
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef _LINUX_LIST_H
++#define _LINUX_LIST_H
++
++/* includes from Linux are disabled:
++#include <linux/types.h>
++#include <linux/stddef.h>
++#include <linux/poison.h>
++#include <linux/const.h>
++#include <linux/kernel.h>
++*/
++/* Xen includes: */
+ #include <xen/lib.h>
++#include <xen/poison.h>
++#include <xen/xenlist.h>
+ #include <asm/system.h>
+-
+-/*
+- * These are non-NULL pointers that will result in faults under normal
+- * circumstances, used to verify that nobody uses non-initialized list
+- * entries. Architectures can override these.
+- */
+-#ifndef LIST_POISON1
+-#define LIST_POISON1  ((void *) 0x00100100)
+-#define LIST_POISON2  ((void *) 0x00200200)
+-#endif
++/* Everything below this point is _identical_ to Linux's list.h */
+ 
+ /*
+  * Simple doubly linked list implementation.
+@@ -30,46 +26,52 @@
+  * using the generic single-entry routines.
+  */
+ 
+-struct list_head {
+-    struct list_head *next, *prev;
+-};
+-
+ #define LIST_HEAD_INIT(name) { &(name), &(name) }
+ 
+ #define LIST_HEAD(name) \
+-    struct list_head name = LIST_HEAD_INIT(name)
+-
+-#define LIST_HEAD_READ_MOSTLY(name) \
+-    struct list_head __read_mostly name = LIST_HEAD_INIT(name)
+-
+-/* Do not move this ahead of the struct list_head definition! */
+-#include <xen/prefetch.h>
++	struct list_head name = LIST_HEAD_INIT(name)
+ 
+ static inline void INIT_LIST_HEAD(struct list_head *list)
+ {
+-    list->next = list;
+-    list->prev = list;
++	WRITE_ONCE(list->next, list);
++	list->prev = list;
+ }
+ 
+-static inline bool list_head_is_null(const struct list_head *list)
++#ifdef CONFIG_DEBUG_LIST
++extern bool __list_add_valid(struct list_head *new,
++			      struct list_head *prev,
++			      struct list_head *next);
++extern bool __list_del_entry_valid(struct list_head *entry);
++#else
++static inline bool __list_add_valid(struct list_head *new,
++				struct list_head *prev,
++				struct list_head *next)
+ {
+-    return !list->next && !list->prev;
++	return true;
+ }
++static inline bool __list_del_entry_valid(struct list_head *entry)
++{
++	return true;
++}
++#endif
+ 
+ /*
+- * Insert a new entry between two known consecutive entries. 
++ * Insert a new entry between two known consecutive entries.
+  *
+  * This is only for internal list manipulation where we know
+  * the prev/next entries already!
+  */
+ static inline void __list_add(struct list_head *new,
+-                              struct list_head *prev,
+-                              struct list_head *next)
++			      struct list_head *prev,
++			      struct list_head *next)
+ {
+-    next->prev = new;
+-    new->next = next;
+-    new->prev = prev;
+-    prev->next = new;
++	if (!__list_add_valid(new, prev, next))
++		return;
++
++	next->prev = new;
++	new->next = next;
++	new->prev = prev;
++	WRITE_ONCE(prev->next, new);
+ }
+ 
+ /**
+@@ -82,9 +84,10 @@ static inline void __list_add(struct list_head *new,
+  */
+ static inline void list_add(struct list_head *new, struct list_head *head)
+ {
+-    __list_add(new, head, head->next);
++	__list_add(new, head, head->next);
+ }
+ 
++
+ /**
+  * list_add_tail - add a new entry
+  * @new: new entry to be added
+@@ -95,67 +98,7 @@ static inline void list_add(struct list_head *new, struct list_head *head)
+  */
+ static inline void list_add_tail(struct list_head *new, struct list_head *head)
+ {
+-    __list_add(new, head->prev, head);
+-}
+-
+-/*
+- * Insert a new entry between two known consecutive entries.
+- *
+- * This is only for internal list manipulation where we know
+- * the prev/next entries already!
+- */
+-static inline void __list_add_rcu(struct list_head *new,
+-                                  struct list_head *prev,
+-                                  struct list_head *next)
+-{
+-    new->next = next;
+-    new->prev = prev;
+-    smp_wmb();
+-    next->prev = new;
+-    prev->next = new;
+-}
+-
+-/**
+- * list_add_rcu - add a new entry to rcu-protected list
+- * @new: new entry to be added
+- * @head: list head to add it after
+- *
+- * Insert a new entry after the specified head.
+- * This is good for implementing stacks.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as list_add_rcu()
+- * or list_del_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * list_for_each_entry_rcu().
+- */
+-static inline void list_add_rcu(struct list_head *new, struct list_head *head)
+-{
+-    __list_add_rcu(new, head, head->next);
+-}
+-
+-/**
+- * list_add_tail_rcu - add a new entry to rcu-protected list
+- * @new: new entry to be added
+- * @head: list head to add it before
+- *
+- * Insert a new entry before the specified head.
+- * This is useful for implementing queues.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as list_add_tail_rcu()
+- * or list_del_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * list_for_each_entry_rcu().
+- */
+-static inline void list_add_tail_rcu(struct list_head *new,
+-                                     struct list_head *head)
+-{
+-    __list_add_rcu(new, head->prev, head);
++	__list_add(new, head->prev, head);
+ }
+ 
+ /*
+@@ -165,97 +108,71 @@ static inline void list_add_tail_rcu(struct list_head *new,
+  * This is only for internal list manipulation where we know
+  * the prev/next entries already!
+  */
+-static inline void __list_del(struct list_head *prev,
+-                              struct list_head *next)
++static inline void __list_del(struct list_head * prev, struct list_head * next)
+ {
+-    next->prev = prev;
+-    prev->next = next;
++	next->prev = prev;
++	WRITE_ONCE(prev->next, next);
+ }
+ 
+ /**
+  * list_del - deletes entry from list.
+  * @entry: the element to delete from the list.
+- * Note: list_empty on entry does not return true after this, the entry is
++ * Note: list_empty() on entry does not return true after this, the entry is
+  * in an undefined state.
+  */
+-static inline void list_del(struct list_head *entry)
++static inline void __list_del_entry(struct list_head *entry)
+ {
+-    ASSERT(entry->next->prev == entry);
+-    ASSERT(entry->prev->next == entry);
+-    __list_del(entry->prev, entry->next);
+-    entry->next = LIST_POISON1;
+-    entry->prev = LIST_POISON2;
++	if (!__list_del_entry_valid(entry))
++		return;
++
++	__list_del(entry->prev, entry->next);
+ }
+ 
+-/**
+- * list_del_rcu - deletes entry from list without re-initialization
+- * @entry: the element to delete from the list.
+- *
+- * Note: list_empty on entry does not return true after this,
+- * the entry is in an undefined state. It is useful for RCU based
+- * lockfree traversal.
+- *
+- * In particular, it means that we can not poison the forward
+- * pointers that may still be used for walking the list.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as list_del_rcu()
+- * or list_add_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * list_for_each_entry_rcu().
+- *
+- * Note that the caller is not permitted to immediately free
+- * the newly deleted entry.  Instead, either synchronize_rcu()
+- * or call_rcu() must be used to defer freeing until an RCU
+- * grace period has elapsed.
+- */
+-static inline void list_del_rcu(struct list_head *entry)
++static inline void list_del(struct list_head *entry)
+ {
+-    __list_del(entry->prev, entry->next);
+-    entry->prev = LIST_POISON2;
++	__list_del_entry(entry);
++	entry->next = LIST_POISON1;
++	entry->prev = LIST_POISON2;
+ }
+ 
+ /**
+  * list_replace - replace old entry by new one
+  * @old : the element to be replaced
+  * @new : the new element to insert
+- * Note: if 'old' was empty, it will be overwritten.
++ *
++ * If @old was empty, it will be overwritten.
+  */
+ static inline void list_replace(struct list_head *old,
+-                                struct list_head *new)
++				struct list_head *new)
+ {
+-    new->next = old->next;
+-    new->next->prev = new;
+-    new->prev = old->prev;
+-    new->prev->next = new;
++	new->next = old->next;
++	new->next->prev = new;
++	new->prev = old->prev;
++	new->prev->next = new;
+ }
+ 
+ static inline void list_replace_init(struct list_head *old,
+-                                     struct list_head *new)
++					struct list_head *new)
+ {
+-    list_replace(old, new);
+-    INIT_LIST_HEAD(old);
++	list_replace(old, new);
++	INIT_LIST_HEAD(old);
+ }
+ 
+-/*
+- * list_replace_rcu - replace old entry by new one
+- * @old : the element to be replaced
+- * @new : the new element to insert
+- *
+- * The old entry will be replaced with the new entry atomically.
+- * Note: 'old' should not be empty.
++/**
++ * list_swap - replace entry1 with entry2 and re-add entry1 at entry2's position
++ * @entry1: the location to place entry2
++ * @entry2: the location to place entry1
+  */
+-static inline void list_replace_rcu(struct list_head *old,
+-                                    struct list_head *new)
++static inline void list_swap(struct list_head *entry1,
++			     struct list_head *entry2)
+ {
+-    new->next = old->next;
+-    new->prev = old->prev;
+-    smp_wmb();
+-    new->next->prev = new;
+-    new->prev->next = new;
+-    old->prev = LIST_POISON2;
++	struct list_head *pos = entry2->prev;
++
++	list_del(entry2);
++	list_replace(entry1, entry2);
++	if (pos == entry1)
++		pos = entry2;
++	list_add(entry1, pos);
+ }
+ 
+ /**
+@@ -264,8 +181,8 @@ static inline void list_replace_rcu(struct list_head *old,
+  */
+ static inline void list_del_init(struct list_head *entry)
+ {
+-    __list_del(entry->prev, entry->next);
+-    INIT_LIST_HEAD(entry);
++	__list_del_entry(entry);
++	INIT_LIST_HEAD(entry);
+ }
+ 
+ /**
+@@ -275,8 +192,8 @@ static inline void list_del_init(struct list_head *entry)
+  */
+ static inline void list_move(struct list_head *list, struct list_head *head)
+ {
+-    __list_del(list->prev, list->next);
+-    list_add(list, head);
++	__list_del_entry(list);
++	list_add(list, head);
+ }
+ 
+ /**
+@@ -285,39 +202,64 @@ static inline void list_move(struct list_head *list, struct list_head *head)
+  * @head: the head that will follow our entry
+  */
+ static inline void list_move_tail(struct list_head *list,
+-                                  struct list_head *head)
++				  struct list_head *head)
+ {
+-    __list_del(list->prev, list->next);
+-    list_add_tail(list, head);
++	__list_del_entry(list);
++	list_add_tail(list, head);
+ }
+ 
+ /**
+- * list_is_last - tests whether @list is the last entry in list @head
++ * list_bulk_move_tail - move a subsection of a list to its tail
++ * @head: the head that will follow our entry
++ * @first: first entry to move
++ * @last: last entry to move, can be the same as first
++ *
++ * Move all entries between @first and including @last before @head.
++ * All three entries must belong to the same linked list.
++ */
++static inline void list_bulk_move_tail(struct list_head *head,
++				       struct list_head *first,
++				       struct list_head *last)
++{
++	first->prev->next = last->next;
++	last->next->prev = first->prev;
++
++	head->prev->next = first;
++	first->prev = head->prev;
++
++	last->next = head;
++	head->prev = last;
++}
++
++/**
++ * list_is_first -- tests whether @list is the first entry in list @head
+  * @list: the entry to test
+  * @head: the head of the list
+  */
+-static inline int list_is_last(const struct list_head *list,
+-                               const struct list_head *head)
++static inline int list_is_first(const struct list_head *list,
++					const struct list_head *head)
+ {
+-    return list->next == head;
++	return list->prev == head;
+ }
+ 
+ /**
+- * list_empty - tests whether a list is empty
+- * @head: the list to test.
++ * list_is_last - tests whether @list is the last entry in list @head
++ * @list: the entry to test
++ * @head: the head of the list
+  */
+-static inline int list_empty(const struct list_head *head)
++static inline int list_is_last(const struct list_head *list,
++				const struct list_head *head)
+ {
+-    return head->next == head;
++	return list->next == head;
+ }
+ 
+ /**
+- * list_is_singular - tests whether a list has exactly one entry
++ * list_empty - tests whether a list is empty
+  * @head: the list to test.
+  */
+-static inline int list_is_singular(const struct list_head *head)
++static inline int list_empty(const struct list_head *head)
+ {
+-    return !list_empty(head) && (head->next == head->prev);
++	return READ_ONCE(head->next) == head;
+ }
+ 
+ /**
+@@ -335,33 +277,157 @@ static inline int list_is_singular(const struct list_head *head)
+  */
+ static inline int list_empty_careful(const struct list_head *head)
+ {
+-    struct list_head *next = head->next;
+-    return (next == head) && (next == head->prev);
++	struct list_head *next = head->next;
++	return (next == head) && (next == head->prev);
+ }
+ 
+-static inline void __list_splice(struct list_head *list,
+-                                 struct list_head *head)
++/**
++ * list_rotate_left - rotate the list to the left
++ * @head: the head of the list
++ */
++static inline void list_rotate_left(struct list_head *head)
++{
++	struct list_head *first;
++
++	if (!list_empty(head)) {
++		first = head->next;
++		list_move_tail(first, head);
++	}
++}
++
++/**
++ * list_rotate_to_front() - Rotate list to specific item.
++ * @list: The desired new front of the list.
++ * @head: The head of the list.
++ *
++ * Rotates list so that @list becomes the new front of the list.
++ */
++static inline void list_rotate_to_front(struct list_head *list,
++					struct list_head *head)
+ {
+-    struct list_head *first = list->next;
+-    struct list_head *last = list->prev;
+-    struct list_head *at = head->next;
++	/*
++	 * Deletes the list head from the list denoted by @head and
++	 * places it as the tail of @list, this effectively rotates the
++	 * list so that @list is at the front.
++	 */
++	list_move_tail(head, list);
++}
+ 
+-    first->prev = head;
+-    head->next = first;
++/**
++ * list_is_singular - tests whether a list has just one entry.
++ * @head: the list to test.
++ */
++static inline int list_is_singular(const struct list_head *head)
++{
++	return !list_empty(head) && (head->next == head->prev);
++}
+ 
+-    last->next = at;
+-    at->prev = last;
++static inline void __list_cut_position(struct list_head *list,
++		struct list_head *head, struct list_head *entry)
++{
++	struct list_head *new_first = entry->next;
++	list->next = head->next;
++	list->next->prev = list;
++	list->prev = entry;
++	entry->next = list;
++	head->next = new_first;
++	new_first->prev = head;
+ }
+ 
+ /**
+- * list_splice - join two lists
++ * list_cut_position - cut a list into two
++ * @list: a new list to add all removed entries
++ * @head: a list with entries
++ * @entry: an entry within head, could be the head itself
++ *	and if so we won't cut the list
++ *
++ * This helper moves the initial part of @head, up to and
++ * including @entry, from @head to @list. You should
++ * pass on @entry an element you know is on @head. @list
++ * should be an empty list or a list you do not care about
++ * losing its data.
++ *
++ */
++static inline void list_cut_position(struct list_head *list,
++		struct list_head *head, struct list_head *entry)
++{
++	if (list_empty(head))
++		return;
++	if (list_is_singular(head) &&
++		(head->next != entry && head != entry))
++		return;
++	if (entry == head)
++		INIT_LIST_HEAD(list);
++	else
++		__list_cut_position(list, head, entry);
++}
++
++/**
++ * list_cut_before - cut a list into two, before given entry
++ * @list: a new list to add all removed entries
++ * @head: a list with entries
++ * @entry: an entry within head, could be the head itself
++ *
++ * This helper moves the initial part of @head, up to but
++ * excluding @entry, from @head to @list.  You should pass
++ * in @entry an element you know is on @head.  @list should
++ * be an empty list or a list you do not care about losing
++ * its data.
++ * If @entry == @head, all entries on @head are moved to
++ * @list.
++ */
++static inline void list_cut_before(struct list_head *list,
++				   struct list_head *head,
++				   struct list_head *entry)
++{
++	if (head->next == entry) {
++		INIT_LIST_HEAD(list);
++		return;
++	}
++	list->next = head->next;
++	list->next->prev = list;
++	list->prev = entry->prev;
++	list->prev->next = list;
++	head->next = entry;
++	entry->prev = head;
++}
++
++static inline void __list_splice(const struct list_head *list,
++				 struct list_head *prev,
++				 struct list_head *next)
++{
++	struct list_head *first = list->next;
++	struct list_head *last = list->prev;
++
++	first->prev = prev;
++	prev->next = first;
++
++	last->next = next;
++	next->prev = last;
++}
++
++/**
++ * list_splice - join two lists, this is designed for stacks
+  * @list: the new list to add.
+  * @head: the place to add it in the first list.
+  */
+-static inline void list_splice(struct list_head *list, struct list_head *head)
++static inline void list_splice(const struct list_head *list,
++				struct list_head *head)
+ {
+-    if (!list_empty(list))
+-        __list_splice(list, head);
++	if (!list_empty(list))
++		__list_splice(list, head, head->next);
++}
++
++/**
++ * list_splice_tail - join two lists, each list being a queue
++ * @list: the new list to add.
++ * @head: the place to add it in the first list.
++ */
++static inline void list_splice_tail(struct list_head *list,
++				struct list_head *head)
++{
++	if (!list_empty(list))
++		__list_splice(list, head->prev, head);
+ }
+ 
+ /**
+@@ -372,325 +438,289 @@ static inline void list_splice(struct list_head *list, struct list_head *head)
+  * The list at @list is reinitialised
+  */
+ static inline void list_splice_init(struct list_head *list,
+-                                    struct list_head *head)
++				    struct list_head *head)
+ {
+-    if (!list_empty(list)) {
+-        __list_splice(list, head);
+-        INIT_LIST_HEAD(list);
+-    }
++	if (!list_empty(list)) {
++		__list_splice(list, head, head->next);
++		INIT_LIST_HEAD(list);
++	}
++}
++
++/**
++ * list_splice_tail_init - join two lists and reinitialise the emptied list
++ * @list: the new list to add.
++ * @head: the place to add it in the first list.
++ *
++ * Each of the lists is a queue.
++ * The list at @list is reinitialised
++ */
++static inline void list_splice_tail_init(struct list_head *list,
++					 struct list_head *head)
++{
++	if (!list_empty(list)) {
++		__list_splice(list, head->prev, head);
++		INIT_LIST_HEAD(list);
++	}
+ }
+ 
+ /**
+  * list_entry - get the struct for this entry
+- * @ptr:    the &struct list_head pointer.
+- * @type:    the type of the struct this is embedded in.
+- * @member:    the name of the list_struct within the struct.
++ * @ptr:	the &struct list_head pointer.
++ * @type:	the type of the struct this is embedded in.
++ * @member:	the name of the list_head within the struct.
+  */
+ #define list_entry(ptr, type, member) \
+-    container_of(ptr, type, member)
++	container_of(ptr, type, member)
+ 
+ /**
+  * list_first_entry - get the first element from a list
+- * @ptr:        the list head to take the element from.
+- * @type:       the type of the struct this is embedded in.
+- * @member:     the name of the list_struct within the struct.
++ * @ptr:	the list head to take the element from.
++ * @type:	the type of the struct this is embedded in.
++ * @member:	the name of the list_head within the struct.
+  *
+  * Note, that list is expected to be not empty.
+  */
+ #define list_first_entry(ptr, type, member) \
+-        list_entry((ptr)->next, type, member)
++	list_entry((ptr)->next, type, member)
+ 
+ /**
+  * list_last_entry - get the last element from a list
+- * @ptr:        the list head to take the element from.
+- * @type:       the type of the struct this is embedded in.
+- * @member:     the name of the list_struct within the struct.
++ * @ptr:	the list head to take the element from.
++ * @type:	the type of the struct this is embedded in.
++ * @member:	the name of the list_head within the struct.
+  *
+  * Note, that list is expected to be not empty.
+  */
+ #define list_last_entry(ptr, type, member) \
+-        list_entry((ptr)->prev, type, member)
++	list_entry((ptr)->prev, type, member)
+ 
+ /**
+  * list_first_entry_or_null - get the first element from a list
+- * @ptr:        the list head to take the element from.
+- * @type:       the type of the struct this is embedded in.
+- * @member:     the name of the list_struct within the struct.
++ * @ptr:	the list head to take the element from.
++ * @type:	the type of the struct this is embedded in.
++ * @member:	the name of the list_head within the struct.
+  *
+  * Note that if the list is empty, it returns NULL.
+  */
+-#define list_first_entry_or_null(ptr, type, member) \
+-        (!list_empty(ptr) ? list_first_entry(ptr, type, member) : NULL)
++#define list_first_entry_or_null(ptr, type, member) ({ \
++	struct list_head *head__ = (ptr); \
++	struct list_head *pos__ = READ_ONCE(head__->next); \
++	pos__ != head__ ? list_entry(pos__, type, member) : NULL; \
++})
+ 
+ /**
+- * list_last_entry_or_null - get the last element from a list
+- * @ptr:        the list head to take the element from.
+- * @type:       the type of the struct this is embedded in.
+- * @member:     the name of the list_struct within the struct.
+- *
+- * Note that if the list is empty, it returns NULL.
++ * list_next_entry - get the next element in list
++ * @pos:	the type * to cursor
++ * @member:	the name of the list_head within the struct.
+  */
+-#define list_last_entry_or_null(ptr, type, member) \
+-        (!list_empty(ptr) ? list_last_entry(ptr, type, member) : NULL)
+-
+-/**
+-  * list_next_entry - get the next element in list
+-  * @pos:        the type * to cursor
+-  * @member:     the name of the list_struct within the struct.
+-  */
+ #define list_next_entry(pos, member) \
+-        list_entry((pos)->member.next, typeof(*(pos)), member)
+- 
+-/**
+-  * list_prev_entry - get the prev element in list
+-  * @pos:        the type * to cursor
+-  * @member:     the name of the list_struct within the struct.
+-  */
+-#define list_prev_entry(pos, member) \
+-        list_entry((pos)->member.prev, typeof(*(pos)), member)
++	list_entry((pos)->member.next, typeof(*(pos)), member)
+ 
+ /**
+- * list_for_each    -    iterate over a list
+- * @pos:    the &struct list_head to use as a loop cursor.
+- * @head:    the head for your list.
++ * list_prev_entry - get the prev element in list
++ * @pos:	the type * to cursor
++ * @member:	the name of the list_head within the struct.
+  */
+-#define list_for_each(pos, head)                                        \
+-    for (pos = (head)->next; prefetch(pos->next), pos != (head);        \
+-         pos = pos->next)
++#define list_prev_entry(pos, member) \
++	list_entry((pos)->member.prev, typeof(*(pos)), member)
+ 
+ /**
+- * __list_for_each - iterate over a list
+- * @pos:    the &struct list_head to use as a loop cursor.
+- * @head:   the head for your list.
+- *
+- * This variant differs from list_for_each() in that it's the
+- * simplest possible list iteration code, no prefetching is done.
+- * Use this for code that knows the list to be very short (empty
+- * or 1 entry) most of the time.
++ * list_for_each	-	iterate over a list
++ * @pos:	the &struct list_head to use as a loop cursor.
++ * @head:	the head for your list.
+  */
+-#define __list_for_each(pos, head)                              \
+-    for (pos = (head)->next; pos != (head); pos = pos->next)
++#define list_for_each(pos, head) \
++	for (pos = (head)->next; pos != (head); pos = pos->next)
+ 
+ /**
+- * list_for_each_prev - iterate over a list backwards
+- * @pos:    the &struct list_head to use as a loop cursor.
+- * @head:   the head for your list.
++ * list_for_each_prev	-	iterate over a list backwards
++ * @pos:	the &struct list_head to use as a loop cursor.
++ * @head:	the head for your list.
+  */
+-#define list_for_each_prev(pos, head)                                   \
+-    for (pos = (head)->prev; prefetch(pos->prev), pos != (head);        \
+-         pos = pos->prev)
++#define list_for_each_prev(pos, head) \
++	for (pos = (head)->prev; pos != (head); pos = pos->prev)
+ 
+ /**
+  * list_for_each_safe - iterate over a list safe against removal of list entry
+- * @pos:    the &struct list_head to use as a loop cursor.
+- * @n:      another &struct list_head to use as temporary storage
+- * @head:   the head for your list.
++ * @pos:	the &struct list_head to use as a loop cursor.
++ * @n:		another &struct list_head to use as temporary storage
++ * @head:	the head for your list.
+  */
+-#define list_for_each_safe(pos, n, head)                        \
+-    for (pos = (head)->next, n = pos->next; pos != (head);      \
+-         pos = n, n = pos->next)
++#define list_for_each_safe(pos, n, head) \
++	for (pos = (head)->next, n = pos->next; pos != (head); \
++		pos = n, n = pos->next)
+ 
+ /**
+- * list_for_each_backwards_safe    -    iterate backwards over a list safe
+- *                                      against removal of list entry
+- * @pos:    the &struct list_head to use as a loop counter.
+- * @n:      another &struct list_head to use as temporary storage
+- * @head:   the head for your list.
++ * list_for_each_prev_safe - iterate over a list backwards safe against removal of list entry
++ * @pos:	the &struct list_head to use as a loop cursor.
++ * @n:		another &struct list_head to use as temporary storage
++ * @head:	the head for your list.
+  */
+-#define list_for_each_backwards_safe(pos, n, head)              \
+-    for ( pos = (head)->prev, n = pos->prev; pos != (head);     \
+-          pos = n, n = pos->prev )
++#define list_for_each_prev_safe(pos, n, head) \
++	for (pos = (head)->prev, n = pos->prev; \
++	     pos != (head); \
++	     pos = n, n = pos->prev)
+ 
+ /**
+- * list_for_each_entry - iterate over list of given type
+- * @pos:    the type * to use as a loop cursor.
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * list_for_each_entry	-	iterate over list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  */
+-#define list_for_each_entry(pos, head, member)                          \
+-    for (pos = list_entry((head)->next, typeof(*pos), member);          \
+-         prefetch(pos->member.next), &pos->member != (head);            \
+-         pos = list_entry(pos->member.next, typeof(*pos), member))
++#define list_for_each_entry(pos, head, member)				\
++	for (pos = list_first_entry(head, typeof(*pos), member);	\
++	     &pos->member != (head);					\
++	     pos = list_next_entry(pos, member))
+ 
+ /**
+  * list_for_each_entry_reverse - iterate backwards over list of given type.
+- * @pos:    the type * to use as a loop cursor.
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  */
+-#define list_for_each_entry_reverse(pos, head, member)                  \
+-    for (pos = list_entry((head)->prev, typeof(*pos), member);          \
+-         prefetch(pos->member.prev), &pos->member != (head);            \
+-         pos = list_entry(pos->member.prev, typeof(*pos), member))
++#define list_for_each_entry_reverse(pos, head, member)			\
++	for (pos = list_last_entry(head, typeof(*pos), member);		\
++	     &pos->member != (head); 					\
++	     pos = list_prev_entry(pos, member))
+ 
+ /**
+- * list_prepare_entry - prepare a pos entry for use in
+- *                      list_for_each_entry_continue
+- * @pos:    the type * to use as a start point
+- * @head:   the head of the list
+- * @member: the name of the list_struct within the struct.
++ * list_prepare_entry - prepare a pos entry for use in list_for_each_entry_continue()
++ * @pos:	the type * to use as a start point
++ * @head:	the head of the list
++ * @member:	the name of the list_head within the struct.
+  *
+- * Prepares a pos entry for use as a start point in
+- * list_for_each_entry_continue.
++ * Prepares a pos entry for use as a start point in list_for_each_entry_continue().
+  */
+-#define list_prepare_entry(pos, head, member)           \
+-    ((pos) ? : list_entry(head, typeof(*pos), member))
++#define list_prepare_entry(pos, head, member) \
++	((pos) ? : list_entry(head, typeof(*pos), member))
+ 
+ /**
+  * list_for_each_entry_continue - continue iteration over list of given type
+- * @pos:    the type * to use as a loop cursor.
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+  * Continue to iterate over list of given type, continuing after
+  * the current position.
+  */
+-#define list_for_each_entry_continue(pos, head, member)                 \
+-    for (pos = list_entry(pos->member.next, typeof(*pos), member);      \
+-         prefetch(pos->member.next), &pos->member != (head);            \
+-         pos = list_entry(pos->member.next, typeof(*pos), member))
++#define list_for_each_entry_continue(pos, head, member) 		\
++	for (pos = list_next_entry(pos, member);			\
++	     &pos->member != (head);					\
++	     pos = list_next_entry(pos, member))
+ 
+ /**
+- * list_for_each_entry_from - iterate over list of given type from the
+- *                            current point
+- * @pos:    the type * to use as a loop cursor.
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * list_for_each_entry_continue_reverse - iterate backwards from the given point
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+- * Iterate over list of given type, continuing from current position.
+- */
+-#define list_for_each_entry_from(pos, head, member)                     \
+-    for (; prefetch(pos->member.next), &pos->member != (head);          \
+-         pos = list_entry(pos->member.next, typeof(*pos), member))
+-
+-/**
+- * list_for_each_entry_safe - iterate over list of given type safe
+- *                            against removal of list entry
+- * @pos:    the type * to use as a loop cursor.
+- * @n:      another type * to use as temporary storage
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * Start to iterate over list of given type backwards, continuing after
++ * the current position.
+  */
+-#define list_for_each_entry_safe(pos, n, head, member)                  \
+-    for (pos = list_entry((head)->next, typeof(*pos), member),          \
+-         n = list_entry(pos->member.next, typeof(*pos), member);        \
+-         &pos->member != (head);                                        \
+-         pos = n, n = list_entry(n->member.next, typeof(*n), member))
++#define list_for_each_entry_continue_reverse(pos, head, member)		\
++	for (pos = list_prev_entry(pos, member);			\
++	     &pos->member != (head);					\
++	     pos = list_prev_entry(pos, member))
+ 
+ /**
+- * list_for_each_entry_safe_continue
+- * @pos:    the type * to use as a loop cursor.
+- * @n:      another type * to use as temporary storage
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * list_for_each_entry_from - iterate over list of given type from the current point
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+- * Iterate over list of given type, continuing after current point,
+- * safe against removal of list entry.
++ * Iterate over list of given type, continuing from current position.
+  */
+-#define list_for_each_entry_safe_continue(pos, n, head, member)         \
+-    for (pos = list_entry(pos->member.next, typeof(*pos), member),      \
+-         n = list_entry(pos->member.next, typeof(*pos), member);        \
+-         &pos->member != (head);                                        \
+-         pos = n, n = list_entry(n->member.next, typeof(*n), member))
++#define list_for_each_entry_from(pos, head, member) 			\
++	for (; &pos->member != (head);					\
++	     pos = list_next_entry(pos, member))
+ 
+ /**
+- * list_for_each_entry_safe_from
+- * @pos:    the type * to use as a loop cursor.
+- * @n:      another type * to use as temporary storage
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * list_for_each_entry_from_reverse - iterate backwards over list of given type
++ *                                    from the current point
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+- * Iterate over list of given type from current point, safe against
+- * removal of list entry.
++ * Iterate backwards over list of given type, continuing from current position.
+  */
+-#define list_for_each_entry_safe_from(pos, n, head, member)             \
+-    for (n = list_entry(pos->member.next, typeof(*pos), member);        \
+-         &pos->member != (head);                                        \
+-         pos = n, n = list_entry(n->member.next, typeof(*n), member))
++#define list_for_each_entry_from_reverse(pos, head, member)		\
++	for (; &pos->member != (head);					\
++	     pos = list_prev_entry(pos, member))
+ 
+ /**
+- * list_for_each_entry_safe_reverse
+- * @pos:    the type * to use as a loop cursor.
+- * @n:      another type * to use as temporary storage
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
+- *
+- * Iterate backwards over list of given type, safe against removal
+- * of list entry.
++ * list_for_each_entry_safe - iterate over list of given type safe against removal of list entry
++ * @pos:	the type * to use as a loop cursor.
++ * @n:		another type * to use as temporary storage
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  */
+-#define list_for_each_entry_safe_reverse(pos, n, head, member)          \
+-    for (pos = list_entry((head)->prev, typeof(*pos), member),          \
+-         n = list_entry(pos->member.prev, typeof(*pos), member);        \
+-         &pos->member != (head);                                        \
+-         pos = n, n = list_entry(n->member.prev, typeof(*n), member))
++#define list_for_each_entry_safe(pos, n, head, member)			\
++	for (pos = list_first_entry(head, typeof(*pos), member),	\
++		n = list_next_entry(pos, member);			\
++	     &pos->member != (head); 					\
++	     pos = n, n = list_next_entry(n, member))
+ 
+ /**
+- * list_for_each_rcu - iterate over an rcu-protected list
+- * @pos:  the &struct list_head to use as a loop cursor.
+- * @head: the head for your list.
++ * list_for_each_entry_safe_continue - continue list iteration safe against removal
++ * @pos:	the type * to use as a loop cursor.
++ * @n:		another type * to use as temporary storage
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+- * This list-traversal primitive may safely run concurrently with
+- * the _rcu list-mutation primitives such as list_add_rcu()
+- * as long as the traversal is guarded by rcu_read_lock().
++ * Iterate over list of given type, continuing after current point,
++ * safe against removal of list entry.
+  */
+-#define list_for_each_rcu(pos, head)                            \
+-    for (pos = (head)->next;                                    \
+-         prefetch(rcu_dereference(pos)->next), pos != (head);   \
+-         pos = pos->next)
+-
+-#define __list_for_each_rcu(pos, head)          \
+-    for (pos = (head)->next;                    \
+-         rcu_dereference(pos) != (head);        \
+-         pos = pos->next)
++#define list_for_each_entry_safe_continue(pos, n, head, member) 		\
++	for (pos = list_next_entry(pos, member), 				\
++		n = list_next_entry(pos, member);				\
++	     &pos->member != (head);						\
++	     pos = n, n = list_next_entry(n, member))
+ 
+ /**
+- * list_for_each_safe_rcu
+- * @pos:   the &struct list_head to use as a loop cursor.
+- * @n:     another &struct list_head to use as temporary storage
+- * @head:  the head for your list.
+- *
+- * Iterate over an rcu-protected list, safe against removal of list entry.
++ * list_for_each_entry_safe_from - iterate over list from current point safe against removal
++ * @pos:	the type * to use as a loop cursor.
++ * @n:		another type * to use as temporary storage
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+- * This list-traversal primitive may safely run concurrently with
+- * the _rcu list-mutation primitives such as list_add_rcu()
+- * as long as the traversal is guarded by rcu_read_lock().
++ * Iterate over list of given type from current point, safe against
++ * removal of list entry.
+  */
+-#define list_for_each_safe_rcu(pos, n, head)            \
+-    for (pos = (head)->next;                            \
+-         n = rcu_dereference(pos)->next, pos != (head); \
+-         pos = n)
++#define list_for_each_entry_safe_from(pos, n, head, member) 			\
++	for (n = list_next_entry(pos, member);					\
++	     &pos->member != (head);						\
++	     pos = n, n = list_next_entry(n, member))
+ 
+ /**
+- * list_for_each_entry_rcu - iterate over rcu list of given type
+- * @pos:    the type * to use as a loop cursor.
+- * @head:   the head for your list.
+- * @member: the name of the list_struct within the struct.
++ * list_for_each_entry_safe_reverse - iterate backwards over list safe against removal
++ * @pos:	the type * to use as a loop cursor.
++ * @n:		another type * to use as temporary storage
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
+  *
+- * This list-traversal primitive may safely run concurrently with
+- * the _rcu list-mutation primitives such as list_add_rcu()
+- * as long as the traversal is guarded by rcu_read_lock().
++ * Iterate backwards over list of given type, safe against removal
++ * of list entry.
+  */
+-#define list_for_each_entry_rcu(pos, head, member)                      \
+-    for (pos = list_entry((head)->next, typeof(*pos), member);          \
+-         prefetch(rcu_dereference(pos)->member.next),                   \
+-         &pos->member != (head);                                        \
+-         pos = list_entry(pos->member.next, typeof(*pos), member))
++#define list_for_each_entry_safe_reverse(pos, n, head, member)		\
++	for (pos = list_last_entry(head, typeof(*pos), member),		\
++		n = list_prev_entry(pos, member);			\
++	     &pos->member != (head); 					\
++	     pos = n, n = list_prev_entry(n, member))
+ 
+ /**
+- * list_for_each_continue_rcu
+- * @pos:    the &struct list_head to use as a loop cursor.
+- * @head:   the head for your list.
+- *
+- * Iterate over an rcu-protected list, continuing after current point.
++ * list_safe_reset_next - reset a stale list_for_each_entry_safe loop
++ * @pos:	the loop cursor used in the list_for_each_entry_safe loop
++ * @n:		temporary storage used in list_for_each_entry_safe
++ * @member:	the name of the list_head within the struct.
+  *
+- * This list-traversal primitive may safely run concurrently with
+- * the _rcu list-mutation primitives such as list_add_rcu()
+- * as long as the traversal is guarded by rcu_read_lock().
++ * list_safe_reset_next is not safe to use in general if the list may be
++ * modified concurrently (eg. the lock is dropped in the loop body). An
++ * exception to this is if the cursor element (pos) is pinned in the list,
++ * and list_safe_reset_next is called after re-taking the lock and before
++ * completing the current iteration of the loop body.
+  */
+-#define list_for_each_continue_rcu(pos, head)                           \
+-    for ((pos) = (pos)->next;                                           \
+-         prefetch(rcu_dereference((pos))->next), (pos) != (head);       \
+-         (pos) = (pos)->next)
++#define list_safe_reset_next(pos, n, member)				\
++	n = list_next_entry(pos, member)
+ 
+ /*
+  * Double linked lists with a single pointer list head.
+@@ -699,302 +729,169 @@ static inline void list_splice_init(struct list_head *list,
+  * You lose the ability to access the tail in O(1).
+  */
+ 
+-struct hlist_head {
+-    struct hlist_node *first;
+-};
+-
+-struct hlist_node {
+-    struct hlist_node *next, **pprev;
+-};
+-
+ #define HLIST_HEAD_INIT { .first = NULL }
+ #define HLIST_HEAD(name) struct hlist_head name = {  .first = NULL }
+ #define INIT_HLIST_HEAD(ptr) ((ptr)->first = NULL)
+ static inline void INIT_HLIST_NODE(struct hlist_node *h)
+ {
+-    h->next = NULL;
+-    h->pprev = NULL;
++	h->next = NULL;
++	h->pprev = NULL;
+ }
+ 
+ static inline int hlist_unhashed(const struct hlist_node *h)
+ {
+-    return !h->pprev;
++	return !h->pprev;
+ }
+ 
+ static inline int hlist_empty(const struct hlist_head *h)
+ {
+-    return !h->first;
++	return !READ_ONCE(h->first);
+ }
+ 
+ static inline void __hlist_del(struct hlist_node *n)
+ {
+-    struct hlist_node *next = n->next;
+-    struct hlist_node **pprev = n->pprev;
+-    *pprev = next;
+-    if (next)
+-        next->pprev = pprev;
++	struct hlist_node *next = n->next;
++	struct hlist_node **pprev = n->pprev;
++
++	WRITE_ONCE(*pprev, next);
++	if (next)
++		next->pprev = pprev;
+ }
+ 
+ static inline void hlist_del(struct hlist_node *n)
+ {
+-    __hlist_del(n);
+-    n->next = LIST_POISON1;
+-    n->pprev = LIST_POISON2;
++	__hlist_del(n);
++	n->next = LIST_POISON1;
++	n->pprev = LIST_POISON2;
+ }
+ 
+-/**
+- * hlist_del_rcu - deletes entry from hash list without re-initialization
+- * @n: the element to delete from the hash list.
+- *
+- * Note: list_unhashed() on entry does not return true after this,
+- * the entry is in an undefined state. It is useful for RCU based
+- * lockfree traversal.
+- *
+- * In particular, it means that we can not poison the forward
+- * pointers that may still be used for walking the hash list.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as hlist_add_head_rcu()
+- * or hlist_del_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * hlist_for_each_entry().
+- */
+-static inline void hlist_del_rcu(struct hlist_node *n)
++static inline void hlist_del_init(struct hlist_node *n)
+ {
+-    __hlist_del(n);
+-    n->pprev = LIST_POISON2;
++	if (!hlist_unhashed(n)) {
++		__hlist_del(n);
++		INIT_HLIST_NODE(n);
++	}
+ }
+ 
+-static inline void hlist_del_init(struct hlist_node *n)
++static inline void hlist_add_head(struct hlist_node *n, struct hlist_head *h)
+ {
+-    if (!hlist_unhashed(n)) {
+-        __hlist_del(n);
+-        INIT_HLIST_NODE(n);
+-    }
++	struct hlist_node *first = h->first;
++	n->next = first;
++	if (first)
++		first->pprev = &n->next;
++	WRITE_ONCE(h->first, n);
++	n->pprev = &h->first;
+ }
+ 
+-/*
+- * hlist_replace_rcu - replace old entry by new one
+- * @old : the element to be replaced
+- * @new : the new element to insert
+- *
+- * The old entry will be replaced with the new entry atomically.
+- */
+-static inline void hlist_replace_rcu(struct hlist_node *old,
+-                                     struct hlist_node *new)
++/* next must be != NULL */
++static inline void hlist_add_before(struct hlist_node *n,
++					struct hlist_node *next)
+ {
+-    struct hlist_node *next = old->next;
+-
+-    new->next = next;
+-    new->pprev = old->pprev;
+-    smp_wmb();
+-    if (next)
+-        new->next->pprev = &new->next;
+-    *new->pprev = new;
+-    old->pprev = LIST_POISON2;
++	n->pprev = next->pprev;
++	n->next = next;
++	next->pprev = &n->next;
++	WRITE_ONCE(*(n->pprev), n);
+ }
+ 
+-static inline void hlist_add_head(struct hlist_node *n, struct hlist_head *h)
++static inline void hlist_add_behind(struct hlist_node *n,
++				    struct hlist_node *prev)
+ {
+-    struct hlist_node *first = h->first;
+-    n->next = first;
+-    if (first)
+-        first->pprev = &n->next;
+-    h->first = n;
+-    n->pprev = &h->first;
+-}
++	n->next = prev->next;
++	prev->next = n;
++	n->pprev = &prev->next;
+ 
+-/**
+- * hlist_add_head_rcu
+- * @n: the element to add to the hash list.
+- * @h: the list to add to.
+- *
+- * Description:
+- * Adds the specified element to the specified hlist,
+- * while permitting racing traversals.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as hlist_add_head_rcu()
+- * or hlist_del_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * hlist_for_each_entry_rcu(), used to prevent memory-consistency
+- * problems on Alpha CPUs.  Regardless of the type of CPU, the
+- * list-traversal primitive must be guarded by rcu_read_lock().
+- */
+-static inline void hlist_add_head_rcu(struct hlist_node *n,
+-                                      struct hlist_head *h)
+-{
+-    struct hlist_node *first = h->first;
+-    n->next = first;
+-    n->pprev = &h->first;
+-    smp_wmb();
+-    if (first)
+-        first->pprev = &n->next;
+-    h->first = n;
++	if (n->next)
++		n->next->pprev  = &n->next;
+ }
+ 
+-/* next must be != NULL */
+-static inline void hlist_add_before(struct hlist_node *n,
+-                    struct hlist_node *next)
++/* after that we'll appear to be on some hlist and hlist_del will work */
++static inline void hlist_add_fake(struct hlist_node *n)
+ {
+-    n->pprev = next->pprev;
+-    n->next = next;
+-    next->pprev = &n->next;
+-    *(n->pprev) = n;
++	n->pprev = &n->next;
+ }
+ 
+-static inline void hlist_add_after(struct hlist_node *n,
+-                    struct hlist_node *next)
++static inline bool hlist_fake(struct hlist_node *h)
+ {
+-    next->next = n->next;
+-    n->next = next;
+-    next->pprev = &n->next;
+-
+-    if(next->next)
+-        next->next->pprev  = &next->next;
++	return h->pprev == &h->next;
+ }
+ 
+-/**
+- * hlist_add_before_rcu
+- * @n: the new element to add to the hash list.
+- * @next: the existing element to add the new element before.
+- *
+- * Description:
+- * Adds the specified element to the specified hlist
+- * before the specified node while permitting racing traversals.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as hlist_add_head_rcu()
+- * or hlist_del_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * hlist_for_each_entry_rcu(), used to prevent memory-consistency
+- * problems on Alpha CPUs.
++/*
++ * Check whether the node is the only node of the head without
++ * accessing head:
+  */
+-static inline void hlist_add_before_rcu(struct hlist_node *n,
+-                                        struct hlist_node *next)
++static inline bool
++hlist_is_singular_node(struct hlist_node *n, struct hlist_head *h)
+ {
+-    n->pprev = next->pprev;
+-    n->next = next;
+-    smp_wmb();
+-    next->pprev = &n->next;
+-    *(n->pprev) = n;
++	return !n->next && n->pprev == &h->first;
+ }
+ 
+-/**
+- * hlist_add_after_rcu
+- * @prev: the existing element to add the new element after.
+- * @n: the new element to add to the hash list.
+- *
+- * Description:
+- * Adds the specified element to the specified hlist
+- * after the specified node while permitting racing traversals.
+- *
+- * The caller must take whatever precautions are necessary
+- * (such as holding appropriate locks) to avoid racing
+- * with another list-mutation primitive, such as hlist_add_head_rcu()
+- * or hlist_del_rcu(), running on this same list.
+- * However, it is perfectly legal to run concurrently with
+- * the _rcu list-traversal primitives, such as
+- * hlist_for_each_entry_rcu(), used to prevent memory-consistency
+- * problems on Alpha CPUs.
+- */
+-static inline void hlist_add_after_rcu(struct hlist_node *prev,
+-                                       struct hlist_node *n)
+-{
+-    n->next = prev->next;
+-    n->pprev = &prev->next;
+-    smp_wmb();
+-    prev->next = n;
+-    if (n->next)
+-        n->next->pprev = &n->next;
++/*
++ * Move a list from one list head to another. Fixup the pprev
++ * reference of the first entry if it exists.
++ */
++static inline void hlist_move_list(struct hlist_head *old,
++				   struct hlist_head *new)
++{
++	new->first = old->first;
++	if (new->first)
++		new->first->pprev = &new->first;
++	old->first = NULL;
+ }
+ 
+ #define hlist_entry(ptr, type, member) container_of(ptr,type,member)
+ 
+-#define hlist_for_each(pos, head)                                       \
+-    for (pos = (head)->first; pos && ({ prefetch(pos->next); 1; });     \
+-         pos = pos->next)
++#define hlist_for_each(pos, head) \
++	for (pos = (head)->first; pos ; pos = pos->next)
+ 
+-#define hlist_for_each_safe(pos, n, head)                       \
+-    for (pos = (head)->first; pos && ({ n = pos->next; 1; });   \
+-         pos = n)
++#define hlist_for_each_safe(pos, n, head) \
++	for (pos = (head)->first; pos && ({ n = pos->next; 1; }); \
++	     pos = n)
+ 
+-/**
+- * hlist_for_each_entry    - iterate over list of given type
+- * @tpos:    the type * to use as a loop cursor.
+- * @pos:    the &struct hlist_node to use as a loop cursor.
+- * @head:    the head for your list.
+- * @member:    the name of the hlist_node within the struct.
+- */
+-#define hlist_for_each_entry(tpos, pos, head, member)                   \
+-    for (pos = (head)->first;                                           \
+-         pos && ({ prefetch(pos->next); 1;}) &&                         \
+-         ({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;});       \
+-         pos = pos->next)
++#define hlist_entry_safe(ptr, type, member) \
++	({ typeof(ptr) ____ptr = (ptr); \
++	   ____ptr ? hlist_entry(____ptr, type, member) : NULL; \
++	})
+ 
+ /**
+- * hlist_for_each_entry_continue - iterate over a hlist continuing
+- *                                 after current point
+- * @tpos:    the type * to use as a loop cursor.
+- * @pos:    the &struct hlist_node to use as a loop cursor.
+- * @member:    the name of the hlist_node within the struct.
++ * hlist_for_each_entry	- iterate over list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the hlist_node within the struct.
+  */
+-#define hlist_for_each_entry_continue(tpos, pos, member)                \
+-    for (pos = (pos)->next;                                             \
+-         pos && ({ prefetch(pos->next); 1;}) &&                         \
+-         ({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;});       \
+-         pos = pos->next)
++#define hlist_for_each_entry(pos, head, member)				\
++	for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member);\
++	     pos;							\
++	     pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+ 
+ /**
+- * hlist_for_each_entry_from - iterate over a hlist continuing from
+- *                             current point
+- * @tpos:    the type * to use as a loop cursor.
+- * @pos:    the &struct hlist_node to use as a loop cursor.
+- * @member:    the name of the hlist_node within the struct.
++ * hlist_for_each_entry_continue - iterate over a hlist continuing after current point
++ * @pos:	the type * to use as a loop cursor.
++ * @member:	the name of the hlist_node within the struct.
+  */
+-#define hlist_for_each_entry_from(tpos, pos, member)                    \
+-    for (; pos && ({ prefetch(pos->next); 1;}) &&                       \
+-         ({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;});       \
+-         pos = pos->next)
++#define hlist_for_each_entry_continue(pos, member)			\
++	for (pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member);\
++	     pos;							\
++	     pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+ 
+ /**
+- * hlist_for_each_entry_safe - iterate over list of given type safe
+- *                             against removal of list entry
+- * @tpos:    the type * to use as a loop cursor.
+- * @pos:    the &struct hlist_node to use as a loop cursor.
+- * @n:        another &struct hlist_node to use as temporary storage
+- * @head:    the head for your list.
+- * @member:    the name of the hlist_node within the struct.
++ * hlist_for_each_entry_from - iterate over a hlist continuing from current point
++ * @pos:	the type * to use as a loop cursor.
++ * @member:	the name of the hlist_node within the struct.
+  */
+-#define hlist_for_each_entry_safe(tpos, pos, n, head, member)           \
+-    for (pos = (head)->first;                                           \
+-         pos && ({ n = pos->next; 1; }) &&                              \
+-         ({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;});       \
+-         pos = n)
+-
++#define hlist_for_each_entry_from(pos, member)				\
++	for (; pos;							\
++	     pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+ 
+ /**
+- * hlist_for_each_entry_rcu - iterate over rcu list of given type
+- * @tpos:   the type * to use as a loop cursor.
+- * @pos:    the &struct hlist_node to use as a loop cursor.
+- * @head:   the head for your list.
+- * @member: the name of the hlist_node within the struct.
+- *
+- * This list-traversal primitive may safely run concurrently with
+- * the _rcu list-mutation primitives such as hlist_add_head_rcu()
+- * as long as the traversal is guarded by rcu_read_lock().
++ * hlist_for_each_entry_safe - iterate over list of given type safe against removal of list entry
++ * @pos:	the type * to use as a loop cursor.
++ * @n:		another &struct hlist_node to use as temporary storage
++ * @head:	the head for your list.
++ * @member:	the name of the hlist_node within the struct.
+  */
+-#define hlist_for_each_entry_rcu(tpos, pos, head, member)               \
+-     for (pos = (head)->first;                                          \
+-          rcu_dereference(pos) && ({ prefetch(pos->next); 1;}) &&       \
+-          ({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;});      \
+-          pos = pos->next)
+-
+-#endif /* __XEN_LIST_H__ */
++#define hlist_for_each_entry_safe(pos, n, head, member) 		\
++	for (pos = hlist_entry_safe((head)->first, typeof(*pos), member);\
++	     pos && ({ n = pos->member.next; 1; });			\
++	     pos = hlist_entry_safe(n, typeof(*pos), member))
+ 
++#endif
+diff --git a/xen/include/xen/poison.h b/xen/include/xen/poison.h
+new file mode 100644
+index 0000000..ee9df9d
+--- /dev/null
++++ b/xen/include/xen/poison.h
+@@ -0,0 +1,14 @@
++#ifndef __XEN_POISON_H__
++#define __XEN_POISON_H__
++
++/*
++ * These are non-NULL pointers that will result in faults under normal
++ * circumstances, used to verify that nobody uses non-initialized list
++ * entries. Architectures can override these.
++ */
++#ifndef LIST_POISON1
++#define LIST_POISON1  ((void *) 0x00100100)
++#define LIST_POISON2  ((void *) 0x00200200)
++#endif
++
++#endif
+diff --git a/xen/include/xen/rculist.h b/xen/include/xen/rculist.h
+new file mode 100644
+index 0000000..12d6d0e
+--- /dev/null
++++ b/xen/include/xen/rculist.h
+@@ -0,0 +1,715 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef _LINUX_RCULIST_H
++#define _LINUX_RCULIST_H
++
++/*
++ * disable Linux's ifdef here:
++#ifdef __KERNEL__
++ * and also the matching endif at the very end of this file.
++*/
++
++/*
++ * RCU-protected list version
++ */
++/*
++ * includes from Linux are disabled:
++#include <linux/list.h>
++#include <linux/rcupdate.h>
++*/
++/* Xen includes: */
++#include <xen/poison.h>
++#include <xen/rcupdate.h>
++#include <xen/list.h>
++/* Everything below this point is _identical_ to Linux's rculist.h */
++
++/*
++ * Why is there no list_empty_rcu()?  Because list_empty() serves this
++ * purpose.  The list_empty() function fetches the RCU-protected pointer
++ * and compares it to the address of the list head, but neither dereferences
++ * this pointer itself nor provides this pointer to the caller.  Therefore,
++ * it is not necessary to use rcu_dereference(), so that list_empty() can
++ * be used anywhere you would want to use a list_empty_rcu().
++ */
++
++/*
++ * INIT_LIST_HEAD_RCU - Initialize a list_head visible to RCU readers
++ * @list: list to be initialized
++ *
++ * You should instead use INIT_LIST_HEAD() for normal initialization and
++ * cleanup tasks, when readers have no access to the list being initialized.
++ * However, if the list being initialized is visible to readers, you
++ * need to keep the compiler from being too mischievous.
++ */
++static inline void INIT_LIST_HEAD_RCU(struct list_head *list)
++{
++	WRITE_ONCE(list->next, list);
++	WRITE_ONCE(list->prev, list);
++}
++
++/*
++ * return the ->next pointer of a list_head in an rcu safe
++ * way, we must not access it directly
++ */
++#define list_next_rcu(list)	(*((struct list_head __rcu **)(&(list)->next)))
++
++/*
++ * Insert a new entry between two known consecutive entries.
++ *
++ * This is only for internal list manipulation where we know
++ * the prev/next entries already!
++ */
++static inline void __list_add_rcu(struct list_head *new,
++		struct list_head *prev, struct list_head *next)
++{
++	if (!__list_add_valid(new, prev, next))
++		return;
++
++	new->next = next;
++	new->prev = prev;
++	rcu_assign_pointer(list_next_rcu(prev), new);
++	next->prev = new;
++}
++
++/**
++ * list_add_rcu - add a new entry to rcu-protected list
++ * @new: new entry to be added
++ * @head: list head to add it after
++ *
++ * Insert a new entry after the specified head.
++ * This is good for implementing stacks.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as list_add_rcu()
++ * or list_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * list_for_each_entry_rcu().
++ */
++static inline void list_add_rcu(struct list_head *new, struct list_head *head)
++{
++	__list_add_rcu(new, head, head->next);
++}
++
++/**
++ * list_add_tail_rcu - add a new entry to rcu-protected list
++ * @new: new entry to be added
++ * @head: list head to add it before
++ *
++ * Insert a new entry before the specified head.
++ * This is useful for implementing queues.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as list_add_tail_rcu()
++ * or list_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * list_for_each_entry_rcu().
++ */
++static inline void list_add_tail_rcu(struct list_head *new,
++					struct list_head *head)
++{
++	__list_add_rcu(new, head->prev, head);
++}
++
++/**
++ * list_del_rcu - deletes entry from list without re-initialization
++ * @entry: the element to delete from the list.
++ *
++ * Note: list_empty() on entry does not return true after this,
++ * the entry is in an undefined state. It is useful for RCU based
++ * lockfree traversal.
++ *
++ * In particular, it means that we can not poison the forward
++ * pointers that may still be used for walking the list.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as list_del_rcu()
++ * or list_add_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * list_for_each_entry_rcu().
++ *
++ * Note that the caller is not permitted to immediately free
++ * the newly deleted entry.  Instead, either synchronize_rcu()
++ * or call_rcu() must be used to defer freeing until an RCU
++ * grace period has elapsed.
++ */
++static inline void list_del_rcu(struct list_head *entry)
++{
++	__list_del_entry(entry);
++	entry->prev = LIST_POISON2;
++}
++
++/**
++ * hlist_del_init_rcu - deletes entry from hash list with re-initialization
++ * @n: the element to delete from the hash list.
++ *
++ * Note: list_unhashed() on the node return true after this. It is
++ * useful for RCU based read lockfree traversal if the writer side
++ * must know if the list entry is still hashed or already unhashed.
++ *
++ * In particular, it means that we can not poison the forward pointers
++ * that may still be used for walking the hash list and we can only
++ * zero the pprev pointer so list_unhashed() will return true after
++ * this.
++ *
++ * The caller must take whatever precautions are necessary (such as
++ * holding appropriate locks) to avoid racing with another
++ * list-mutation primitive, such as hlist_add_head_rcu() or
++ * hlist_del_rcu(), running on this same list.  However, it is
++ * perfectly legal to run concurrently with the _rcu list-traversal
++ * primitives, such as hlist_for_each_entry_rcu().
++ */
++static inline void hlist_del_init_rcu(struct hlist_node *n)
++{
++	if (!hlist_unhashed(n)) {
++		__hlist_del(n);
++		n->pprev = NULL;
++	}
++}
++
++/**
++ * list_replace_rcu - replace old entry by new one
++ * @old : the element to be replaced
++ * @new : the new element to insert
++ *
++ * The @old entry will be replaced with the @new entry atomically.
++ * Note: @old should not be empty.
++ */
++static inline void list_replace_rcu(struct list_head *old,
++				struct list_head *new)
++{
++	new->next = old->next;
++	new->prev = old->prev;
++	rcu_assign_pointer(list_next_rcu(new->prev), new);
++	new->next->prev = new;
++	old->prev = LIST_POISON2;
++}
++
++/**
++ * __list_splice_init_rcu - join an RCU-protected list into an existing list.
++ * @list:	the RCU-protected list to splice
++ * @prev:	points to the last element of the existing list
++ * @next:	points to the first element of the existing list
++ * @sync:	synchronize_rcu, synchronize_rcu_expedited, ...
++ *
++ * The list pointed to by @prev and @next can be RCU-read traversed
++ * concurrently with this function.
++ *
++ * Note that this function blocks.
++ *
++ * Important note: the caller must take whatever action is necessary to prevent
++ * any other updates to the existing list.  In principle, it is possible to
++ * modify the list as soon as sync() begins execution. If this sort of thing
++ * becomes necessary, an alternative version based on call_rcu() could be
++ * created.  But only if -really- needed -- there is no shortage of RCU API
++ * members.
++ */
++static inline void __list_splice_init_rcu(struct list_head *list,
++					  struct list_head *prev,
++					  struct list_head *next,
++					  void (*sync)(void))
++{
++	struct list_head *first = list->next;
++	struct list_head *last = list->prev;
++
++	/*
++	 * "first" and "last" tracking list, so initialize it.  RCU readers
++	 * have access to this list, so we must use INIT_LIST_HEAD_RCU()
++	 * instead of INIT_LIST_HEAD().
++	 */
++
++	INIT_LIST_HEAD_RCU(list);
++
++	/*
++	 * At this point, the list body still points to the source list.
++	 * Wait for any readers to finish using the list before splicing
++	 * the list body into the new list.  Any new readers will see
++	 * an empty list.
++	 */
++
++	sync();
++
++	/*
++	 * Readers are finished with the source list, so perform splice.
++	 * The order is important if the new list is global and accessible
++	 * to concurrent RCU readers.  Note that RCU readers are not
++	 * permitted to traverse the prev pointers without excluding
++	 * this function.
++	 */
++
++	last->next = next;
++	rcu_assign_pointer(list_next_rcu(prev), first);
++	first->prev = prev;
++	next->prev = last;
++}
++
++/**
++ * list_splice_init_rcu - splice an RCU-protected list into an existing list,
++ *                        designed for stacks.
++ * @list:	the RCU-protected list to splice
++ * @head:	the place in the existing list to splice the first list into
++ * @sync:	synchronize_rcu, synchronize_rcu_expedited, ...
++ */
++static inline void list_splice_init_rcu(struct list_head *list,
++					struct list_head *head,
++					void (*sync)(void))
++{
++	if (!list_empty(list))
++		__list_splice_init_rcu(list, head, head->next, sync);
++}
++
++/**
++ * list_splice_tail_init_rcu - splice an RCU-protected list into an existing
++ *                             list, designed for queues.
++ * @list:	the RCU-protected list to splice
++ * @head:	the place in the existing list to splice the first list into
++ * @sync:	synchronize_rcu, synchronize_rcu_expedited, ...
++ */
++static inline void list_splice_tail_init_rcu(struct list_head *list,
++					     struct list_head *head,
++					     void (*sync)(void))
++{
++	if (!list_empty(list))
++		__list_splice_init_rcu(list, head->prev, head, sync);
++}
++
++/**
++ * list_entry_rcu - get the struct for this entry
++ * @ptr:        the &struct list_head pointer.
++ * @type:       the type of the struct this is embedded in.
++ * @member:     the name of the list_head within the struct.
++ *
++ * This primitive may safely run concurrently with the _rcu list-mutation
++ * primitives such as list_add_rcu() as long as it's guarded by rcu_read_lock().
++ */
++#define list_entry_rcu(ptr, type, member) \
++	container_of(READ_ONCE(ptr), type, member)
++
++/*
++ * Where are list_empty_rcu() and list_first_entry_rcu()?
++ *
++ * Implementing those functions following their counterparts list_empty() and
++ * list_first_entry() is not advisable because they lead to subtle race
++ * conditions as the following snippet shows:
++ *
++ * if (!list_empty_rcu(mylist)) {
++ *	struct foo *bar = list_first_entry_rcu(mylist, struct foo, list_member);
++ *	do_something(bar);
++ * }
++ *
++ * The list may not be empty when list_empty_rcu checks it, but it may be when
++ * list_first_entry_rcu rereads the ->next pointer.
++ *
++ * Rereading the ->next pointer is not a problem for list_empty() and
++ * list_first_entry() because they would be protected by a lock that blocks
++ * writers.
++ *
++ * See list_first_or_null_rcu for an alternative.
++ */
++
++/**
++ * list_first_or_null_rcu - get the first element from a list
++ * @ptr:        the list head to take the element from.
++ * @type:       the type of the struct this is embedded in.
++ * @member:     the name of the list_head within the struct.
++ *
++ * Note that if the list is empty, it returns NULL.
++ *
++ * This primitive may safely run concurrently with the _rcu list-mutation
++ * primitives such as list_add_rcu() as long as it's guarded by rcu_read_lock().
++ */
++#define list_first_or_null_rcu(ptr, type, member) \
++({ \
++	struct list_head *__ptr = (ptr); \
++	struct list_head *__next = READ_ONCE(__ptr->next); \
++	likely(__ptr != __next) ? list_entry_rcu(__next, type, member) : NULL; \
++})
++
++/**
++ * list_next_or_null_rcu - get the first element from a list
++ * @head:	the head for the list.
++ * @ptr:        the list head to take the next element from.
++ * @type:       the type of the struct this is embedded in.
++ * @member:     the name of the list_head within the struct.
++ *
++ * Note that if the ptr is at the end of the list, NULL is returned.
++ *
++ * This primitive may safely run concurrently with the _rcu list-mutation
++ * primitives such as list_add_rcu() as long as it's guarded by rcu_read_lock().
++ */
++#define list_next_or_null_rcu(head, ptr, type, member) \
++({ \
++	struct list_head *__head = (head); \
++	struct list_head *__ptr = (ptr); \
++	struct list_head *__next = READ_ONCE(__ptr->next); \
++	likely(__next != __head) ? list_entry_rcu(__next, type, \
++						  member) : NULL; \
++})
++
++/**
++ * list_for_each_entry_rcu	-	iterate over rcu list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
++ *
++ * This list-traversal primitive may safely run concurrently with
++ * the _rcu list-mutation primitives such as list_add_rcu()
++ * as long as the traversal is guarded by rcu_read_lock().
++ */
++#define list_for_each_entry_rcu(pos, head, member) \
++	for (pos = list_entry_rcu((head)->next, typeof(*pos), member); \
++		&pos->member != (head); \
++		pos = list_entry_rcu(pos->member.next, typeof(*pos), member))
++
++/**
++ * list_entry_lockless - get the struct for this entry
++ * @ptr:        the &struct list_head pointer.
++ * @type:       the type of the struct this is embedded in.
++ * @member:     the name of the list_head within the struct.
++ *
++ * This primitive may safely run concurrently with the _rcu
++ * list-mutation primitives such as list_add_rcu(), but requires some
++ * implicit RCU read-side guarding.  One example is running within a special
++ * exception-time environment where preemption is disabled and where lockdep
++ * cannot be invoked.  Another example is when items are added to the list,
++ * but never deleted.
++ */
++#define list_entry_lockless(ptr, type, member) \
++	container_of((typeof(ptr))READ_ONCE(ptr), type, member)
++
++/**
++ * list_for_each_entry_lockless - iterate over rcu list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_struct within the struct.
++ *
++ * This primitive may safely run concurrently with the _rcu
++ * list-mutation primitives such as list_add_rcu(), but requires some
++ * implicit RCU read-side guarding.  One example is running within a special
++ * exception-time environment where preemption is disabled and where lockdep
++ * cannot be invoked.  Another example is when items are added to the list,
++ * but never deleted.
++ */
++#define list_for_each_entry_lockless(pos, head, member) \
++	for (pos = list_entry_lockless((head)->next, typeof(*pos), member); \
++	     &pos->member != (head); \
++	     pos = list_entry_lockless(pos->member.next, typeof(*pos), member))
++
++/**
++ * list_for_each_entry_continue_rcu - continue iteration over list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_head within the struct.
++ *
++ * Continue to iterate over list of given type, continuing after
++ * the current position which must have been in the list when the RCU read
++ * lock was taken.
++ * This would typically require either that you obtained the node from a
++ * previous walk of the list in the same RCU read-side critical section, or
++ * that you held some sort of non-RCU reference (such as a reference count)
++ * to keep the node alive *and* in the list.
++ *
++ * This iterator is similar to list_for_each_entry_from_rcu() except
++ * this starts after the given position and that one starts at the given
++ * position.
++ */
++#define list_for_each_entry_continue_rcu(pos, head, member) 		\
++	for (pos = list_entry_rcu(pos->member.next, typeof(*pos), member); \
++	     &pos->member != (head);	\
++	     pos = list_entry_rcu(pos->member.next, typeof(*pos), member))
++
++/**
++ * list_for_each_entry_from_rcu - iterate over a list from current point
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the list_node within the struct.
++ *
++ * Iterate over the tail of a list starting from a given position,
++ * which must have been in the list when the RCU read lock was taken.
++ * This would typically require either that you obtained the node from a
++ * previous walk of the list in the same RCU read-side critical section, or
++ * that you held some sort of non-RCU reference (such as a reference count)
++ * to keep the node alive *and* in the list.
++ *
++ * This iterator is similar to list_for_each_entry_continue_rcu() except
++ * this starts from the given position and that one starts from the position
++ * after the given position.
++ */
++#define list_for_each_entry_from_rcu(pos, head, member)			\
++	for (; &(pos)->member != (head);					\
++		pos = list_entry_rcu(pos->member.next, typeof(*(pos)), member))
++
++/**
++ * hlist_del_rcu - deletes entry from hash list without re-initialization
++ * @n: the element to delete from the hash list.
++ *
++ * Note: list_unhashed() on entry does not return true after this,
++ * the entry is in an undefined state. It is useful for RCU based
++ * lockfree traversal.
++ *
++ * In particular, it means that we can not poison the forward
++ * pointers that may still be used for walking the hash list.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as hlist_add_head_rcu()
++ * or hlist_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * hlist_for_each_entry().
++ */
++static inline void hlist_del_rcu(struct hlist_node *n)
++{
++	__hlist_del(n);
++	n->pprev = LIST_POISON2;
++}
++
++/**
++ * hlist_replace_rcu - replace old entry by new one
++ * @old : the element to be replaced
++ * @new : the new element to insert
++ *
++ * The @old entry will be replaced with the @new entry atomically.
++ */
++static inline void hlist_replace_rcu(struct hlist_node *old,
++					struct hlist_node *new)
++{
++	struct hlist_node *next = old->next;
++
++	new->next = next;
++	new->pprev = old->pprev;
++	rcu_assign_pointer(*(struct hlist_node __rcu **)new->pprev, new);
++	if (next)
++		new->next->pprev = &new->next;
++	old->pprev = LIST_POISON2;
++}
++
++/*
++ * return the first or the next element in an RCU protected hlist
++ */
++#define hlist_first_rcu(head)	(*((struct hlist_node __rcu **)(&(head)->first)))
++#define hlist_next_rcu(node)	(*((struct hlist_node __rcu **)(&(node)->next)))
++#define hlist_pprev_rcu(node)	(*((struct hlist_node __rcu **)((node)->pprev)))
++
++/**
++ * hlist_add_head_rcu
++ * @n: the element to add to the hash list.
++ * @h: the list to add to.
++ *
++ * Description:
++ * Adds the specified element to the specified hlist,
++ * while permitting racing traversals.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as hlist_add_head_rcu()
++ * or hlist_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * hlist_for_each_entry_rcu(), used to prevent memory-consistency
++ * problems on Alpha CPUs.  Regardless of the type of CPU, the
++ * list-traversal primitive must be guarded by rcu_read_lock().
++ */
++static inline void hlist_add_head_rcu(struct hlist_node *n,
++					struct hlist_head *h)
++{
++	struct hlist_node *first = h->first;
++
++	n->next = first;
++	n->pprev = &h->first;
++	rcu_assign_pointer(hlist_first_rcu(h), n);
++	if (first)
++		first->pprev = &n->next;
++}
++
++/**
++ * hlist_add_tail_rcu
++ * @n: the element to add to the hash list.
++ * @h: the list to add to.
++ *
++ * Description:
++ * Adds the specified element to the specified hlist,
++ * while permitting racing traversals.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as hlist_add_head_rcu()
++ * or hlist_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * hlist_for_each_entry_rcu(), used to prevent memory-consistency
++ * problems on Alpha CPUs.  Regardless of the type of CPU, the
++ * list-traversal primitive must be guarded by rcu_read_lock().
++ */
++static inline void hlist_add_tail_rcu(struct hlist_node *n,
++				      struct hlist_head *h)
++{
++	struct hlist_node *i, *last = NULL;
++
++	/* Note: write side code, so rcu accessors are not needed. */
++	for (i = h->first; i; i = i->next)
++		last = i;
++
++	if (last) {
++		n->next = last->next;
++		n->pprev = &last->next;
++		rcu_assign_pointer(hlist_next_rcu(last), n);
++	} else {
++		hlist_add_head_rcu(n, h);
++	}
++}
++
++/**
++ * hlist_add_before_rcu
++ * @n: the new element to add to the hash list.
++ * @next: the existing element to add the new element before.
++ *
++ * Description:
++ * Adds the specified element to the specified hlist
++ * before the specified node while permitting racing traversals.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as hlist_add_head_rcu()
++ * or hlist_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * hlist_for_each_entry_rcu(), used to prevent memory-consistency
++ * problems on Alpha CPUs.
++ */
++static inline void hlist_add_before_rcu(struct hlist_node *n,
++					struct hlist_node *next)
++{
++	n->pprev = next->pprev;
++	n->next = next;
++	rcu_assign_pointer(hlist_pprev_rcu(n), n);
++	next->pprev = &n->next;
++}
++
++/**
++ * hlist_add_behind_rcu
++ * @n: the new element to add to the hash list.
++ * @prev: the existing element to add the new element after.
++ *
++ * Description:
++ * Adds the specified element to the specified hlist
++ * after the specified node while permitting racing traversals.
++ *
++ * The caller must take whatever precautions are necessary
++ * (such as holding appropriate locks) to avoid racing
++ * with another list-mutation primitive, such as hlist_add_head_rcu()
++ * or hlist_del_rcu(), running on this same list.
++ * However, it is perfectly legal to run concurrently with
++ * the _rcu list-traversal primitives, such as
++ * hlist_for_each_entry_rcu(), used to prevent memory-consistency
++ * problems on Alpha CPUs.
++ */
++static inline void hlist_add_behind_rcu(struct hlist_node *n,
++					struct hlist_node *prev)
++{
++	n->next = prev->next;
++	n->pprev = &prev->next;
++	rcu_assign_pointer(hlist_next_rcu(prev), n);
++	if (n->next)
++		n->next->pprev = &n->next;
++}
++
++#define __hlist_for_each_rcu(pos, head)				\
++	for (pos = rcu_dereference(hlist_first_rcu(head));	\
++	     pos;						\
++	     pos = rcu_dereference(hlist_next_rcu(pos)))
++
++/**
++ * hlist_for_each_entry_rcu - iterate over rcu list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the hlist_node within the struct.
++ *
++ * This list-traversal primitive may safely run concurrently with
++ * the _rcu list-mutation primitives such as hlist_add_head_rcu()
++ * as long as the traversal is guarded by rcu_read_lock().
++ */
++#define hlist_for_each_entry_rcu(pos, head, member)			\
++	for (pos = hlist_entry_safe (rcu_dereference_raw(hlist_first_rcu(head)),\
++			typeof(*(pos)), member);			\
++		pos;							\
++		pos = hlist_entry_safe(rcu_dereference_raw(hlist_next_rcu(\
++			&(pos)->member)), typeof(*(pos)), member))
++
++/**
++ * hlist_for_each_entry_rcu_notrace - iterate over rcu list of given type (for tracing)
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the hlist_node within the struct.
++ *
++ * This list-traversal primitive may safely run concurrently with
++ * the _rcu list-mutation primitives such as hlist_add_head_rcu()
++ * as long as the traversal is guarded by rcu_read_lock().
++ *
++ * This is the same as hlist_for_each_entry_rcu() except that it does
++ * not do any RCU debugging or tracing.
++ */
++#define hlist_for_each_entry_rcu_notrace(pos, head, member)			\
++	for (pos = hlist_entry_safe (rcu_dereference_raw_notrace(hlist_first_rcu(head)),\
++			typeof(*(pos)), member);			\
++		pos;							\
++		pos = hlist_entry_safe(rcu_dereference_raw_notrace(hlist_next_rcu(\
++			&(pos)->member)), typeof(*(pos)), member))
++
++/**
++ * hlist_for_each_entry_rcu_bh - iterate over rcu list of given type
++ * @pos:	the type * to use as a loop cursor.
++ * @head:	the head for your list.
++ * @member:	the name of the hlist_node within the struct.
++ *
++ * This list-traversal primitive may safely run concurrently with
++ * the _rcu list-mutation primitives such as hlist_add_head_rcu()
++ * as long as the traversal is guarded by rcu_read_lock().
++ */
++#define hlist_for_each_entry_rcu_bh(pos, head, member)			\
++	for (pos = hlist_entry_safe(rcu_dereference_bh(hlist_first_rcu(head)),\
++			typeof(*(pos)), member);			\
++		pos;							\
++		pos = hlist_entry_safe(rcu_dereference_bh(hlist_next_rcu(\
++			&(pos)->member)), typeof(*(pos)), member))
++
++/**
++ * hlist_for_each_entry_continue_rcu - iterate over a hlist continuing after current point
++ * @pos:	the type * to use as a loop cursor.
++ * @member:	the name of the hlist_node within the struct.
++ */
++#define hlist_for_each_entry_continue_rcu(pos, member)			\
++	for (pos = hlist_entry_safe(rcu_dereference_raw(hlist_next_rcu( \
++			&(pos)->member)), typeof(*(pos)), member);	\
++	     pos;							\
++	     pos = hlist_entry_safe(rcu_dereference_raw(hlist_next_rcu(	\
++			&(pos)->member)), typeof(*(pos)), member))
++
++/**
++ * hlist_for_each_entry_continue_rcu_bh - iterate over a hlist continuing after current point
++ * @pos:	the type * to use as a loop cursor.
++ * @member:	the name of the hlist_node within the struct.
++ */
++#define hlist_for_each_entry_continue_rcu_bh(pos, member)		\
++	for (pos = hlist_entry_safe(rcu_dereference_bh(hlist_next_rcu(  \
++			&(pos)->member)), typeof(*(pos)), member);	\
++	     pos;							\
++	     pos = hlist_entry_safe(rcu_dereference_bh(hlist_next_rcu(	\
++			&(pos)->member)), typeof(*(pos)), member))
++
++/**
++ * hlist_for_each_entry_from_rcu - iterate over a hlist continuing from current point
++ * @pos:	the type * to use as a loop cursor.
++ * @member:	the name of the hlist_node within the struct.
++ */
++#define hlist_for_each_entry_from_rcu(pos, member)			\
++	for (; pos;							\
++	     pos = hlist_entry_safe(rcu_dereference_raw(hlist_next_rcu(	\
++			&(pos)->member)), typeof(*(pos)), member))
++
++/* Xen: disable Linux's: #endif */	/* __KERNEL__ */
++#endif
+diff --git a/xen/include/xen/rcupdate.h b/xen/include/xen/rcupdate.h
+index 3402eb5..c6a1985 100644
+--- a/xen/include/xen/rcupdate.h
++++ b/xen/include/xen/rcupdate.h
+@@ -123,19 +123,63 @@ typedef struct _rcu_read_lock rcu_read_lock_t;
+  */
+ #define rcu_dereference(p)     (p)
+ 
++#define rcu_dereference_raw(p) \
++({ \
++    /* Dependency order vs. p above. */ \
++    typeof(p) ________p1 = READ_ONCE(p); \
++    ((typeof(*p) __force *)(________p1)); \
++})
++
++/**
++ * RCU_INITIALIZER() - statically initialize an RCU-protected global variable
++ * @v: The value to statically initialize with.
++ */
++#define RCU_INITIALIZER(v) (typeof(*(v)) __force __rcu *)(v)
++
+ /**
+- * rcu_assign_pointer - assign (publicize) a pointer to a newly
+- * initialized structure that will be dereferenced by RCU read-side
+- * critical sections.  Returns the value assigned.
++ * rcu_assign_pointer() - assign to RCU-protected pointer
++ * @p: pointer to assign to
++ * @v: value to assign (publish)
++ *
++ * Assigns the specified value to the specified RCU-protected
++ * pointer, ensuring that any concurrent RCU readers will see
++ * any prior initialization.
+  *
+  * Inserts memory barriers on architectures that require them
+- * (pretty much all of them other than x86), and also prevents
+- * the compiler from reordering the code that initializes the
+- * structure after the pointer assignment.  More importantly, this
+- * call documents which pointers will be dereferenced by RCU read-side
+- * code.
++ * (which is most of them), and also prevents the compiler from
++ * reordering the code that initializes the structure after the pointer
++ * assignment.  More importantly, this call documents which pointers
++ * will be dereferenced by RCU read-side code.
++ *
++ * In some special cases, you may use RCU_INIT_POINTER() instead
++ * of rcu_assign_pointer().  RCU_INIT_POINTER() is a bit faster due
++ * to the fact that it does not constrain either the CPU or the compiler.
++ * That said, using RCU_INIT_POINTER() when you should have used
++ * rcu_assign_pointer() is a very bad thing that results in
++ * impossible-to-diagnose memory corruption.  So please be careful.
++ * See the RCU_INIT_POINTER() comment header for details.
++ *
++ * Note that rcu_assign_pointer() evaluates each of its arguments only
++ * once, appearances notwithstanding.  One of the "extra" evaluations
++ * is in typeof() and the other visible only to sparse (__CHECKER__),
++ * neither of which actually execute the argument.  As with most cpp
++ * macros, this execute-arguments-only-once property is important, so
++ * please be careful when making changes to rcu_assign_pointer() and the
++ * other macros that it invokes.
+  */
+-#define rcu_assign_pointer(p, v) ({ smp_wmb(); (p) = (v); })
++#define rcu_assign_pointer(p, v)                                          \
++({                                                                        \
++    uintptr_t _r_a_p__v = (uintptr_t)(v);                                 \
++                                                                          \
++    if (__builtin_constant_p(v) && (_r_a_p__v) == (uintptr_t)NULL)        \
++        WRITE_ONCE((p), (typeof(p))(_r_a_p__v));                          \
++    else                                                                  \
++    {                                                                     \
++        smp_mb();                                                         \
++        WRITE_ONCE((p), RCU_INITIALIZER((typeof(p))_r_a_p__v));           \
++    }                                                                     \
++    _r_a_p__v;                                                            \
++})
+ 
+ void rcu_init(void);
+ void rcu_check_callbacks(int cpu);
+diff --git a/xen/include/xen/xenlist.h b/xen/include/xen/xenlist.h
+new file mode 100644
+index 0000000..d31c391
+--- /dev/null
++++ b/xen/include/xen/xenlist.h
+@@ -0,0 +1,26 @@
++#ifndef __XEN_XENLIST_H__
++#define __XEN_XENLIST_H__
++
++/* Xen extensions to Linux's list.h */
++
++struct list_head {
++    struct list_head *next, *prev;
++};
++
++#define LIST_HEAD_READ_MOSTLY(name) \
++    struct list_head __read_mostly name = LIST_HEAD_INIT(name)
++
++static inline bool list_head_is_null(const struct list_head *list)
++{
++    return !list->next && !list->prev;
++}
++
++struct hlist_head {
++    struct hlist_node *first;
++};
++
++struct hlist_node {
++    struct hlist_node *next, **pprev;
++};
++
++#endif /* __XEN_XENLIST_H__ */
+diff --git a/xen/xsm/flask/avc.c b/xen/xsm/flask/avc.c
+index 640c708..7e16822 100644
+--- a/xen/xsm/flask/avc.c
++++ b/xen/xsm/flask/avc.c
+@@ -25,6 +25,7 @@
+ #include <xen/kernel.h>
+ #include <xen/sched.h>
+ #include <xen/init.h>
++#include <xen/rculist.h>
+ #include <xen/rcupdate.h>
+ #include <asm/atomic.h>
+ #include <asm/current.h>
+@@ -255,11 +256,9 @@ int avc_get_hash_stats(struct xen_flask_hash_stats *arg)
+         head = &avc_cache.slots[i];
+         if ( !hlist_empty(head) )
+         {
+-            struct hlist_node *next;
+-
+             slots_used++;
+             chain_len = 0;
+-            hlist_for_each_entry_rcu(node, next, head, list)
++            hlist_for_each_entry_rcu(node, head, list)
+                 chain_len++;
+             if ( chain_len > max_chain_len )
+                 max_chain_len = chain_len;
+@@ -310,7 +309,6 @@ static inline int avc_reclaim_node(void)
+     int hvalue, try, ecx;
+     unsigned long flags;
+     struct hlist_head *head;
+-    struct hlist_node *next;
+     spinlock_t *lock;
+ 
+     for ( try = 0, ecx = 0; try < AVC_CACHE_SLOTS; try++ )
+@@ -322,7 +320,7 @@ static inline int avc_reclaim_node(void)
+ 
+         spin_lock_irqsave(&avc_cache.slots_lock[hvalue], flags);
+         rcu_read_lock(&avc_rcu_lock);
+-        hlist_for_each_entry(node, next, head, list)
++        hlist_for_each_entry(node, head, list)
+         {
+             avc_node_delete(node);
+             avc_cache_stats_incr(reclaims);
+@@ -375,11 +373,10 @@ static inline struct avc_node *avc_search_node(u32 ssid, u32 tsid, u16 tclass)
+     struct avc_node *node, *ret = NULL;
+     int hvalue;
+     struct hlist_head *head;
+-    struct hlist_node *next;
+ 
+     hvalue = avc_hash(ssid, tsid, tclass);
+     head = &avc_cache.slots[hvalue];
+-    hlist_for_each_entry_rcu(node, next, head, list)
++    hlist_for_each_entry_rcu(node, head, list)
+     {
+         if ( ssid == node->ae.ssid &&
+              tclass == node->ae.tclass &&
+@@ -479,7 +476,6 @@ static struct avc_node *avc_insert(u32 ssid, u32 tsid, u16 tclass,
+     if ( node )
+     {
+         struct hlist_head *head;
+-        struct hlist_node *next;
+         spinlock_t *lock;
+ 
+         hvalue = avc_hash(ssid, tsid, tclass);
+@@ -489,7 +485,7 @@ static struct avc_node *avc_insert(u32 ssid, u32 tsid, u16 tclass,
+         lock = &avc_cache.slots_lock[hvalue];
+ 
+         spin_lock_irqsave(lock, flag);
+-        hlist_for_each_entry(pos, next, head, list)
++        hlist_for_each_entry(pos, head, list)
+         {
+             if ( pos->ae.ssid == ssid &&
+                  pos->ae.tsid == tsid &&
+@@ -620,7 +616,6 @@ static int avc_update_node(u32 perms, u32 ssid, u32 tsid, u16 tclass,
+     unsigned long flag;
+     struct avc_node *pos, *node, *orig = NULL;
+     struct hlist_head *head;
+-    struct hlist_node *next;
+     spinlock_t *lock;
+     
+     node = avc_alloc_node();
+@@ -637,7 +632,7 @@ static int avc_update_node(u32 perms, u32 ssid, u32 tsid, u16 tclass,
+ 
+     spin_lock_irqsave(lock, flag);
+ 
+-    hlist_for_each_entry(pos, next, head, list)
++    hlist_for_each_entry(pos, head, list)
+     {
+         if ( ssid == pos->ae.ssid &&
+              tsid == pos->ae.tsid &&
+@@ -680,7 +675,6 @@ int avc_ss_reset(u32 seqno)
+     unsigned long flag;
+     struct avc_node *node;
+     struct hlist_head *head;
+-    struct hlist_node *next;
+     spinlock_t *lock;
+ 
+     for ( i = 0; i < AVC_CACHE_SLOTS; i++ )
+@@ -690,7 +684,7 @@ int avc_ss_reset(u32 seqno)
+ 
+         spin_lock_irqsave(lock, flag);
+         rcu_read_lock(&avc_rcu_lock);
+-        hlist_for_each_entry(node, next, head, list)
++        hlist_for_each_entry(node, head, list)
+             avc_node_delete(node);
+         rcu_read_unlock(&avc_rcu_lock);
+         spin_unlock_irqrestore(lock, flag);
+-- 
+2.1.4
+

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -19,6 +19,7 @@ SRC_URI_append = " \
     file://kconfig-grant-table.patch \
     file://kconfig-grant-table-v2-interface.patch \
     file://kconfig-grant-table-exotic.patch \
+    file://unfork-linux-lists.patch \
     file://hvm-pm-hibernate-s-state.patch;patch=1 \
     file://prune-vga-acpi-dev.patch;patch=1 \
     file://smbios.patch;patch=1 \


### PR DESCRIPTION
Add patch to switch Xen to use modern Linux's list macros and simplify
tracking upstream Linux's header files involved.

Xen's list headers were forked from Linux a long time ago and at this point
are missing significant updates. Bring in the current Linux files and apply
only the minimum necessary changes to them to enable use within Xen.

This change separates out the RCU list functions into a separate header,
rculist.h, as per Linux. Likewise the poison values are moved into a
separate header, as per Linux, so that they are available to both list.h
and rculist.h.

Xen's unique additions to its version of list.h are moved into a
new separate header, list_xen.h, in order to simplify keeping the contents
of Xen's list.h exactly in sync with Linux's list.h.

Necessary macros are imported from Linux's compiler.h into Xen's, with
minor changes to avoid ratholing into causing further imports.

Linux removed the list_for_each_rcu macro, replacing all uses of it with
list_for_each_entry_rcu, so do the same to the one call site Xen has
within arch/x86/mm/mem_sharing.c.

The hlist macros also changed to drop an unnecessary argument, so
apply that change too -- only affects xsm/flask/avc.c.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>