### PR TITLE
Initscript cleanup

### DIFF
--- a/recipes-core/images/xenclient-syncvm-image.bb
+++ b/recipes-core/images/xenclient-syncvm-image.bb
@@ -20,6 +20,8 @@ export IMAGE_BASENAME = "xenclient-syncvm-image"
 COMPATIBLE_MACHINE = "(xenclient-syncvm)"
 
 INITSCRIPT_REMOVE = " \
+    finish.sh \
+    rmnologin.sh \
     urandom \
 "
 

--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -116,7 +116,7 @@ RDEPENDS_${PN} = " \
     xen-xenstore \
     tpm2-tss \
     tpm2-tools \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', 'xen-blktap xen-libblktapctl xen-libvhd', 'blktap3', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', 'xen-blktap xen-libblktapctl xen-libvhd', 'blktap3 tapback', d)} \
     pesign \
     ipxe \
 "

--- a/recipes-extended/xen/blktap3.bb
+++ b/recipes-extended/xen/blktap3.bb
@@ -26,8 +26,11 @@ S = "${WORKDIR}/git"
 
 inherit autotools-brokensep xenclient update-rc.d
 
-INITSCRIPT_NAME = "tapback-daemon"
-INITSCRIPT_PARAMS = "defaults 61"
+PACKAGES =+ "tapback"
+
+INITSCRIPT_PACKAGES = "tapback"
+INITSCRIPT_NAME_tapback = "tapback"
+INITSCRIPT_PARAMS_tapback = "defaults 61"
 
 TARGET_CPPFLAGS += "-DTAP_CTL_NO_DEFAULT_CGROUP_SLICE"
 
@@ -39,9 +42,9 @@ do_install_append() {
 	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'false', 'true', d)}; then
 		rm -rf ${D}/usr/lib/systemd
 	fi
-	install -d ${D}/etc/init.d
+	install -d ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/tapback.initscript \
-		${D}/etc/init.d/tapback-daemon
+		${D}${sysconfdir}/init.d/tapback
 }
 
 # QA dev-elf: libvhdio-3.5.0.so does not honor the SOLIBSDEV format.
@@ -54,6 +57,10 @@ FILES_${PN}-dev += " \
 "
 FILES_${PN} += " \
     ${libdir}/libvhdio-*.so \
+"
+FILES_tapback += " \
+    ${bindir}/tapback \
+    ${sysconfdir}/init.d/tapback \
 "
 RDEPENDS_${PN} += "glibc-gconv-utf-16"
 RCONFLICTS_${PN} = "xen-blktap xen-libblktap xen-libblktapctl xen-libvhd"


### PR DESCRIPTION
sycnvm included finish.sh, rmnologin.sh & tapback-daemon initscripts - all of which are unneeded.

finish.sh & rmnologin.sh are just removed.

For tapback, we can create a new subpackage out of blktap3 containing tapback and the initscript (renamed from tapback-daemon to just tapback).  This new package must be installed in dom0 to keep things working.  This means tapback is no longer installed in syncvm or the installer.