### PR TITLE
OXT-1664: Refactor code duplication between packages.

### DIFF
--- a/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
+++ b/recipes-openxt/openxt-keymanagement/openxt-keymanagement/key-functions
@@ -388,24 +388,11 @@ encrypted_unlock() {
     local part="${1}"
     local name="${2}"
     local key_file="${3}"
-    local ret=0
 
-    is_tpm_2_0
-    local tpm2=$?
-    if [ "${tpm2}" -eq 0 ];
-    then
-        if pcr_bank_exists "sha256"; then
-            local unseal_file=${key_file}
-            tpm2_unsealdata -H 0x81000000 -n "${unseal_file}.sha256" -u "${key_file}.pub.sha256" -g 0xB $( < ${unseal_file}.pcrs )| cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
-            ret=$?
-        fi
-    else
-        tpm_unsealdata_sa -z -i $key_file | \
-            cryptsetup -q -d - -S ${ESLOT} luksOpen "${part}" "${name}" >/dev/null 2>&1
-        ret=$?
-    fi
-
-    return $ret
+    # Since the key is read from stdin, `-d -` is absolutely necessary, or
+    # cryptsetup will stop reading it at the first LF character.
+    tpm_unseal "${key_file}" | \
+        cryptsetup -d - -S "${ESLOT}" luksOpen "${part}" "${name}"
 }
 
 remove_own_key() {

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/ml-functions
@@ -666,13 +666,7 @@ mle_success() {
 
 write_config_pcrs() {
     local root="${1:-/}"
-    local pcrs
-
-    if is_tpm_2_0 ; then
-        pcrs="-r 0 -r 1 -r 2 -r 3 -r 4 -r 5 -r 7 -r 8 -r 15 -r 17 -r 18 -r 19"
-    else
-        pcrs="-p 0 -p 1 -p 2 -p 3 -p 4 -p 5 -p 7 -p 8 -p 15 -p 17 -p 18 -p 19"
-    fi
+    local pcrs="0 1 2 3 4 5 7 8 15 17 18 19"
 
     echo "$pcrs" > ${root}/config/config.pcrs
 }

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -68,14 +68,6 @@ pcr_in_selection() {
     return 1
 }
 
-# Usage: read_pcr_selection
-# Sanitize and print the content of file ${config_pcrs} on stdout.
-# ${config_pcrs} is defined in the 'Configurables' section.
-read_pcr_selection() {
-    # strip out -r/-p to leave just the digits
-    sed -e 's/-[rp]//g' "${config_pcrs}"
-}
-
 # Usage rotate_sealed_files
 # Rename the existing sealed key files to *.old.
 rotate_sealed_keyfiles() {
@@ -146,7 +138,7 @@ while getopts ":sufc:t:p:g:b:r:4:8:h" opt; do
 done
 
 # read_pcr_selection will read ${config_pcrs} which can be changed on cmdline.
-pcr_selection="$( read_pcr_selection )"
+pcr_selection="$(cat "${config_pcrs}")"
 
 case "${operation}" in
 seal)

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -57,10 +57,10 @@ EOF
 # ${pcr_selection} is defined in the 'Configurables' section, it contains the
 # list of PCRs defined in ${config_pcrs}.
 pcr_in_selection() {
-    pcr="$1"
+    local pcr="$1"
 
-    for p in $pcr_selection ; do
-        if [ $p -eq $pcr ] ; then
+    for p in ${pcr_selection}; do
+        if [ "${p}" -eq "${pcr}" ]; then
             return 0
         fi
     done
@@ -73,22 +73,34 @@ pcr_in_selection() {
 # ${config_pcrs} is defined in the 'Configurables' section.
 read_pcr_selection() {
     # strip out -r/-p to leave just the digits
-    sed -e 's/-[rp]//g' $config_pcrs
+    sed -e 's/-[rp]//g' "${config_pcrs}"
+}
+
+# Usage rotate_sealed_files
+# Rename the existing sealed key files to *.old.
+rotate_sealed_keyfiles() {
+    local ext
+
+    for ext in {,.pub}.sha1 {,.pub}.sha256; do
+        if [ -e "${sealed_key}${ext}" ]; then
+            mv "${sealed_key}${ext}" "${sealed_key}${ext}.old"
+        fi
+    done
 }
 
 # Globals
-TPM_DEV="$(find /sys/class -name tpm0)/device"
-
-is_tpm_2_0
-tpm2=$?
+hashalg="$(tpm_get_hash_algorithm)"
+if is_tpm_2_0; then
+    tpm2="0"
+else
+    tpm2="1"
+fi
 
 # Configurables
 operation="seal"
 config_key="/config/keys/config.key"
 sealed_key="/boot/system/tpm/config.tss"
 config_pcrs="/config/config.pcrs"
-pcr_selection="$( read_pcr_selection )"
-hashalg="sha1"
 good_pcrs="/config/good.pcrs"
 bad_pcrs="/boot/system/tpm/bad.pcrs"
 root_dev="/dev/mapper/xenclient-root"
@@ -118,127 +130,69 @@ pcr8_objs=(
 )
 
 while getopts ":sufc:t:p:g:b:r:4:8:h" opt; do
-    case $opt in
-    s)
-        operation="seal"
-    ;;
-    u)
-        operation="unseal"
-    ;;
-    f)
-        operation="forward"
-    ;;
-    c)
-        config_key=${OPTARG}
-    ;;
-    t)
-        sealed_key=${OPTARG}
-    ;;
-    p)
-        pcr_list=${OPTARG}
-    ;;
-    g)
-        good_pcrs=${OPTARG}
-    ;;
-    b)
-        bad_pcrs=${OPTARG}
-    ;;
-    r)
-        root_dev=${OPTARG}
-    ;;
-    [48])
-        IFS=', ' read -r -a "pcr${opt}_objs" <<< "${OPTARG}"
-    ;;
-    h)
-        usage
-        exit 0
-    ;;
-    *)
-        err "invalid option: -$opt"
-    ;;
+    case "${opt}" in
+    s) operation="seal" ;;
+    u) operation="unseal" ;;
+    f) operation="forward" ;;
+    c) config_key="${OPTARG}" ;;
+    t) sealed_key="${OPTARG}" ;;
+    p) config_pcrs="${OPTARG}" ;;
+    g) good_pcrs="${OPTARG}" ;;
+    b) bad_pcrs="${OPTARG}" ;;
+    r) root_dev="${OPTARG}" ;;
+    [48]) IFS=', ' read -r -a "pcr${opt}_objs" <<< "${OPTARG}" ;;
+    h) usage
+       exit 0
+       ;;
+    \?) err "unknown option: -${OPTARG}" ;;
+    *) err "getopts falal error" ;;
     esac
 done
 
-case $operation in
+# read_pcr_selection will read ${config_pcrs} which can be changed on cmdline.
+pcr_selection="$( read_pcr_selection )"
+
+case "${operation}" in
 seal)
-    file_exists=1
-    if [ "${tpm2}" -eq 0 ];
-    then
-        sealerr=0
-        seal_file=${config_key}
-        clean_old_tpm_files
-        if pcr_bank_exists "sha256" && [ ${sealerr} -eq 0 ]; then
-            sealout=$(tpm2_sealdata -H 0x81000000 -I ${seal_file} -O ${sealed_key}.sha256 -o ${sealed_key}.pub.sha256 -g 0xB -G 8 -b 0x492 $(cat /config/config.pcrs) 2>&1)
-            sealerr=$?
-        fi
-    else
-        sealout=$(tpm_sealdata_sa -i ${config_key} \
-            -o ${sealed_key} -z $(cat ${pcr_list}) 2>&1)
-        sealerr=$?
+    rotate_sealed_keyfiles
+
+    pcr_params=""
+    for p in ${pcr_selection}; do
+        pcr_params="${pcr_params} -p ${p}"
+    done
+
+    if ! tpm_seal -a "${hashalg}" ${pcr_params} "${config_key}" "${sealed_key}"; then
+        err "failed to seal against PCRs."
     fi
 
