### PR TITLE
S9: SyncVM fixes

### DIFF
--- a/recipes-core/base-files/files/xenclient-syncvm/fstab
+++ b/recipes-core/base-files/files/xenclient-syncvm/fstab
@@ -1,12 +1,14 @@
 proc            /proc                   proc    defaults                0  0
-xenfs           /proc/xen               xenfs   defaults                0  0
-devpts          /dev/pts                devpts  mode=0620,gid=5         0  0
-tmpfs           /var/volatile           tmpfs   defaults,size=1M        0  0
+sysfs           /sys                    sysfs   nosuid,noexec,nodev     0  0
+devtmpfs        /dev                    devtmpfs    mode=0755,nosuid    0  0
+tmpfs           /run                    tmpfs   defaults,size=5M        0  0
+tmpfs           /var/volatile           tmpfs   defaults,size=100M      0  0
 tmpfs           /var/cache              tmpfs   defaults,size=100M      0  0
-tmpfs           /var/lock               tmpfs   defaults,size=1M        0  0
-tmpfs           /var/run                tmpfs   defaults,size=1M        0  0
-tmpfs           /var/log                tmpfs   defaults,size=10M       0  0
-tmpfs           /tmp                    tmpfs   defaults,size=100M      0  0
+xenfs           /proc/xen               xenfs   defaults                0  0
+
+rootfs          /                       auto    defaults,ro,noatime     1  1
+
+devpts          /dev/pts                devpts  mode=0620,gid=5         0  0
 
 tmpfs           /dev/shm                tmpfs   mode=0777,size=1M       0  0
 tmpfs           /media/ram              tmpfs   defaults,size=1M        0  0

--- a/recipes-core/base-files/files/xenclient-syncvm/fstab.early
+++ b/recipes-core/base-files/files/xenclient-syncvm/fstab.early
@@ -1,0 +1,7 @@
+proc            /proc                   proc    defaults                0  0
+sysfs           /sys                    sysfs   nosuid,noexec,nodev     0  0
+devtmpfs        /dev                    devtmpfs    mode=0755,nosuid    0  0
+tmpfs           /run                    tmpfs   defaults,size=5M        0  0
+tmpfs           /var/volatile           tmpfs   defaults,size=100M      0  0
+tmpfs           /var/cache              tmpfs   defaults,size=100M      0  0
+xenfs           /proc/xen               xenfs   defaults                0  0

--- a/recipes-core/images/xenclient-syncvm-image.bb
+++ b/recipes-core/images/xenclient-syncvm-image.bb
@@ -52,8 +52,6 @@ post_rootfs_shell_commands() {
 
     # TODO: This can be handled through populate-volatiles.sh
     # Create read-only rootfs required links.
-    rm -f ${IMAGE_ROOTFS}/etc/resolv.conf;
-    ln -s /var/volatile/etc/resolv.conf ${IMAGE_ROOTFS}/etc/resolv.conf;
     rm -f ${IMAGE_ROOTFS}/etc/network/interfaces;
     ln -s /var/volatile/etc/network/interfaces ${IMAGE_ROOTFS}/etc/network/interfaces;
 }

--- a/recipes-core/images/xenclient-syncvm-image.bb
+++ b/recipes-core/images/xenclient-syncvm-image.bb
@@ -49,11 +49,6 @@ post_rootfs_shell_commands() {
 
     # Trick to resolve dom0 name with V4V.
     echo '1.0.0.0 dom0' >> ${IMAGE_ROOTFS}/etc/hosts;
-
-    # TODO: This can be handled through populate-volatiles.sh
-    # Create read-only rootfs required links.
-    rm -f ${IMAGE_ROOTFS}/etc/network/interfaces;
-    ln -s /var/volatile/etc/network/interfaces ${IMAGE_ROOTFS}/etc/network/interfaces;
 }
 ROOTFS_POSTPROCESS_COMMAND += "post_rootfs_shell_commands; "
 

--- a/recipes-openxt/libicbinn/pyicbinn_git.bb
+++ b/recipes-openxt/libicbinn/pyicbinn_git.bb
@@ -11,7 +11,7 @@ SRCREV = "${AUTOREV}"
 SRC_URI = "git://${OPENXT_GIT_MIRROR}/icbinn.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 
 DEPENDS = "swig-native libicbinn-resolved xenclient-rpcgen-native"
-RDEPENDS_${PN} += "python-lang"
+RDEPENDS_${PN} += "python-lang python-importlib"
 
 inherit distutils
 inherit xenclient

--- a/recipes-openxt/xenclient-syncvm-tweaks/xenclient-syncvm-tweaks-1.0/network-config.initscript
+++ b/recipes-openxt/xenclient-syncvm-tweaks/xenclient-syncvm-tweaks-1.0/network-config.initscript
@@ -37,7 +37,7 @@ netmask $(domstore_read network/netmask)
 gateway $(domstore_read network/gateway)
 EOF
 
-    cat <<EOF > /var/volatile/etc/resolv.conf
+    cat <<EOF > /etc/resolv.conf
 nameserver $(domstore_read network/dns)
 EOF
 

--- a/recipes-openxt/xenclient-syncvm-tweaks/xenclient-syncvm-tweaks-1.0/volatiles
+++ b/recipes-openxt/xenclient-syncvm-tweaks/xenclient-syncvm-tweaks-1.0/volatiles
@@ -1,2 +1,3 @@
 d root root 0755 /var/volatile/etc/network none
-f root root 0644 /var/volatile/etc/network/interfaces none
+l root root 0644 /etc/network/interfaces /var/volatile/etc/network/interfaces
+f root root 0644 /etc/network/interfaces none


### PR DESCRIPTION
This is the stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1195

The syncvm image is a little broken. This PR provides some fixes.

syncvm was using the default SELinux fstab.early, but syncvm doesn't run SELinux. Additionally, the regular fstab was incorrect. Fix up both of those. One symptom was sshd failed to start, so you couldn't sshv4v in.

We also have some fixes for setting up volatiles.

sync-client wasn't running since pyicbinn couldn't import importlib. Fix that dependency.