### PR TITLE
OXT-1627: [hvmloader] Pass ipxe ROM to hvmloader

### DIFF
--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -118,6 +118,7 @@ RDEPENDS_${PN} = " \
     tpm2-tools \
     ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', 'xen-blktap xen-libblktapctl xen-libvhd', 'blktap3', d)} \
     pesign \
+    ipxe \
 "
 
 # OE upgrade - temporarly disabled:

--- a/recipes-extended/ipxe/ipxe_%.bbappend
+++ b/recipes-extended/ipxe/ipxe_%.bbappend
@@ -20,4 +20,5 @@ EXTRA_OEMAKE_append = " HOST_CFLAGS='${BUILD_CFLAGS} ${BUILD_LDFLAGS}'"
 
 do_compile_append() {
     oe_runmake bin/intel.rom
+    oe_runmake bin/82540em.rom
 }

--- a/recipes-extended/xen/files/hvmloader-legacy-seabios-optionroms.patch
+++ b/recipes-extended/xen/files/hvmloader-legacy-seabios-optionroms.patch
@@ -108,7 +108,7 @@ PATCHES
  echo "};"
 --- a/tools/firmware/hvmloader/seabios.c
 +++ b/tools/firmware/hvmloader/seabios.c
-@@ -25,10 +25,22 @@
+@@ -25,10 +25,23 @@
  #include "util.h"
  
  #include "smbios_types.h"
@@ -127,11 +127,12 @@ PATCHES
 +#include "roms.inc"
 +
 +#define SEABIOS_OPTIONROM_PHYSICAL_END 0x000EA000
++#define OPTIONROM_PHYSICAL_ADDRESS     0x000C8000
 +
  struct seabios_info {
      char signature[14]; /* XenHVMSeaBIOS\0 */
      uint8_t length;     /* Length of this struct */
-@@ -130,9 +142,11 @@ static void seabios_setup_e820(void)
+@@ -130,9 +143,11 @@ static void seabios_setup_e820(void)
      dump_e820_table(e820, info->e820_nr);
  }
  