-    if [ -e ${sealed_key} ]; then
-        file_exists=0
-    elif [ -e ${sealed_key}.sha256 ]; then
-        file_exists=0
-    else
-        file_exists=1
-    fi
+    rm -f "${bad_pcrs}"
+    tpm_list_pcrs > "${good_pcrs}"
 
-    if [ $sealerr -eq 0 ] && [ -e ${sealed_key} ]; then
-        # store PCR hints for recovery
-        if [ -d "${TPM_DEV}" ]; then
-            [ -f "${bad_pcrs}" ] && rm "${bad_pcrs}"
-            if [ "${tpm2}" -eq 0 ]; then
-                tpm2_pcrlist > "${good_pcrs}"
-            else
-                cat "${TPM_DEV}/pcrs" > "${good_pcrs}"
-            fi
-        fi
-
-        exit 0
-    fi
+    exit 0
 ;;
 forward)
-    [ "${tpm2}" -eq 0 ] && hashalg="sha256"
-
     # PCR4 holds the hashes of OpenXT's EFI applications: shim, xen and dom0 kernel.
     # PCR8 holds the hashes of the other critical components of OpenXT's boot:
     #  openxt.cfg, the initrd and the XSM policy.
     # If PCR8 is all 0 we were not booting with UEFI
-    if [ "${tpm2}" -eq 0 ]; then
-        pcr8=$(tpm2_pcrlist -L sha256:8 | cut -f2 -d: | tr -d ' ' | tail -n1)
-        pcr17=$(tpm2_pcrlist -L sha256:17 | cut -f2 -d: | tr -d ' ' | tail -n1)
-    else
-        pcr8=$(grep PCR-08 ${TPM_DEV}/pcrs | cut -f2 -d: | tr -d ' ')
-        pcr17=$(grep PCR-17 ${TPM_DEV}/pcrs | cut -f2 -d: | tr -d ' ' | tr '[:upper:]' '[:lower:]')
-    fi
+    pcr8="$(tpm_get_pcr 8)"
+    pcr17="$(tpm_get_pcr 17)"
 
     pcr_forward=()
-    if ! contains_only "${pcr8}" 0; then
+    if ! contains_only "${pcr8}" "0"; then
         # PCR4 is first extended with the digest of EV_SEPARATOR
         # See TCG EFI Protocol Specification 5.2 Crypto Agile Log Entry Format
-        ev_separator=""
-        if [ "${tpm2}" -ne 0 ]; then
-            # Read the currently used separator from tpm0 sysfs.
-            if [ -e "/sys/kernel/security/tpm0/ascii_bios_measurements" ]; then
-                ev_separator="$(awk '$1 == 4 && $3 == 04 { print $2 }' /sys/kernel/security/tpm0/ascii_bios_measurements)"
-            fi
-            # Pick `printf "\xff\xff\xff\xff" | sha1sum` as it looks popular.
-            ev_separator=${ev_separator:-"d9be6524a5f5047db5866813acf3277892a7a30a"}
-        else
-            ev_separator="df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"
-        fi
+        ev_separator="$(tpm_get_ev_separator)"
 
         pcr4=$(hash_extend 0 "${ev_separator}" "${hashalg}")
 
-        hash=$(pesign -h -d ${hashalg} -i "${pcr4_objs[0]}" | awk '{ print $2 }')
-        pcr4=$(hash_extend $pcr4 $hash $hashalg) ||
+        hash=$(pesign -h -d "${hashalg}" -i "${pcr4_objs[0]}" | awk '{ print $2 }')
+        pcr4=$(hash_extend "${pcr4}" "${hash}" "${hashalg}") ||
             err "failed to calculate pcr4"
 
         for o in ${pcr4_objs[@]:1}; do
             hash=$(${hashalg}sum "${o}" | awk '{ print $1 }')
-            pcr4=$(hash_extend $pcr4 $hash $hashalg) ||
+            pcr4=$(hash_extend "${pcr4}" "${hash}" "${hashalg}") ||
                 err "failed to calculate pcr4"
         done
 
@@ -246,14 +200,14 @@ forward)
 
         for o in ${pcr8_objs[@]}; do
             hash=$(${hashalg}sum "${o}" | awk '{ print $1 }')
-            pcr8=$(hash_extend $pcr8 $hash $hashalg) ||
+            pcr8=$(hash_extend "${pcr8}" "${hash}" "${hashalg}") ||
                 err "failed to calculate pcr8"
         done
 
         modules=$(cat /usr/share/xenclient/bootloader/openxt.cfg | grep "sinit" | awk -F'=' '{print $2}')
         for module in $modules; do
             hash=$(${hashalg}sum /boot/$module | awk '{ print $1 }')
-            pcr8=$(hash_extend $pcr8 $hash $hashalg) ||
+            pcr8=$(hash_extend "${pcr8}" "${hash}" "${hashalg}") ||
                 err "failed to calculate pcr8"
         done
 
@@ -262,7 +216,7 @@ forward)
     fi
 
     if pcr_in_selection 15 ; then
-        [ -r ${root_dev} ] || err "cannot read root_dev ${root_dev}"
+        [ -r "${root_dev}" ] || err "cannot read root_dev ${root_dev}"
         # During early init, rootfs is hashed and is given to
         # tpm_extend which for tpm1.2 hashes the rootfs hash again and
         # hands that value to the TPM to be extended into PCR 15
@@ -301,39 +255,38 @@ forward)
         pcr_forward[19]=":${pcr19}"
     fi
 
+    rm -f /boot/system/tpm/forward_pcr.lst
     for p in ${pcr_selection}; do
         pcr_params="${pcr_params} -p ${p}${pcr_forward[${p}]}"
+        if [ -n "${pcr_forward[${p}]}" ]; then
+            echo "${p}${pcr_forward[${p}]}" >> /boot/system/tpm/forward_pcr.lst
+        fi
     done
 
-    echo "$pcr_params" > /boot/system/tpm/forward_pcr.lst
+    rotate_sealed_keyfiles
 
-    if [ -e "${sealed_key}" ]; then
-        mv ${sealed_key} ${sealed_key}.old
+    if ! tpm_seal -a "${hashalg}" ${pcr_params} "${config_key}" "${sealed_key}"; then
+        err "forward seal of key failed"
     fi
-    if [ -e "${sealed_key}.sha1" ]; then
-        mv ${sealed_key}.sha1 ${sealed_key}.sha1.old
-    fi
-    if [ -e "${sealed_key}.sha256" ]; then
-        mv ${sealed_key}.sha256 ${sealed_key}.sha256.old
-    fi
-
-    tpm_seal -a ${hashalg} ${pcr_params} ${config_key} ${sealed_key}
-    [ $? -eq 0 ] || err "forward seal of key failed"
 
     exit 0
 ;;
 unseal)
-    for p in ${pcr_selection}; do
-        pcr_params="${pcr_params} -p ${p}"
-    done
+    if [ ! -e "${sealed_key}.${hashalg}" ]; then
+        err "sealed key file missing"
+    fi
 
-    [ -e "${sealed_key}.${hashalg}" ] || err "sealed key file missing"
-    [ "${tpm2}" -eq 0 ] && [ -e "${sealed_key}.pub.${hashalg}" ] ||
+    if [ "${tpm2}" -eq "0" -a ! -e "${sealed_key}.pub.${hashalg}" ]; then
         err "sealed pub key file missing"
+    fi
 
-    tpm_unseal -a ${hashalg} ${pcr_params} ${sealed_key}
-    [ $? -eq 0 ] || err "unseal failed"
+    if ! tpm_unseal -a "${hashalg}" "${sealed_key}"; then
+        err "unseal failed"
+    fi
+
+    exit 0
+;;
+*)
+    err "Unknown operation \"${operation}\""
 ;;
 esac
