### PR TITLE
xen: Amend version number.

### DIFF
--- a/recipes-extended/xen/xen-version.inc
+++ b/recipes-extended/xen/xen-version.inc
@@ -1,3 +1,3 @@
-XEN_PV = "RELEASE-4.12.0"
+XEN_PV = "4.12.1-pre"
 XEN_BRANCH = "stable-4.12"
 XEN_SRCREV = "b4f291b0ca914454cbac9fa5580bb35f8ab04eee"


### PR DESCRIPTION
The commit tracked in `stable-4.12` is post `4.12.0` and is referenced as `4.12.1-pre`. Reflect that on the recipe version number.