### PR TITLE
cross recipe: renaming initramfs.gz to initrd

### DIFF
--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
@@ -121,7 +121,7 @@ parse_eficfg() {
         [ -z "$tboot" ] && tboot=$(echo -n $line | grep "tboot" | sed 's/tboot=/\/boot\/tboot /g')
         [ -z "$xen" ] && xen=$(echo -n $line | grep "options" | sed 's/options=/\/boot\/xen.efi /g')
         [ -z "$linux" ] && linux=$(echo -n $line | grep "kernel" | sed 's/kernel=/\/boot\/bzImage /g')
-        [ -z "$initrd" ] && initrd=$(echo -n $line | grep "ramdisk" | sed 's/ramdisk=/\/boot\/initramfs.gz /g')
+        [ -z "$initrd" ] && initrd=$(echo -n $line | grep "ramdisk" | sed 's/ramdisk=/\/boot\/initrd /g')
         [ -z "$xsm" ] && xsm=$(echo -n $line | grep "xsm" | sed 's/xsm=/\/etc\/xen\/xenrefpolicy\/policy\/policy.24 /g')
         [ -z "$ucode" ] && ucode=$(echo -n $line | grep "ucode" | sed 's/ucode=/\/boot\/microcode_intel.bin /g')
     done

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -99,7 +99,7 @@ pcr4_objs=(
 )
 pcr8_objs=(
     /usr/share/xenclient/bootloader/openxt.cfg
-    /boot/initramfs.gz
+    /boot/initrd
     /etc/xen/xenrefpolicy/policy/policy.24
     /boot/microcode_intel.bin
 )

--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/grub.cfg
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/grub.cfg
@@ -39,7 +39,7 @@ menuentry "XenClient: Normal" {
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
         module /boot/bzImage $LINUX_COMMON_CMD autostart
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN
@@ -65,7 +65,7 @@ menuentry "XenClient Technical Support Option: Safe graphics" {
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
         module /boot/bzImage $LINUX_COMMON_CMD autostart safe-graphic nomodeset
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN
@@ -88,7 +88,7 @@ menuentry "XenClient Technical Support Option: Safe Mode (no autostart of VMs)" 
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
         module /boot/bzImage $LINUX_COMMON_CMD
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN
@@ -112,7 +112,7 @@ menuentry "XenClient Technical Support Option: Safe Mode with AMT serial" {
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,amt
         module /boot/bzImage $LINUX_COMMON_CMD
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN
@@ -136,7 +136,7 @@ menuentry "XenClient Technical Support Option: Normal Mode with synchronised con
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci sync_console
         module /boot/bzImage $LINUX_COMMON_CMD autostart
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN
@@ -160,7 +160,7 @@ menuentry "XenClient Technical Support Option: console access" {
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1 com1=115200,8n1,pci
         module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon runlevel=3
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN
@@ -184,7 +184,7 @@ menuentry "XenClient Technical Support Option: console access with AMT serial" {
         multiboot /boot/tboot.gz $TBOOT_COMMON_CMD
         module /boot/xen-debug.gz $XEN_COMMON_CMD console=com1,vga com1=115200,8n1,amt
         module /boot/bzImage $LINUX_COMMON_CMD console=tty0 fbcon runlevel=3
-        module /boot/initramfs.gz
+        module /boot/initrd
         module /boot/GM45_GS45_PM45_SINIT_51.BIN
         module /boot/Q35_SINIT_51.BIN
         module /boot/Q45_Q43_SINIT_51.BIN

--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
@@ -7,29 +7,29 @@ ucode=microcode_intel.bin
 [openxt-normal]
 options=placeholder console=com1 dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 autostart
-ramdisk=initramfs.gz
+ramdisk=initrd
 xsm=policy.24
  
 [openxt-support-safe-graphics]
 options=console=com1 dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 safe-graphic nomodeset
-ramdisk=initramfs.gz
+ramdisk=initrd
 xsm=policy.24
 
 [openxt-support-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0
-ramdisk=initramfs.gz
+ramdisk=initrd
 xsm=policy.24
 
 [openxt-support-console]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
-ramdisk=initramfs.gz
+ramdisk=initrd
 xsm=policy.24
 
 [openxt-support-console-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
 kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
-ramdisk=initramfs.gz
+ramdisk=initrd
 xsm=policy.24


### PR DESCRIPTION
OpenEmbedded classes and recipes follow the convention that an image's
init image is called initrd when built into the image. In order to
better use OpenEmbedded's existing tooling it is helpful to follow then
naming convention of the init image.

This is a cross cutting change that must be made in a single commit. As
a result this make the appropriate changes across the supporting files
for both openxt-measuredlaunch and xenclient-dom0-tweaks.

This is tied to OpenXT/installer#114

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>