-
-err "unexpectedly finsihed"

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -90,11 +90,7 @@ rotate_sealed_keyfiles() {
 
 # Globals
 hashalg="$(tpm_get_hash_algorithm)"
-if is_tpm_2_0; then
-    tpm2="0"
-else
-    tpm2="1"
-fi
+tpm_ver="$(get_tpm_version)"
 
 # Configurables
 operation="seal"
@@ -228,8 +224,8 @@ forward)
         # correct predict PCR15 during forward seal.
         root_hash=$(dd status=none if=${root_dev} iflag=direct bs=8M | \
                         ${hashalg}sum|cut -f1 -d' ')
-        [ "${tpm2}" -ne 0 ] && root_hash=$(echo -n ${root_hash} | \
-                                               ${hashalg}sum|cut -f1 -d' ')
+        [ "${tpm_ver}" = "1.2" ] && root_hash=$(echo -n ${root_hash} | \
+                                                ${hashalg}sum|cut -f1 -d' ')
         pcr15=$(hash_extend 0 ${root_hash} ${hashalg}) ||
                 err "failed to hash root device"
 
@@ -276,7 +272,7 @@ unseal)
         err "sealed key file missing"
     fi
 
-    if [ "${tpm2}" -eq "0" -a ! -e "${sealed_key}.pub.${hashalg}" ]; then
+    if [ "${tpm_ver}" = "2.0" -a ! -e "${sealed_key}.pub.${hashalg}" ]; then
         err "sealed pub key file missing"
     fi
 

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Load openxt-measuredlaunch helpers.
 . /usr/lib/openxt/ml-functions
 [ $? -eq 0 ] || {
     echo "failed to load ml-functions"
@@ -10,11 +11,15 @@ if [ -f /etc/openxt/seal-system.conf ]; then
     . /etc/openxt/seal-system.conf
 fi
 
+# Usage: err MESSAGE
+# Print MESSAGE on stderr and end the script with an error code 1.
 err() {
     echo "seal-system: $1" >&2
     exit 1
 }
 
+# Usage: constains_only STRING CHARACTER
+# Succeeds when all the characters in STRING are CHARACTER.
 contains_only() {
     local s="$1"
     local c="$2"
@@ -46,6 +51,10 @@ Usage: seal-system [-h] [-s|-u|-f] [-ctpgbr path] -[48 object[,objects]]"
 EOF
 }
 
+# Usage: pcr_in_selection PCR-ID
+# Returns 0 if pcr-id PCR is in ${pcr_selection}, 1 otherwise.
+# ${pcr_selection} is defined in the 'Configurables' section, it contains the
+# list of PCRs defined in ${config_pcrs}.
 pcr_in_selection() {
     pcr="$1"
 
@@ -58,6 +67,9 @@ pcr_in_selection() {
     return 1
 }
 
+# Usage: read_pcr_selection
+# Sanitize and print the content of file ${config_pcrs} on stdout.
+# ${config_pcrs} is defined in the 'Configurables' section.
 read_pcr_selection() {
     # strip out -r/-p to leave just the digits
     sed -e 's/-[rp]//g' $config_pcrs

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -68,18 +68,6 @@ pcr_in_selection() {
     return 1
 }
 
-# Usage rotate_sealed_files
-# Rename the existing sealed key files to *.old.
-rotate_sealed_keyfiles() {
-    local ext
-
-    for ext in {,.pub}.sha1 {,.pub}.sha256; do
-        if [ -e "${sealed_key}${ext}" ]; then
-            mv "${sealed_key}${ext}" "${sealed_key}${ext}.old"
-        fi
-    done
-}
-
 # Globals
 hashalg="$(tpm_get_hash_algorithm)"
 tpm_ver="$(get_tpm_version)"
@@ -142,8 +130,6 @@ pcr_selection="$(cat "${config_pcrs}")"
 
 case "${operation}" in
 seal)
-    rotate_sealed_keyfiles
-
     pcr_params=""
     for p in ${pcr_selection}; do
         pcr_params="${pcr_params} -p ${p}"
@@ -250,8 +236,6 @@ forward)
             echo "${p}${pcr_forward[${p}]}" >> /boot/system/tpm/forward_pcr.lst
         fi
     done
-
-    rotate_sealed_keyfiles
 
     if ! tpm_seal -a "${hashalg}" ${pcr_params} "${config_key}" "${sealed_key}"; then
         err "forward seal of key failed"

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -317,7 +317,7 @@ forward)
         mv ${sealed_key}.sha256 ${sealed_key}.sha256.old
     fi
 
-    tpm_forward_seal -a ${hashalg} ${pcr_params} ${config_key} ${sealed_key}
+    tpm_seal -a ${hashalg} ${pcr_params} ${config_key} ${sealed_key}
     [ $? -eq 0 ] || err "forward seal of key failed"
 
     exit 0

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -1,22 +1,23 @@
 #!/bin/bash
 
-# Load openxt-measuredlaunch helpers.
-. /usr/lib/openxt/ml-functions
-[ $? -eq 0 ] || {
-    echo "failed to load ml-functions"
-    exit 1
-}
-
-if [ -f /etc/openxt/seal-system.conf ]; then
-    . /etc/openxt/seal-system.conf
-fi
-
 # Usage: err MESSAGE
 # Print MESSAGE on stderr and end the script with an error code 1.
 err() {
     echo "seal-system: $1" >&2
     exit 1
 }
+
+# Load openxt-measuredlaunch helpers.
+if [ ! -f /usr/lib/openxt/ml-functions ]; then
+    err "Failed to load ml-functions. \
+        Is openxt-measuredlaunch installed correctly?"
+fi
+. /usr/lib/openxt/ml-functions
+
+# Load optional script configuration.
+if [ -f /etc/openxt/seal-system.conf ]; then
+    . /etc/openxt/seal-system.conf
+fi
 
 # Usage: constains_only STRING CHARACTER
 # Succeeds when all the characters in STRING are CHARACTER.

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -234,7 +234,7 @@ seal()
     dialog --colors --backtitle "${BACK_TITLE}" --mixedgauge \
         "  Sealing..." 0 0 20
 
