### PR TITLE
S9: OXT-1623: libxl: add back stubdom check for helper kill

### DIFF
--- a/recipes-extended/xen/files/libxl-disable-json-updates.patch
+++ b/recipes-extended/xen/files/libxl-disable-json-updates.patch
@@ -49,7 +49,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_internal.h
 +++ b/tools/libxl/libxl_internal.h
-@@ -3604,7 +3604,7 @@ _hidden void libxl__bootloader_run(libxl
+@@ -3606,7 +3606,7 @@ _hidden void libxl__bootloader_run(libxl
          libxl__prepare_ao_device(ao, aodev);                            \
          aodev->action = LIBXL__DEVICE_ACTION_ADD;                       \
          aodev->callback = device_addrm_aocomplete;                      \

--- a/recipes-extended/xen/files/libxl-disable-vnc-query-when-disabled.patch
+++ b/recipes-extended/xen/files/libxl-disable-vnc-query-when-disabled.patch
@@ -35,7 +35,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_qmp.c
 +++ b/tools/libxl/libxl_qmp.c
-@@ -1296,7 +1296,7 @@ int libxl__qmp_initializations(libxl__gc
+@@ -1301,7 +1301,7 @@ int libxl__qmp_initializations(libxl__gc
          ret = qmp_change(gc, qmp, "vnc", "password", vnc->passwd);
          qmp_write_domain_console_item(gc, domid, "vnc-pass", vnc->passwd);
      }

--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -173,7 +173,7 @@ PATCHES
      dds->domain_finished = 1;
      destroy_finish_check(egc, dds);
  }
-@@ -1131,8 +1140,11 @@ void libxl__destroy_domid(libxl__egc *eg
+@@ -1135,8 +1144,11 @@ void libxl__destroy_domid(libxl__egc *eg
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -73,7 +73,7 @@ PATCHES
  
  /* from libxl_dtdev */
  
-@@ -3907,6 +3914,7 @@ struct libxl__destroy_domid_state {
+@@ -3909,6 +3916,7 @@ struct libxl__destroy_domid_state {
      libxl__devices_remove_state drs;
      libxl__destroy_devicemodel_state ddms;
      libxl__ev_child destroyer;
@@ -173,7 +173,7 @@ PATCHES
      dds->domain_finished = 1;
      destroy_finish_check(egc, dds);
  }
-@@ -1105,8 +1114,11 @@ void libxl__destroy_domid(libxl__egc *eg
+@@ -1131,8 +1140,11 @@ void libxl__destroy_domid(libxl__egc *eg
          goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -385,7 +385,7 @@ PATCHES
  /* libxl__device_destroy_tapdisk:
   *   Destroys any tapdisk process associated with the backend represented
   *   by be_path.
-@@ -1987,6 +1990,7 @@ _hidden int libxl__qmp_restore(libxl__gc
+@@ -1989,6 +1992,7 @@ _hidden int libxl__qmp_restore(libxl__gc
  /* Set dirty bitmap logging status */
  _hidden int libxl__qmp_set_global_dirty_log(libxl__gc *gc, int domid, bool enable);
  _hidden int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid, const libxl_device_disk *disk);
@@ -395,7 +395,7 @@ PATCHES
  /* Query the bitmap of CPUs */
 --- a/tools/libxl/libxl_qmp.c
 +++ b/tools/libxl/libxl_qmp.c
-@@ -1067,6 +1067,17 @@ int libxl__qmp_set_global_dirty_log(libx
+@@ -1072,6 +1072,17 @@ int libxl__qmp_set_global_dirty_log(libx
                             NULL, NULL);
  }
  
@@ -413,7 +413,7 @@ PATCHES
  int libxl__qmp_insert_cdrom(libxl__gc *gc, int domid,
                              const libxl_device_disk *disk)
  {
-@@ -1076,6 +1087,7 @@ int libxl__qmp_insert_cdrom(libxl__gc *g
+@@ -1081,6 +1092,7 @@ int libxl__qmp_insert_cdrom(libxl__gc *g
      QMP_PARAMETERS_SPRINTF(&args, "device", "ide-%i", dev_number);
  
      if (disk->format == LIBXL_DISK_FORMAT_EMPTY) {

--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -113,37 +113,41 @@ PATCHES
      libxl__store_libxl_entry(gc, dm_domid, "stubdom-version",
 --- a/tools/libxl/libxl_domain.c
 +++ b/tools/libxl/libxl_domain.c
-@@ -1020,11 +1020,41 @@ static void domain_destroy_domid_cb(libx
+@@ -1020,11 +1020,45 @@ static void domain_destroy_domid_cb(libx
                                      libxl__ev_child *destroyer,
                                      pid_t pid, int status);
  
 +static void kill_openxt_helpers(libxl__gc *gc, uint32_t dm_domid)
 +{
 +    char *pid;
++    int rc;
 +
 +    /* Kill qmp-helper */
 +    pid = libxl__xs_read(gc, XBT_NULL,
 +                         GCSPRINTF("/local/domain/%d/"XS_QMP_PID, dm_domid));
-+    if (!pid)
-+        LOG(ERROR, "Cannot get qmp_helper pid for domain %d", dm_domid);
-+    else
-+        kill(strtol(pid, NULL, 10), SIGKILL);
++    if (pid) {
++        rc = kill(strtol(pid, NULL, 10), SIGKILL);
++        if (rc < 0)
++            LOG(ERROR, "Failed to kill qmp_helper for domain %d", dm_domid);
++    }
 +
 +    /* Kill atapi-pt-helper */
 +    pid = libxl__xs_read(gc, XBT_NULL,
 +                         GCSPRINTF("/local/domain/%d/"XS_ATAPI_PT_PID, dm_domid));
-+    if (!pid)
-+        LOG(ERROR, "Cannot get atapi-pt_helper pid for domain %d", dm_domid);
-+    else
-+        kill(strtol(pid, NULL, 10), SIGKILL);
++    if (pid) {
++        rc = kill(strtol(pid, NULL, 10), SIGKILL);
++        if (rc < 0)
++            LOG(ERROR, "Failed to kill atapi-pt_helper for domain %d", dm_domid);
++    }
 +
 +    /* Kill audio-helper */
 +    pid = libxl__xs_read(gc, XBT_NULL,
 +                         GCSPRINTF("/local/domain/%d/"XS_AUDIO_PID, dm_domid));
-+    if (!pid)
-+        LOG(ERROR, "Cannot get audio_helper pid for domain %d", dm_domid);
-+    else
-+        kill(strtol(pid, NULL, 10), SIGKILL);
++    if (pid) {
++        rc = kill(strtol(pid, NULL, 10), SIGKILL);
++        if (rc < 0)
++            LOG(ERROR, "Failed to kill audio_helper for domain %d", dm_domid);
++    }
 +}
 +
  void libxl__destroy_domid(libxl__egc *egc, libxl__destroy_domid_state *dis)
@@ -155,7 +159,7 @@ PATCHES
      char *dom_path;
      int rc, dm_present;
  
-@@ -1042,7 +1072,8 @@ void libxl__destroy_domid(libxl__egc *eg
+@@ -1042,7 +1076,8 @@ void libxl__destroy_domid(libxl__egc *eg
  
      switch (libxl__domain_type(gc, domid)) {
      case LIBXL_DOMAIN_TYPE_HVM:
@@ -165,7 +169,7 @@ PATCHES
              dm_present = 0;
              break;
          }
-@@ -1079,6 +1110,9 @@ void libxl__destroy_domid(libxl__egc *eg
+@@ -1079,6 +1114,9 @@ void libxl__destroy_domid(libxl__egc *eg
          libxl__destroy_device_model(egc, &dis->ddms);
          return;
      } else {

--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -165,12 +165,13 @@ PATCHES
              dm_present = 0;
              break;
          }
-@@ -1079,6 +1110,8 @@ void libxl__destroy_domid(libxl__egc *eg
+@@ -1079,6 +1110,9 @@ void libxl__destroy_domid(libxl__egc *eg
          libxl__destroy_device_model(egc, &dis->ddms);
          return;
      } else {
 +        /* OpenXT: if the domain has a stubdom, we kill the stubdom helpers here */
-+        kill_openxt_helpers(gc, stubdom_id);
++        if (stubdom_id)
++            kill_openxt_helpers(gc, stubdom_id);
          dm_destroy_cb(egc, &dis->ddms, 0);
          return;
      }

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -220,7 +220,7 @@ PATCHES
          libxl__destroy_domid(egc, &dds->stubdom);
      } else {
          dds->stubdom_finished = 1;
-@@ -1824,7 +1833,7 @@ int libxl_retrieve_domain_configuration(
+@@ -1820,7 +1829,7 @@ int libxl_retrieve_domain_configuration(
                          break;
                  }
  

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -220,7 +220,7 @@ PATCHES
          libxl__destroy_domid(egc, &dds->stubdom);
      } else {
          dds->stubdom_finished = 1;
-@@ -1820,7 +1829,7 @@ int libxl_retrieve_domain_configuration(
+@@ -1824,7 +1833,7 @@ int libxl_retrieve_domain_configuration(
                          break;
                  }
  


### PR DESCRIPTION
OXT-1623

This check was missed when upgrading from xen-4.11

Signed-off-by: Mahantesh Salimath <salimathm@ainfosec.com>