### PR TITLE
S9: OXT-1562: xinitrc: Create & export XDG_RUNTIME_DIR

### DIFF
--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/xinitrc
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/xinitrc
@@ -44,6 +44,16 @@ if test "x$XDG_CACHE_HOME" = "x" ; then
 fi
 [ -d "$XDG_CACHE_HOME" ] || mkdir "$XDG_CACHE_HOME"
 
+# $XDG_RUNTIME_DIR defines the base directory relative to which user specific
+# non-essential runtime files and other file objects should be stored.
+# uim uses this - setting it silences "uim_helper_get_pathname() failed"
+if test "x$XDG_RUNTIME_DIR" = "x" ; then
+  XDG_RUNTIME_DIR=/run/user/$UID
+  export XDG_RUNTIME_DIR
+fi
+[ -d "$XDG_RUNTIME_DIR" ] || mkdir -p "$XDG_RUNTIME_DIR"
+chmod 0700 "$XDG_RUNTIME_DIR"
+
 # set up XDG user directores.  see
 # http://freedesktop.org/wiki/Software/xdg-user-dirs
 if which xdg-user-dirs-update >/dev/null 2>&1; then


### PR DESCRIPTION
This is the stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1201

XDG_RUNTIME_DIR is a standard enironment variable that software expects
to be set.  Set it, export it, and create the underlying directory.
More info can be found here:
https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

This silences the uim_helper_get_pathname messages from surf in uivm:
VM uivm (3): uim_helper_get_pathname() failed

libuim tries to mkdir(/root/.uim.d/socket), but /root is not writable.
It failes, printing the message.  With XDG_RUNTIME_DIR set, it can
mkdir($XDG_RUNTIME_DIR/uim/socket) which avoids the message.

OXT-1562

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 3d7758679ae382a91aefbd6621511dfd41272573)