-    for p in $(sed -e 's/-[rp]//g' "/config/config.pcrs"); do
+    for p in $(cat "/config/config.pcrs"); do
         pcr_opts="${pcr_opts} -p ${p}"
     done
     sealout="$(tpm_seal ${pcr_opts} "${config_key}" "${sealed_key}" 2>&1)"

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -223,64 +223,37 @@ fail_first_seal()
 
 seal()
 {
-    local tss_file=${1}
-    local sealerr=0
-    local file_exists=1
+    local config_key="/config/keys/config.key"
+    local sealed_key="$1"
     local sealout=""
-    local seal_file="/config/keys/config.key"
+    local sealrc=""
+    local pcr_opts
+
     maybe_break "seal"
+
     dialog --colors --backtitle "${BACK_TITLE}" --mixedgauge \
         "  Sealing..." 0 0 20
 
-    is_tpm_2_0
-    local tpm2=$?
-
-    if [ "${tpm2}" -eq 0 ];
-    then
-        clean_old_tpm_files
-        if pcr_bank_exists "sha256"; then
-            sealout=$(tpm2_sealdata -H 0x81000000 -I ${seal_file} -O ${tss_file}.sha256 -o ${tss_file}.pub.sha256 -g 0xB -G 0x8 -b 0x492 $(cat /config/config.pcrs) 2>&1 )
-            cp /config/config.pcrs ${tss_file}.pcrs
-            sealerr=$?
-        fi
-    else
-        sealout=$(tpm_sealdata_sa -i /config/keys/config.key \
-            -o ${tss_file} -z $(cat /config/config.pcrs) 2>&1)
-        sealerr=$?
-    fi
-
-    if [ -e ${tss_file} ]; then
-        file_exists=0
-    elif [ -e ${tss_file}.sha256 ]; then
-        file_exists=0
-    else
-        file_exists=1
-    fi
-
-
-    if [ $sealerr -eq 0 ] && [ $file_exists -eq 0 ]; then
-        dialog --colors --backtitle "${BACK_TITLE}" --mixedgauge \
-            "  Sealing: Done" 0 0 100
-
-        # store PCR hints for recovery
-        #  do PCR quote
-        if [ "${PCR_DEV}" ]; then
-            [ -f "${PCRS_BAD}" ] && rm "${PCRS_BAD}"
-            if [ "${tpm2}" -eq 0 ];
-            then
-                tpm2_pcrlist > "${PCRS_GOOD}"
-            else
-                cat "${PCR_DEV}/device/pcrs" > "${PCRS_GOOD}"
-            fi
-        fi
-
-        poweroff -r
-        exit 1
-    else
+    for p in $(sed -e 's/-[rp]//g' "/config/config.pcrs"); do
+        pcr_opts="${pcr_opts} -p ${p}"
+    done
+    sealout="$(tpm_seal ${pcr_opts} "${config_key}" "${sealed_key}" 2>&1)"
+    sealrc="$?"
+    if [ "${sealrc}" -ne "0" ]; then
         dialog --colors --backtitle "${BACK_TITLE}" --msgbox \
-            "Sealing Failed\n  Error code : $sealerr\n  Output : $sealout" 0 0
+            "Sealing Failed\n  Error code: ${sealrc}\n  Output: ${sealout}" 0 0
         return 1
     fi
+
+    rm -f "${PCRS_BAD}"
+    tpm_list_pcrs > "${PCRS_GOOD}"
+
+    dialog --colors --backtitle "${BACK_TITLE}" --mixedgauge \
+        "  Sealing: Done" 0 0 100
+
+    poweroff -r
+    # Just reboot into sealed system...
+    exit 1
 }
 
 reseal()
@@ -307,9 +280,7 @@ unlock_config()
     local measured_flag="/config/tpm/measured-boot"
 
     local sig=$(dd if="${lv_path}" bs=4 count=1 2>/dev/null)
-    is_tpm_2_0
-    local tpm2=$?
-    case "$sig" in
+    case "${sig}" in
     LUKS)
         if [ -e /boot/system/tpm/enabled ]; then
             # This will seal/reboot or fail/halt
@@ -340,13 +311,7 @@ unlock_config()
             maybe_break "measure-fail"
 
             # store PCR hints for recovery
-            #  do PCR quote
-            if [ "${tpm2}" -eq 0 ];
-            then
-                [ -d "${PCR_DEV}" ] && tpm2_pcrlist > "${PCRS_BAD}"
-            else
-                [ -d "${PCR_DEV}" ] && cat "${PCR_DEV}/device/pcrs" > "${PCRS_BAD}"
-            fi
+            tpm_list_pcrs > "${PCRS_BAD}"
 
             unseal_failure
             [ -f ${measured_flag} ] && rm -f ${measured_flag}

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/pcr1-fix.sh
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/pcr1-fix.sh
@@ -25,9 +25,9 @@ config_pcrs="${root}/config/config.pcrs"
     exit 1
 }
 
-grep '\-p 1' "${config_pcrs}"
+grep -q '\b1\b' "${config_pcrs}"
 case $? in
-    0)  sed -i -e 's&-p 1 &&' "${config_pcrs}"
+    0)  sed -i -e 's|\b1\b\s*||' "${config_pcrs}"
         if [ $? -gt 0 ]; then
             echo "Unable to remove PCR[1] from measurement list." >&2
             exit 1

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -743,200 +743,155 @@ tpm_get_pcr() {
 # Seal the secret key file and create the sealed key pair for unsealing.
 tpm_seal() {
     local root=""
-    local hashalg="sha1"
+    local hashalg="$(tpm_get_hash_algorithm)"
     local pcrs=""
-    local pcr_params=""
     local OPTIND
     local opt
+    local allout
 
     while getopts ":a:r:p:" opt; do
         case "${opt}" in
-            a)
-                hashalg=${OPTARG}
-            ;;
-            r)
-                root=${OPTARG}
-            ;;
-            p)
-                pcrs="${pcrs} ${OPTARG}"
-            ;;
+            a) hashalg="${OPTARG}" ;;
+            r) root="${OPTARG}" ;;
+            p) pcrs="${pcrs} ${OPTARG}" ;;
         esac
     done
     shift $((OPTIND-1))
 
-    local secret="${root}/${1}"
-    local tss="${root}/${2}"
+    local secret="${root}/$1"
+    local tss="${root}/$2"
 
-    for p in ${pcrs}; do
-        if [[ "${tpm2}" -eq 0 ]]; then
-            pcr_params="${pcr_params} -r ${p}"
-        else
-            pcr_params="${pcr_params} -p ${p}"
+    local pcr_opts="$(tpm_pcrs_to_opts ${pcrs})"
+
+    if ! tpm_pcrlist_save "${tss}.pcrs" ${pcrs}; then
+        echo "tpm_seal: Failed to save PCR ID list." >&2
+        return 1
+    fi
+
+    if is_tpm_2_0; then
+        if ! pcr_bank_exists "${hashalg}"; then
+            echo "tpm_seal: Requested algorithm \"${hashalg}\" does not "\
+                "exist or is not supported." >&2
+            return 1
         fi
-    done
 
-    is_tpm_2_0
-    if [ $? -eq 0 ]; then
-        pcr_bank_exists "${hashalg}"
-        [ $? -eq 0 ] || return 1
-
-        # pcr_params starts with -p or -r, but that's okay because
-        # echo only honors flags -n -e & -E
-        echo "${pcr_params}" > ${tss}.pcrs
-
-        case $hashalg in
+        case "${hashalg}" in
         sha1)
-            sealout=$(tpm2_sealdata -H ${OXT_HANDLE_SHA1} -I ${secret} \
-                -O ${tss}.sha1 -o ${tss}.pub.sha1 -g ${TPM_ALG_SHA1} \
-                -G ${TPM_ALG_KEYEDHASH} -b ${OXT_SEAL_ATTR} ${pcr_params} 2>&1)
-            return $?
+            allout="$(tpm2_sealdata -H "${OXT_HANDLE_SHA1}" -I "${secret}" \
+                -O "${tss}.sha1" -o "${tss}.pub.sha1" -g "${TPM_ALG_SHA1}" \
+                -G "${TPM_ALG_KEYEDHASH}" -b "${OXT_SEAL_ATTR}" \
+                ${pcr_opts} 2>&1)"
+            if [ $? -ne 0 ]; then
+                echo "tpm_seal: Failed to seal data (TPM 2.0) "\
+                    "using sha1 algorithm:" >&2
+                echo "${allout}" >&2
+                return 1
+            fi
         ;;
         sha256)
-            sealout=$(tpm2_sealdata -H ${OXT_HANDLE_SHA256} -I ${secret} \
-                -O ${tss}.sha256 -o ${tss}.pub.sha256 -g ${TPM_ALG_SHA256} \
-                -G ${TPM_ALG_KEYEDHASH} -b ${OXT_SEAL_ATTR} ${pcr_params} 2>&1)
-            return $?
+            allout="$(tpm2_sealdata -H "${OXT_HANDLE_SHA256}" -I "${secret}" \
+                -O "${tss}.sha256" -o "${tss}.pub.sha256" -g "${TPM_ALG_SHA256}" \
+                -G "${TPM_ALG_KEYEDHASH}" -b "${OXT_SEAL_ATTR}" \
+                ${pcr_opts} 2>&1)"
+            if [ $? -ne 0 ]; then
+                echo "tpm_seal: Failed to seal data (TPM 2.0) "\
+                    "using sha256 algorithm:" >&2
+                echo "${allout}" >&2
+                return 1
+            fi
         ;;
         *)
