### PR TITLE
Introduce IMAGE_FEATURE wildcard-sshd-argo

### DIFF
--- a/classes/openxt-image.bbclass
+++ b/classes/openxt-image.bbclass
@@ -39,6 +39,17 @@ read_only_rootfs_hook_extend() {
 }
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs", "read_only_rootfs_hook_extend; ", "",d)}'
 
+# A hook function to only accept sshargo from dom0.  sshd-argo will bind a
+# single-source ring to dom0 instead of a wildcard ring.
+read_only_rootfs_no_sshd_argo_wildcard() {
+    # Aside from dom0, we only want to allow sshargo from dom0.
+    if [ -f "${IMAGE_ROOTFS}/etc/ssh/sshd_config_argo" ]; then
+        echo "export ARGO_ACCEPT_DOM0_ONLY=1" >> "${IMAGE_ROOTFS}/etc/default/ssh-argo"
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "wildcard-sshd-argo", "", "read_only_rootfs_no_sshd_argo_wildcard; ",d)}'
+IMAGE_FEATURES[validitems] += "wildcard-sshd-argo"
+
 # Add and entry to /etc/inittab to start a tty on hvc0 (debug).
 start_tty_on_hvc0() {
 	echo 'hvc0:12345:respawn:/bin/start_getty 115200 hvc0 vt102' >> "${IMAGE_ROOTFS}/etc/inittab"

--- a/recipes-core/images/xenclient-dom0-image.bb
+++ b/recipes-core/images/xenclient-dom0-image.bb
@@ -16,6 +16,7 @@ IMAGE_FEATURES += " \
     package-management \
     read-only-rootfs \
     root-bash-shell \
+    wildcard-sshd-argo \
 "
 IMAGE_FSTYPES = "ext3.gz"
 export IMAGE_BASENAME = "xenclient-dom0-image"


### PR DESCRIPTION
This is part of work to reduce the number of wilcard argo rings
https://github.com/OpenXT/linux-xen-argo/pull/3

By specifying ARGO_ACCEPT_DOM0_ONLY=1, the argo interposer will create a
single source argo ring to dom0.  We want this in all the servicevms
since they should only accept sshargo from dom0.  Dom0 can't use this
since it needs to accept sshargo from uivm.

Therefore make the default to add ARGO_ACCEPT_DOM0_ONLY=1 and omit it
when IMAGE_FEATURES contains wildcard-sshd-argo.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>