### PR TITLE
udev-volatiles: Conditionally call restorecon

### DIFF
--- a/recipes-core/initscripts/initscripts-1.0/udev-volatiles.sh
+++ b/recipes-core/initscripts/initscripts-1.0/udev-volatiles.sh
@@ -12,15 +12,9 @@ fi
 # Environment.
 
 begin "Populate volatiles for udev..."
-RESTORECON=${RESTORECON:-/sbin/restorecon}
-if [ ! -x "${RESTORECON}" ]; then
-    failure "SELinux \`${RESTORECON}' tool is missing."
-    exit 1
-fi
-
 mkdir -p /run/lock
-if ! ${RESTORECON} -R /run/lock ; then
-    failure "${RESTORECON} failed."
+if ! restore -R /run/lock ; then
+    failure "${RESTORECON} -R /run/lock failed."
     exit 1
 fi
 


### PR DESCRIPTION
I just saw "SELinux `/sbin/restorecon' tool is missing." in the uivm
logs.  It is indeed missing since uivm doesn't run SELinux.  This means
udev-volatiles bailed early without creating /run/lock.

/etc/init.d/functions already has a restore() function to only call
restorecon when it is present.  Switch to using that instead of bailing
early from the script.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>