+            echo "tpm_seal: Algorithm \"${hashalg}\" is not supported." >&2
             return 1
         ;;
         esac
     else
-        sealout=$(tpm_sealdata_sa -i ${secret} -o ${tss}.sha1 \
-            -z ${pcr_params} 2>&1)
-        return $?
-    fi
-}
-
-tpm_forward_seal() {
-    local root=""
-    local forward_values=""
-    local hashalg="sha1"
-    local pcrs=""
-    local pcr_params=""
-    local OPTIND
-    local opt
-    local p
-    is_tpm_2_0
-    local tpm2=$?
-
-    while getopts ":a:r:p:" opt; do
-        case "${opt}" in
-            a)
-                hashalg=${OPTARG}
-            ;;
-            r)
-                root=${OPTARG}
-            ;;
-            p)
-                pcrs="${pcrs} ${OPTARG}"
-            ;;
-        esac
-    done
-    shift $((OPTIND-1))
-
-    local key="${root}/${1}"
-    local tss="${root}/${2}"
-
-    for p in ${pcrs}; do
-        if [[ "${tpm2}" -eq 0 ]]; then
-            pcr_params="${pcr_params} -r ${p}"
-        else
-            pcr_params="${pcr_params} -p ${p}"
-        fi
-    done
-
-    if [ "${tpm2}" -eq 0 ];
-    then
-        seal_file=${key}
-        clean_old_tpm_files
-        if pcr_bank_exists "sha256"; then
-            # We only want the PCRs numbers and not the forward seal values
-            echo "${pcr_params}" | \
-                sed -e 's/:[0-9a-zA-Z]\{64\}//g' > ${tss}.pcrs
-            tpm2_sealdata -H ${OXT_HANDLE_SHA256} -I ${seal_file} \
-                          -O ${tss}.sha256 -o ${tss}.pub.sha256 \
-                          -g ${TPM_ALG_SHA256} -G ${TPM_ALG_KEYEDHASH} \
-                          -b ${OXT_SEAL_ATTR} ${pcr_params} 2>&1
-            err=$?
-            if [ $err -ne 0 ]; then return $err; fi
-        fi
-        [ -e ${tss} ] || [ -e ${tss}.sha256 ] && return 0
-        return 1
-    else
-        /etc/init.d/trousers status > /dev/null 2>&1
+        allout="$(tpm_sealdata_sa -i "${secret}" -o "${tss}.sha1" \
+            -z ${apcr_opts} 2>&1)"
         if [ $? -ne 0 ]; then
-            tpm_sealdata_sa -i ${key} -o ${tss} -z ${pcr_params} 2>&1
-            return $?
-        else
-            tpm_sealdata -i ${key} -o ${tss} -z ${pcr_params} 2>&1
-            return $?
+            echo "tpm_seal: Failed to seal data (TPM 1.2):" >&2
+            echo "${allout}" >&2
+            return 1
         fi
     fi
+
+    return 0
 }
 
-# Usage: tpm_unseal [ -a hash-algorithm ] [-r path-to-root ] [ -p pcr-id ] TSS-FILE-BASENAME
+# Usage: tpm_unseal [ -a hash-algorithm ] [-r path-to-root ] TSS-FILE-BASENAME
 # Ask the TPM for the secret key using the sealed TSS keys given the current
 # PCR values.
 # Print the secret on stdout on success, otherwise print the error logs on
 # stderr and nothing on stdout.
-# -p has no effect.
 tpm_unseal() {
     local root=""
-    local hashalg="sha1"
+    local hashalg="$(tpm_get_hash_algorithm)"
     local pcrs=""
-    local pcr_params=""
     local OPTIND
     local opt
+    # Capture stderr into this variable while stdout is output normally.
+    # The usual sleight of hand goes:
+    #    { stderr="$(cmd args 2>&1 1>&3 3>&-)"; } 3>&1
+    local stderr
 
-    while getopts ":a:r:p:" opt; do
+    while getopts ":a:r:" opt; do
         case "${opt}" in
-            a)
-                hashalg=${OPTARG}
-            ;;
-            r)
-                root=${OPTARG}
-            ;;
-            p)
-                pcrs="${pcrs} ${OPTARG}"
-            ;;
+            a) hashalg="${OPTARG}" ;;
+            r) root="${OPTARG}" ;;
         esac
     done
     shift $((OPTIND-1))
 
-    local tss="${root}/${1}"
+    local tss="${root}/$1"
+    local pcr_opts="$(tpm_pcrs_to_opts $(cat "${tss}.pcrs"))"
 
-    is_tpm_2_0
-    if [ $? -eq 0 ]; then
-        for p in ${pcrs}; do
-            pcr_params="${pcr_params} -r ${p}"
-        done
+    if is_tpm_2_0; then
+        if ! pcr_bank_exists "${hashalg}"; then
+            echo "tpm_seal: Requested algorithm \"${hashalg}\" does not "\
+                "exist or is not supported." >&2
+            return 1
+        fi
 
-        pcr_bank_exists "${hashalg}"
-        [ $? -eq 0 ] || return 1
-
-        case $hashalg in
+        case "${hashalg}" in
         sha1)
-            tpm2_unsealdata -H ${OXT_HANDLE_SHA1} -n "${tss}.sha1" \
-                            -u "${tss}.pub.sha1" -g ${TPM_ALG_SHA1} \
-                            $( < ${tss}.pcrs ) 2>/dev/null
-            return $?
+            { stderr="$(tpm2_unsealdata -H "${OXT_HANDLE_SHA1}" \
+                -n "${tss}.sha1" -u "${tss}.pub.sha1" \
+                -g "${TPM_ALG_SHA1}" ${pcr_opts} 2>&1 1>&3 3>&-)"; } 3>&1
+            if [ "$?" -ne 0 ]; then
+                echo "tpm_unseal: Failed to unseal data (TPM 2.0) "\
+                    "using sha1 algorithm:" >&2
+                echo "${stderr}" >&2
+                return 1
+            fi
         ;;
         sha256)
-            tpm2_unsealdata -H ${OXT_HANDLE_SHA256} -n "${tss}.sha256" \
-                            -u "${tss}.pub.sha256" -g ${TPM_ALG_SHA256} \
-                            $( < ${tss}.pcrs ) 2>/dev/null
-            return $?
+            { stderr="$(tpm2_unsealdata -H "${OXT_HANDLE_SHA256}" \
+                -n "${tss}.sha256" -u "${tss}.pub.sha256" \
+                -g "${TPM_ALG_SHA256}" ${pcr_opts} 2>&1 1>&3 3>&-)"; } 3>&1
+            if [ "$?" -ne 0 ]; then
+                echo "tpm_unseal: Failed to unseal data (TPM 2.0) "\
+                    "using sha256 algorithm:" >&2
+                echo "${stderr}" >&2
+                return 1
+            fi
         ;;
         *)
+            echo "tpm_unseal: Algorithm \"${hashalg}\" is not supported." >&2
             return 1
         ;;
         esac
     else
-        tpm_unsealdata_sa -z -i $tss 2>/dev/null
-        ret=$?
+        # tpm_unsealdata_sa does not offer to unseal against a given list of
+        # PCRs.
+        { stderr="$(tpm_unsealdata_sa -z -i "${tss}.sha1" 2>&1 1>&3 3>&-)"; } 3>&1
+        if [ "$?" -ne 0 ]; then
+            echo "tpm_unseal: Failed to unseal data (TPM 1.2): " >&2
+            echo "${stderr}" >&2
+            return 1
+        fi
     fi
 
