### PR TITLE
S9 : OXT-1636 : libnl : fix disabling of network

### DIFF
--- a/recipes-support/libnl/libnl/revert-rtnl-link-change.patch
+++ b/recipes-support/libnl/libnl/revert-rtnl-link-change.patch
@@ -1,0 +1,13 @@
+--- a/lib/route/link.c
++++ b/lib/route/link.c
+@@ -1729,9 +1729,7 @@ int rtnl_link_build_change_request(struc
+ 	    !strcmp(orig->l_name, changes->l_name))
+ 		changes->ce_mask &= ~LINK_ATTR_IFNAME;
+ 
+-	rt = af_request_type(orig->l_family);
+-
+-	if ((err = build_link_msg(rt, &ifi, changes, flags, result)) < 0)
++	if ((err = build_link_msg(RTM_NEWLINK, &ifi, changes, flags, result)) < 0)
+ 		goto errout;
+ 
+ 	return 0;

--- a/recipes-support/libnl/libnl_3.2.29.bbappend
+++ b/recipes-support/libnl/libnl_3.2.29.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += " \
+    file://revert-rtnl-link-change.patch \
+"


### PR DESCRIPTION
OXT-1636

Unchecking the Enable Networking button under Network icon is broken.
With the network disabled, guests (with wired networking) are still able to access the internet.
This is essentially because NetworkManager fails to bring the brbridged interface down.
NetworkManager uses libnl to bring an interface up or down, in case of bringing brbridged down,
libnl gives an error (-NLE_OPNOTSUPP) of operation not supported.

In stable-7 branch this feature is working. libnl version in stable-7 is 3.2.25
The current version is 3.2.29. The change that is causing this issue is the first argument
that is passed to the function build_link_msg(), it used to be RTM_NEWLINK, now for brbridged
it is essentially RTM_SETLINK. This PR reverts this change to fix our issue.

Looking at the description for rtnl_link_change()/rtnl_link_build_change_request() functions,
it is clear that if  msg fails with -NLE_OPNOTSUPP when msg type is RTM_NEWLINK,
the operation is retried with msg type altered to RTM_SETLINK. This is because RTM_NEWLINK is supposed to work for newer linux kernels and RTM_SETLINK for older ones.

Signed-off-by: Mahantesh Salimath <salimathm@ainfosec.com>