### PR TITLE
S9: OXT-1670: refpolicy: Let vhd-util create UNIX/DGRAM sockets.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/admin/vhdutils.te
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/admin/vhdutils.te
@@ -81,3 +81,6 @@ statusreport_write_storage_files(vhdutil_t)
 statusreport_write_tmp_files(vhdutil_t)
 statusreport_getattr_storage_files(vhdutil_t)
 statusreport_getattr_tmp_files(vhdutil_t)
+
+# Log to syslog.
+logging_send_syslog_msg(vhdutil_t)


### PR DESCRIPTION
vhd-util, provided by blktap3, logs to syslog using UNIX/DGRAM socket.

The log now reported is:
```
vhd-util: vhd_util_read_key: using keyfile /config/platform-crypto-keys/ea4f1606-cb49-4788-861f-a68a1168e1ff,aes-xts-plain,512.key, Size (bytes) 64
```
Additional logs is added if `vhd-util` fails.