+    return 0
 }
 
 QUIRK_D="/usr/lib/tpm-scripts/quirks.d"

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -619,6 +619,9 @@ tpm2_write_tboot_policy() {
                  "${policy}" >/dev/null 2>&1
 }
 
+# Usage: tpm_get_pcr PCR-ID
+# Print the content of PCR-ID on stdout. The value is normalized: all
+# lowercase, no space.
 tpm_get_pcr() {
     local pcr="${1}"
 
@@ -636,6 +639,8 @@ tpm_get_pcr() {
     fi
 }
 
+# Usage: tpm_seal [ -a hash-algorithm ] [-r path-to-root ] [ -p pcr-id[:value] ] SECRET-KEY-FILE TSS-BASENAME
+# Seal the secret key file and create the sealed key pair for unsealing.
 tpm_seal() {
     local root=""
     local hashalg="sha1"
@@ -770,6 +775,12 @@ tpm_forward_seal() {
     fi
 }
 
+# Usage: tpm_unseal [ -a hash-algorithm ] [-r path-to-root ] [ -p pcr-id ] TSS-FILE-BASENAME
+# Ask the TPM for the secret key using the sealed TSS keys given the current
+# PCR values.
+# Print the secret on stdout on success, otherwise print the error logs on
+# stderr and nothing on stdout.
+# -p has no effect.
 tpm_unseal() {
     local root=""
     local hashalg="sha1"

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -52,13 +52,16 @@ is_tpm_2_0 () {
     [ "$(get_tpm_version)" = "2.0" ]
 }
 
+# Usage: pcr_bank_exists HASH-ALGORITHM-STRING
+# Returns successfuly if a matching bank exists for the given hash algorithm.
 pcr_bank_exists () {
-    local alg_in=$1
+    local alg_in="$1"
+    local bank
+    local banks="$(tpm2_pcrlist -s | cut -d ':' -f 2)"
 
-    banks=$(tpm2_pcrlist -s | cut -d ':' -f 2)
     for bank in $banks; do
-        alg=$(echo $bank | cut -d '(' -f 1)
-        if [ "$alg" = $alg_in ]; then
+        local alg="$(echo "${bank}" | cut -d '(' -f 1)"
+        if [ "${alg}" = "${alg_in}" ]; then
             return 0
         fi
     done

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -116,15 +116,32 @@ handle_alg() {
     esac
 }
 
+# Usage: alg_to_handle TPM-ALGORITHM-CODE
+# Print the matching handle code for the given TPM algorithm code, or nothing
+# if no match is found.
+# Supported: OXT_HANDLE_SHA1, OXT_HANDLE_SHA256.
 alg_to_handle () {
-    alg=$1
-    case $alg in
-        ${TPM_ALG_SHA256})
-            echo "${OXT_HANDLE_SHA256}"
-            ;;
-        ${TPM_ALG_SHA1})
-            echo "${OXT_HANDLE_SHA1}"
-            ;;
+    local alg="$1"
+
+    case "${alg}" in
+        "${TPM_ALG_SHA1}") echo "${OXT_HANDLE_SHA1}" ;;
+        "${TPM_ALG_SHA256}") echo "${OXT_HANDLE_SHA256}" ;;
+    esac
+}
+
+# Usage: hashalg_to_alg HASH-ALGORITHM-STRING
+# Print the matching TPM algorithm code for the given hash algorithm, or
+# nothing if no match is found.
+# Supported: sha1, sha256, sha384, sha512, sm3_256.
+hashalg_to_alg() {
+    local hashalg="$1"
+
+    case "${hashalg}" in
+        "sha1") echo "${TPM_ALG_SHA1}" ;;
+        "sha256") echo "${TPM_ALG_SHA256}" ;;
+        "sha384") echo "${TPM_ALG_SHA384}" ;;
+        "sha512") echo "${TPM_ALG_SHA512}" ;;
+        "sm3_256") echo "${TPM_ALG_SM3_256}" ;;
     esac
 }
 
@@ -776,42 +793,25 @@ tpm_seal() {
     fi
 
     if is_tpm_2_0; then
-        if ! pcr_bank_exists "${hashalg}"; then
-            echo "tpm_seal: Requested algorithm \"${hashalg}\" does not "\
-                "exist or is not supported." >&2
+        local alg="$(hashalg_to_alg "${hashalg}")"
+        local handle="$(alg_to_handle "${alg}")"
+
+        if [ -z "${alg}" -o -z "${handle}" ] || \
+            ! pcr_bank_exists "${hashalg}"; then
+            echo "tpm_unseal: Algorithm \"${hashalg}\" is not supported." >&2
             return 1
         fi
 
-        case "${hashalg}" in
-        sha1)
-            allout="$(tpm2_sealdata -H "${OXT_HANDLE_SHA1}" -I "${secret}" \
-                -O "${tss}.sha1" -o "${tss}.pub.sha1" -g "${TPM_ALG_SHA1}" \
-                -G "${TPM_ALG_KEYEDHASH}" -b "${OXT_SEAL_ATTR}" \
-                ${pcr_opts} 2>&1)"
-            if [ $? -ne 0 ]; then
-                echo "tpm_seal: Failed to seal data (TPM 2.0) "\
-                    "using sha1 algorithm:" >&2
-                echo "${allout}" >&2
-                return 1
-            fi
-        ;;
-        sha256)
-            allout="$(tpm2_sealdata -H "${OXT_HANDLE_SHA256}" -I "${secret}" \
-                -O "${tss}.sha256" -o "${tss}.pub.sha256" -g "${TPM_ALG_SHA256}" \
-                -G "${TPM_ALG_KEYEDHASH}" -b "${OXT_SEAL_ATTR}" \
-                ${pcr_opts} 2>&1)"
-            if [ $? -ne 0 ]; then
-                echo "tpm_seal: Failed to seal data (TPM 2.0) "\
-                    "using sha256 algorithm:" >&2
-                echo "${allout}" >&2
-                return 1
-            fi
-        ;;
-        *)
-            echo "tpm_seal: Algorithm \"${hashalg}\" is not supported." >&2
+        allout="$(tpm2_sealdata -H "${handle}" -I "${secret}" \
+            -O "${tss}.${hashalg}" -o "${tss}.pub.${hashalg}" -g "${alg}" \
+            -G "${TPM_ALG_KEYEDHASH}" -b "${OXT_SEAL_ATTR}" \
+            ${pcr_opts} 2>&1)"
+        if [ $? -ne 0 ]; then
+            echo "tpm_seal: Failed to seal data (TPM 2.0) "\
+                "using ${hashalg} algorithm:" >&2
+            echo "${allout}" >&2
             return 1
-        ;;
-        esac
+        fi
     else
         local tss_bin="tpm_sealdata"
 