@@ -144,7 +145,7 @@ PATCHES
  {
      unsigned int bios_dest = 0x100000 - bios_length;
  
-@@ -140,12 +154,76 @@ static void seabios_load(const struct bi
+@@ -140,12 +155,79 @@ static void seabios_load(const struct bi
      memcpy((void *)bios_dest, bios_addr, bios_length);
      seabios_config.bios_address = bios_dest;
      seabios_config.image_size = bios_length;
@@ -188,6 +189,9 @@ PATCHES
 +    if ( ipxe_module_addr )
 +    {
 +        etherboot_phys_addr = VGABIOS_PHYSICAL_ADDRESS + vgabios_sz;
++        if ( etherboot_phys_addr < OPTIONROM_PHYSICAL_ADDRESS )
++            etherboot_phys_addr = OPTIONROM_PHYSICAL_ADDRESS;
++
 +        /* round address at 2k boundary for BIOS ROM scanning */
 +        etherboot_phys_addr = (etherboot_phys_addr + 0x7ff) & ~0x7ff;
 +        etherboot_sz = scan_etherboot_nic(SEABIOS_OPTIONROM_PHYSICAL_END,
@@ -222,3 +226,22 @@ PATCHES
  
      .bios_load = seabios_load,
  
+--- a/tools/firmware/hvmloader/hvmloader.c
++++ b/tools/firmware/hvmloader/hvmloader.c
+@@ -363,9 +363,15 @@ int main(void)
+     bios_module = get_module_entry(hvm_start_info, "firmware");
+     if ( bios_module )
+     {
++        const struct hvm_modlist_entry *ipxe;
++        uint32_t ipxe_paddr = 0;
+         uint32_t paddr = bios_module->paddr;
++
++        ipxe = get_module_entry(hvm_start_info, "ipxe");
++        if ( ipxe )
++            ipxe_paddr = ipxe->paddr;
+ 
+-        bios->bios_load(bios, (void *)paddr, bios_module->size, NULL);
++        bios->bios_load(bios, (void *)paddr, bios_module->size, (void*)ipxe_paddr);
+     }
+ #ifdef ENABLE_ROMBIOS
+     else if ( bios == &rombios_config )

--- a/recipes-extended/xen/files/libxl-seabios-ipxe.patch
+++ b/recipes-extended/xen/files/libxl-seabios-ipxe.patch
@@ -1,0 +1,75 @@
+################################################################################
+SHORT DESCRIPTION: 
+################################################################################
+Modify libxl to pass ipxe ROM for seabios.
+
+################################################################################
+LONG DESCRIPTION: 
+################################################################################
+Upstream xen only supports passing the ipxe file to hvmloader if we're using
+rombios. Because we use seabios, we need to disable the check for rombios
+so we can use --with-system-ipxe, and enable the codepath if the bios we're
+using is seabios in libxl_dom.c
+################################################################################
+CHANGELOG 
+################################################################################
+
+################################################################################
+REMOVAL 
+################################################################################
+None
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+None
+
+################################################################################
+INTERNAL DEPENDENCIES 
+################################################################################
+
+################################################################################
+PATCHES 
+################################################################################
+
+--- a/tools/configure.ac
++++ b/tools/configure.ac
+@@ -266,10 +266,6 @@ AC_ARG_WITH([system-ipxe],
+ ],[])
+ AS_IF([test "x$ipxe" = "xy" -o -n "$ipxe_path" ], [
+ 
+-    AS_IF([test "x$enable_rombios" = "xno"], [
+-        AC_MSG_ERROR([Rombios is required to use IPXE])
+-    ], [])
+-
+     AC_DEFINE_UNQUOTED([IPXE_PATH],
+                        ["${ipxe_path:-$XENFIRMWAREDIR/ipxe.bin}"],
+                        [IPXE path])
+--- a/tools/libxl/libxl_dom.c
++++ b/tools/libxl/libxl_dom.c
+@@ -1150,7 +1150,8 @@ static int libxl__domain_firmware(libxl_
+     }
+ 
+     if (info->type == LIBXL_DOMAIN_TYPE_HVM &&
+-        info->u.hvm.bios == LIBXL_BIOS_TYPE_ROMBIOS &&
++        (info->u.hvm.bios == LIBXL_BIOS_TYPE_ROMBIOS ||
++         info->u.hvm.bios == LIBXL_BIOS_TYPE_SEABIOS) &&
+         libxl__ipxe_path()) {
+         const char *fp = libxl__ipxe_path();
+         rc = xc_dom_module_file(dom, fp, "ipxe");
+--- a/tools/configure
++++ b/tools/configure
+@@ -4622,13 +4622,6 @@ fi
+ if test "x$ipxe" = "xy" -o -n "$ipxe_path" ; then :
+ 
+ 
+-    if test "x$enable_rombios" = "xno"; then :
+-
+-        as_fn_error $? "Rombios is required to use IPXE" "$LINENO" 5
+-
+-fi
+-
+-
+ cat >>confdefs.h <<_ACEOF
+ #define IPXE_PATH "${ipxe_path:-$XENFIRMWAREDIR/ipxe.bin}"
+ _ACEOF

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -98,6 +98,7 @@ SRC_URI_append = " \
     file://argo-add-viptables.patch \
     file://argo-fix-full-ring-write-bug.patch \
     file://argo-fix-requeue-msg-len-bug.patch \
+    file://libxl-seabios-ipxe.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -90,7 +90,7 @@ EXTRA_OEMAKE += "CONFIG_IOEMU=n"
 EXTRA_OEMAKE += "CONFIG_TESTS=n"
 EXTRA_OEMAKE += "DESTDIR=${D}"
 
-EXTRA_OECONF += " --enable-blktap2 "
+EXTRA_OECONF += " --enable-blktap2 --with-system-ipxe=/usr/share/firmware/82540em.rom "
 
 #Make sure we disable all compiler optimizations to avoid a nasty segfault in the 
 #reboot case.


### PR DESCRIPTION
  With Xen 4.12, etherboot is no longer built with hvmloader.
  The expectation is to use a separate ipxe ROM and pass it along
  to hvmloader via libxl. This patch completes the codepath for
  seabios so that we can pass along a ROM from ipxe.bb to use
  for guest pxe booting.

  OXT-1627

Signed-off-by: Chris <rogersc@ainfosec.com>