### PR TITLE
S9: OXT-1628: Uprev libtirpc to 1.1.4

### DIFF
--- a/recipes-extended/libtirpc/libtirpc_1.1.4.bb
+++ b/recipes-extended/libtirpc/libtirpc_1.1.4.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Transport-Independent RPC library"
+DESCRIPTION = "Libtirpc is a port of Suns Transport-Independent RPC library to Linux"
+SECTION = "libs/network"
+HOMEPAGE = "http://sourceforge.net/projects/libtirpc/"
+BUGTRACKER = "http://sourceforge.net/tracker/?group_id=183075&atid=903784"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=f835cce8852481e4b2bbbdd23b5e47f3 \
+                    file://src/netname.c;beginline=1;endline=27;md5=f8a8cd2cb25ac5aa16767364fb0e3c24"
+
+PROVIDES = "virtual/librpc"
+
+SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tar.bz2"
+
+SRC_URI[md5sum] = "f5d2a623e9dfbd818d2f3f3a4a878e3a"
+SRC_URI[sha256sum] = "2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d"
+
+inherit autotools pkgconfig
+
+EXTRA_OECONF = "--disable-gssapi"
+
+do_install_append() {
+        chown root:root ${D}${sysconfdir}/netconfig
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
With pyicbinn linked with -Bsymbolic, sync-client segfaulted with:
VM syncvm (5): [ 18.669233] python[555]: segfault at 0 ip 0000000000000000 sp 00007ffe5a6c1328 error 14 in python2.7[400000+1000]
VM syncvm (5): [ 18.669247] Code: Bad RIP value.

Upreving libtirpc to 1.1.4 avoids the segfault.