### PR TITLE
libargo: Don't call restorecon from udev

### DIFF
--- a/recipes-openxt/libargo/files/13-argo.rules
+++ b/recipes-openxt/libargo/files/13-argo.rules
@@ -1,2 +1,0 @@
-KERNEL=="argo_dgram", RUN+="/sbin/restorecon /dev/argo_dgram"
-KERNEL=="argo_stream", RUN+="/sbin/restorecon /dev/argo_stream"

--- a/recipes-openxt/libargo/libargo_git.bb
+++ b/recipes-openxt/libargo/libargo_git.bb
@@ -6,19 +6,10 @@ DEPENDS = "xen argo-module-headers"
 PV = "git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/linux-xen-argo.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
-	   file://13-argo.rules"
+SRC_URI = "git://${OPENXT_GIT_MIRROR}/linux-xen-argo.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 
 S = "${WORKDIR}/git/libargo"
 
 inherit autotools-brokensep pkgconfig lib_package xenclient
 
 EXTRA_OECONF += "--with-pic"
-
-do_install_append(){
-    install -d ${D}/etc
-    install -d ${D}/etc/udev
-    install -d ${D}/etc/udev/rules.d
-    install ${WORKDIR}/13-argo.rules ${D}/etc/udev/rules.d
-}
-


### PR DESCRIPTION
Stop calling restorecon on the /dev/argo_{dgram,stream} device nodes.

udev already labels the devices properly when they are created, so
restorecon is unnecessary.

This means uivm won't call have
udevd[99]: failed to execute '/sbin/restorecon' '/sbin/restorecon /dev/v4v_stream': No such file or directory
udevd[99]: failed to execute '/sbin/restorecon' '/sbin/restorecon /dev/v4v_dgram': No such file or directory

OXT-1535

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>