### PR TITLE
OXT-1577: udev: fix cdrom eject by disabling locking of cdrom devices

### DIFF
--- a/recipes-core/eudev/eudev/disable-cdrom-lock.patch
+++ b/recipes-core/eudev/eudev/disable-cdrom-lock.patch
@@ -1,0 +1,21 @@
+--- a/rules/60-cdrom_id.rules
++++ b/rules/60-cdrom_id.rules
+@@ -8,12 +8,12 @@ ENV{DEVTYPE}!="disk", GOTO="cdrom_end"
+ # unconditionally tag device as CDROM
+ KERNEL=="sr[0-9]*", ENV{ID_CDROM}="1"
+ 
+-# media eject button pressed
+-ENV{DISK_EJECT_REQUEST}=="?*", RUN+="cdrom_id --eject-media $devnode", GOTO="cdrom_end"
+-
+-# import device and media properties and lock tray to
+-# enable the receiving of media eject button events
+-IMPORT{program}="cdrom_id --lock-media $devnode"
++# import device and media properties.
++# OXT: device is not locked, it is typically locked to enable reception of
++# media eject button events. In OpenXT media eject button event is
++# never triggered. Hence, no need to handle eject button event either.
++# (handled by executing 'cdrom_id --eject-media $devnode' on event reception).
++IMPORT{program}="cdrom_id $devnode"
+ 
+ # ejecting a CD does not remove the device node, so mark the systemd device
+ # unit as inactive while there is no medium; this automatically cleans up of

--- a/recipes-core/eudev/eudev_%.bbappend
+++ b/recipes-core/eudev/eudev_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+  file://disable-cdrom-lock.patch \
+  "


### PR DESCRIPTION
OXT-1577

Currently udev locks the cdrom device and on pressing the physical eject button the cd-tray doesn't open. Typically udev should recieve an event (DISK_EJECT_REQUEST) on pressing the physical eject button, but in OpenXT it doesn't. The only way now to fix this is to not lock the cdrom device.

cdrom_id is used by udev to get device information and capabilities, this info is used to create symlinks like /dev/cdrom or /dev/dvd. Also, cdrom_id is used to lock the device. This PR removes the argument to lock the device. Locking was basically done to recieve DISK_EJECT_REQUEST event, as this event is not getting triggered there is no use of locking.

Note: If mounted, care should be taken to unmount the device before pressing eject button.

Signed-off-by: Mahantesh Salimath <salimathm@ainfosec.com>