### PR TITLE
txt-info: Remove useless statement in KBuild

### DIFF
--- a/recipes-openxt/txt-info-module/files/sources/Kbuild
+++ b/recipes-openxt/txt-info-module/files/sources/Kbuild
@@ -1,4 +1,3 @@
 obj-m += txt_info.o
-vsock_txt_info-y += txt_info.o
 
 ccflags-y := -I$(src)/include


### PR DESCRIPTION
Remove meaningless statement (copy-paste/replace) in KBuild.
No functional change.