@@ -859,40 +859,24 @@ tpm_unseal() {
     local pcr_opts="$(tpm_pcrs_to_opts $(cat "${tss}.pcrs"))"
 
     if is_tpm_2_0; then
-        if ! pcr_bank_exists "${hashalg}"; then
-            echo "tpm_seal: Requested algorithm \"${hashalg}\" does not "\
-                "exist or is not supported." >&2
+        local alg="$(hashalg_to_alg "${hashalg}")"
+        local handle="$(alg_to_handle "${alg}")"
+
+        if [ -z "${alg}" -o -z "${handle}" ] || \
+            ! pcr_bank_exists "${hashalg}"; then
+            echo "tpm_unseal: Algorithm \"${hashalg}\" is not supported." >&2
             return 1
         fi
 
-        case "${hashalg}" in
-        sha1)
-            { stderr="$(tpm2_unsealdata -H "${OXT_HANDLE_SHA1}" \
-                -n "${tss}.sha1" -u "${tss}.pub.sha1" \
-                -g "${TPM_ALG_SHA1}" ${pcr_opts} 2>&1 1>&3 3>&-)"; } 3>&1
-            if [ "$?" -ne 0 ]; then
-                echo "tpm_unseal: Failed to unseal data (TPM 2.0) "\
-                    "using sha1 algorithm:" >&2
-                echo "${stderr}" >&2
-                return 1
-            fi
-        ;;
-        sha256)
-            { stderr="$(tpm2_unsealdata -H "${OXT_HANDLE_SHA256}" \
-                -n "${tss}.sha256" -u "${tss}.pub.sha256" \
-                -g "${TPM_ALG_SHA256}" ${pcr_opts} 2>&1 1>&3 3>&-)"; } 3>&1
-            if [ "$?" -ne 0 ]; then
-                echo "tpm_unseal: Failed to unseal data (TPM 2.0) "\
-                    "using sha256 algorithm:" >&2
-                echo "${stderr}" >&2
-                return 1
-            fi
-        ;;
-        *)
-            echo "tpm_unseal: Algorithm \"${hashalg}\" is not supported." >&2
+        { stderr="$(tpm2_unsealdata -H "${handle}" \
+            -n "${tss}.${hashalg}" -u "${tss}.pub.${hashalg}" \
+            -g "${alg}" ${pcr_opts} 2>&1 1>&3 3>&-)"; } 3>&1
+        if [ "$?" -ne 0 ]; then
+            echo "tpm_unseal: Failed to unseal data (TPM 2.0) "\
+                "using ${hashalg} algorithm:" >&2
+            echo "${stderr}" >&2
             return 1
-        ;;
-        esac
+        fi
     else
         local tss_bin="tpm_unsealdata"
 

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -766,8 +766,52 @@ tpm_get_pcr() {
     fi
 }
 
+# Usage tpm_save_keyfiles BASENAME
+# Rename the existing sealed key files for BASENAME with the .old suffix.
+tpm_save_keyfiles() {
+    local basename="$1"
+    local ext
+
+    for ext in {,.pub}.sha1 {,.pub}.sha256; do
+        if [ -e "${basename}${ext}" ]; then
+            mv "${basename}${ext}" "${basename}${ext}.old"
+        fi
+    done
+}
+
+# Usage tpm_restore_keyfiles BASENAME
+# Renamed the saved key files for BASENAME without the .old suffix.
+# Fails if the saved key files are incoherent.
+tpm_restore_keyfiles() {
+    local basename="$1"
+    local valid="false"
+    local ext alg
+
+    if is_tpm_2_0; then
+        for alg in sha1 sha256; do
+            if [ -e "${basename}.${alg}.old" -a -e "${basename}.pub.${alg}.old" ]; then
+                valid="true"
+            fi
+        done
+    else
+        if [ -e "${basename}.sha1.old" ]; then
+            valid="true"
+        fi
+    fi
+    if [ "${valid}" != "true" ]; then
+        return 1
+    fi
+
+    for ext in {,.pub}.sha1 {,.pub}.sha256; do
+        if [ -e "${basename}${ext}.old" ]; then
+            mv "${basename}${ext}.old" "${basename}${ext}"
+        fi
+    done
+}
+
 # Usage: tpm_seal [ -a hash-algorithm ] [-r path-to-root ] [ -p pcr-id[:value] ] SECRET-KEY-FILE TSS-BASENAME
-# Seal the secret key file and create the sealed key pair for unsealing.
+# Seal the secret key file and create the sealed key/key-pair for unsealing.
+# Existing key(s) will be saved and renamed with the .old suffix on success.
 tpm_seal() {
     local root=""
     local hashalg="$(tpm_get_hash_algorithm)"
@@ -805,6 +849,7 @@ tpm_seal() {
             return 1
         fi
 
+        tpm_save_keyfiles "${tss}"
         allout="$(tpm2_sealdata -H "${handle}" -I "${secret}" \
             -O "${tss}.${hashalg}" -o "${tss}.pub.${hashalg}" -g "${alg}" \
             -G "${TPM_ALG_KEYEDHASH}" -b "${OXT_SEAL_ATTR}" \
@@ -813,6 +858,7 @@ tpm_seal() {
             echo "tpm_seal: Failed to seal data (TPM 2.0) "\
                 "using ${hashalg} algorithm:" >&2
             echo "${allout}" >&2
+            tpm_restore_keyfiles "${tss}"
             return 1
         fi
     else
@@ -822,11 +868,13 @@ tpm_seal() {
         if ! tcsd_running; then
             tss_bin="${tss_bin}_sa"
         fi
+        tpm_save_keyfiles "${tss}"
         allout="$(${tss_bin} -i "${secret}" -o "${tss}.sha1" \
             -z ${pcr_opts} 2>&1)"
         if [ $? -ne 0 ]; then
             echo "tpm_seal: Failed to seal data (TPM 1.2):" >&2
             echo "${allout}" >&2
+            tpm_restore_keyfiles "${tss}"
             return 1
         fi
     fi

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -619,23 +619,123 @@ tpm2_write_tboot_policy() {
                  "${policy}" >/dev/null 2>&1
 }
 
+# Usage: tpm_get_syspath [TPM-DEVICE-ID]
+# Verify and print the path of the TPM, with the given id (default:0), on
+# stdout. Returns 0 on success, 1 if the path in the sysfs cannot be found.
+tpm_get_syspath() {
+    local devid="${1:-0}"
+    local syspath="/sys/class/tpm/tpm${devid}"
+
+    if [ ! -e "${syspath}" ]; then
+        echo "tpm_get_syspath: tpm${devid} has no entry in the sysfs." >&2
+        return 1
+    fi
+    echo "${syspath}"
+}
+
+# Usage: tpm_get_ev_separator
+# Print the EV_SEPARATOR value as presented by the kernel, or our best guess as
+# what it may be, on stdout.
+tpm_get_ev_separator() {
+    local evs
+
+    if is_tpm_2_0; then
+        # TPM 2.0: `printf "\xff\xff\xff\xff" | sha256sum`, best guess...
+        evs="df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"
+    else
+        # TPM 1.2 will expose a securityfs node with ASCII values.
+        local path="/sys/kernel/security/tpm0/ascii_bios_measurements"
+
+        evs=$(awk '$1 == 4 && $3 == 04 { print $2 }' "${path}")
+        # Fallback: Pick `printf "\xff\xff\xff\xff" | sha1sum`, best guess...
+        evs=${evs:-"d9be6524a5f5047db5866813acf3277892a7a30a"}
+    fi
+    echo "${evs}"
+}
+
+# Usage: tpm_list_pcrs
+# Print all the PCR values of the first TPM on stdout.
+tpm_list_pcrs() {
+    if is_tpm_2_0; then
+        tpm2_pcrlist
+    else
+        cat "$(tpm_get_syspath)/device/pcrs"
+    fi
+}
+
+# tpm_pcrlist_save PCRLIST-FILE PCR-IDS
+# Write the list of PCR-IDS to the PCRLIST-FILE, overwriting the existing one
+# if necessary.
+tpm_pcrlist_save() {
+    local file="$1"
+    shift 1
+    local pcrlist=""
+
+    # Sanity check list of number in PCR id range ([0-23])
+    for p in "$@"; do
+        pcrid="${p%%:*}"
+        if [ "$(expr "${pcrid}" : '^[[:digit:]]\+$')" -a \
+             "${pcrid}" -gt 23 -o "${pcrid}" -lt 0 ]; then
+            return 1
+        fi
+        pcrlist="${pcrlist} ${pcrid}"
+    done
+
+    echo "${pcrlist}" > "${file}"
+}
+
+# tpm_pcrs_to_opts PCR-IDS
+# Print a list of options from PCR-IDS suitable to use as argument with TSS
+# utilities. This makes handling TPM1.2 and TPM2.0 TSS stacks easier.
+tpm_pcrs_to_opts() {
+    local tss_opt
+    local pcr_opts
+
+    if is_tpm_2_0; then
+        tss_opt="-r"
+    else
+        tss_opt="-p"
+    fi
+    for p in "$@"; do
+        pcr_opts="${pcr_opts} ${tss_opt} ${p}"
+    done
+    echo "${pcr_opts}"
+}
+
+# Usage: tpm_pcr_value_normalize PCR-VALUE
+# Print the PCR-VALUE, from TPM-TSS output, normalized on stdout.
+# Normalized here means no space, all lowercase, no PCR identifier, and only
+# the last line.
+# This is relevant for to be consistent across TSS versions and keeps format
+# sanitizing in one centralized place, should it require to be amended.
+tpm_pcr_value_normalize() {
+    echo "$1" | awk -F ':' 'END{ gsub(" ", "", $2); print tolower($2) }'
+}
+
+# Usage: tpm_get_hash_algorithm
+# Print the default hash algorithm to use within the current environment.
+tpm_get_hash_algorithm() {
+    local hashalg="sha1"
+
+    if is_tpm_2_0; then
+        if pcr_bank_exists "sha256"; then
+            hashalg="sha256"
+        fi
+    fi
+    echo "${hashalg}"
+}
+
 # Usage: tpm_get_pcr PCR-ID
 # Print the content of PCR-ID on stdout. The value is normalized: all
 # lowercase, no space.
 tpm_get_pcr() {
-    local pcr="${1}"
+    local pcr="$1"
+    local hashalg="$(tpm_get_hash_algorithm)"
 
-    is_tpm_2_0
-    if [ $? -eq 0 ]; then
-        if pcr_bank_exists "sha256"; then
-            echo "$(tpm2_pcrlist -L sha256:${pcr} | tail -1 | cut -f2 -d: | tr 'A-Z' 'a-z' | tr -d \ )"
-        else
-            echo "$(tpm2_pcrlist -L sha1:${pcr} | tail -1 | cut -f2 -d: | tr 'A-Z' 'a-z' | tr -d \ )"
-        fi
+    if is_tpm_2_0; then
+        tpm_pcr_value_normalize "$(tpm2_pcrlist -L ${hashalg}:${pcr})"
     else
-        local tpm="$(find /sys/class -name tpm0 2>/dev/null)/device"
-
-        echo "$(grep PCR-${pcr} ${tpm}/pcrs|cut -f2 -d:|tr 'A-Z' 'a-z'|tr -d \ )"
+        tpm_pcr_value_normalize "$(grep PCR-${pcr} "$(tpm_get_syspath)/device/pcrs")"
     fi
 }
 

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -123,21 +123,23 @@ alg_to_handle () {
     esac
 }
 
-tcsd_start() {
-    is_tpm_2_0
-    local tpm2=$?
-    if [ "${tpm2}" -ne 0 ];
-    then
-        local ret=1
-        /etc/init.d/trousers status > /dev/null
-        if [ $? -ne 0 ]; then
-            /etc/init.d/trousers start > /dev/null
-            sleep 1
-            /etc/init.d/trousers status > /dev/null
-            [ $? -ne 0 ] && return 1
-        fi
+tcsd_running() {
+    if [ ! -x "/etc/init.d/trousers" ]; then
+        return 1
     fi
-    return 0
+    /etc/init.d/trousers status > /dev/null 2>&1
+}
+
+tcsd_start() {
+    # TPM2.0 TSS does not require tcsd.
+    if is_tpm_2_0; then
+        return 0
+    fi
+    if tcsd_running; then
+        return 0
+    fi
+
+    /etc/init.d/trousers start
 }
 # Function to determin whether or not the TPM is active
 # returns 0 if active
@@ -806,8 +808,14 @@ tpm_seal() {
         ;;
         esac
     else
-        allout="$(tpm_sealdata_sa -i "${secret}" -o "${tss}.sha1" \
-            -z ${apcr_opts} 2>&1)"
+        local tss_bin="tpm_sealdata"
+
+        # Use the standalone binary if tcsd is not running.
+        if ! tcsd_running; then
+            tss_bin="${tss_bin}_sa"
+        fi
+        allout="$(${tss_bin} -i "${secret}" -o "${tss}.sha1" \
+            -z ${pcr_opts} 2>&1)"
         if [ $? -ne 0 ]; then
             echo "tpm_seal: Failed to seal data (TPM 1.2):" >&2
             echo "${allout}" >&2
@@ -881,9 +889,15 @@ tpm_unseal() {
         ;;
         esac
     else
+        local tss_bin="tpm_unsealdata"
+
+        # Use the standalone binary if tcsd is not running.
+        if ! tcsd_running; then
+            tss_bin="${tss_bin}_sa"
+        fi
         # tpm_unsealdata_sa does not offer to unseal against a given list of
         # PCRs.
-        { stderr="$(tpm_unsealdata_sa -z -i "${tss}.sha1" 2>&1 1>&3 3>&-)"; } 3>&1
+        { stderr="$(${tss_bin} -z -i "${tss}.sha1" 2>&1 1>&3 3>&-)"; } 3>&1
         if [ "$?" -ne 0 ]; then
             echo "tpm_unseal: Failed to unseal data (TPM 1.2): " >&2
             echo "${stderr}" >&2

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -30,21 +30,26 @@ clean_old_tpm_files () {
     [ -e /boot/system/tpm/config.tss.pub.sha256 ] && rm /boot/system/tpm/config.tss.pub.sha256
 }
 
-is_tpm_2_0 () {
+# Usage: get_tpm_version [DEVID]
+# Print the version of the TPM device with DEVID (default to 0).
+get_tpm_version() {
+    local devid="${1:-0}"
+    local path="$(tpm_get_syspath "${devid}")"
+
     # See the TPM chardev driver implementation:
     # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/char/tpm/tpm-sysfs.c?h=v4.14.34#n296
     # Assuming a TPM has already been detected, absence of the sysfs entry
     # means TPM 2.0.
     # This is still valid on Linux 4.16.
-    if [ ! -e /sys/class/tpm/tpm0/device/caps ]; then
-        return 0
+    if [ ! -e "${path}/device/caps" ]; then
+        echo "2.0"
+    else
+        awk '/TCG version:/ { print $3 }' "${path}/device/caps"
     fi
+}
 
-    # Sysfs caps entry contains TPM manufacturer and version info.
-    # https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-tpm
-    local tpm_ver="$(awk '/TCG version:/ { print $3 }' /sys/class/tpm/tpm0/device/caps)"
-
-    [ "${tpm_ver}" = "2.0" ]
+is_tpm_2_0 () {
+    [ "$(get_tpm_version)" = "2.0" ]
 }
 
 pcr_bank_exists () {


### PR DESCRIPTION
Remove code duplication between the different scripts used to perform sealing/unsealing operations by implementing common behaviors in `xenclient-tpm-scripts` and using the existing `tpm-functions` files in dependent scripts. Duplicate implementations were starting to drift apart (OXT-1665, OXT-1666).

Helper introduced in `tpm-functions`:
- tpm_get_syspath: print sysfs path to TPM device.
- tpm_get_ev_separator: print EV_SEPARATOR value.
- tpm_list_pcrs: list PCR values (1.2 && 2.0)
- tpm_pcrlist_save: Sanity check and save PCR id to file.
- tpm_pcrs_to_opts: Convert list of PCR ids to list of options suitable to use with TSS tools.
- tpm_pcr_value_normalize: Normalize PCR values across TSS version.
- tpm_get_hash_algorithm: Print default hash algorithm for platform.

This also changes the content of some files, mostly used for diagnostic:
- `/boot/system/tpm/config.tss.pcrs` no longer has the TSS options depending on the TSS tools used for the relevant TPM version. It is now a list of PCR ids separated by spaces. This makes it easier to be used generically in `tpm-functions`.
- `/boot/system/tpm/forward_pcr.lst` now contains only the PCR values predicted during forward sealing, one `PCR-ID:HASH` pair per line.