### PR TITLE
qemu chardev-argo fixes

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -7,7 +7,7 @@
 +chardev-obj-$(CONFIG_XEN) += char-argo.o
 --- /dev/null
 +++ b/chardev/char-argo.c
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,345 @@
 +/*
 + * QEMU System Emulator
 + *
@@ -85,17 +85,31 @@
 +static int argo_chr_write(Chardev *chr, const uint8_t *buf, int len)
 +{
 +    ArgoChardev *s = ARGO_CHARDEV(chr);
++    int write_len = len;
 +    int ret;
 +
++ again:
 +    if (s->stream) {
-+        ret = argo_send(s->fd, buf, len, 0);
++        ret = argo_send(s->fd, buf, write_len, 0);
 +    } else {
-+        ret = argo_sendto(s->fd, buf, len, 0, &s->remote_addr);
++        ret = argo_sendto(s->fd, buf, write_len, 0, &s->remote_addr);
 +    }
-+    if (ret != len) {
-+        fprintf(stderr, "%s error: argo_sendto() failed (%s) - %d %d.\n",
-+                ARGO_CHARDRV_NAME, strerror(errno), ret, len);
-+        return 0;
++
++    if (ret == -1 && errno == EMSGSIZE) {
++        /*
++         * try again with a smaller chunk, but avoid 0 since argo_send returns
++         * 0 for that case and we'll end up looping.  Instead return -1 since
++         * we haven't made progress and the message will get dropped.
++         */
++        write_len /= 2;
++        if (write_len) {
++            goto again;
++        }
++    }
++
++    if (ret == -1) {
++        fprintf(stderr, "%s error: argo_sendto() errno=%d (%s) len=%d write_len=%d.\n",
++                ARGO_CHARDRV_NAME, errno, strerror(errno), len, write_len);
 +    }
 +
 +    return ret;

--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -238,7 +238,7 @@
 +    localport = localport_str ? strtoul(localport_str, NULL, 0) : 0;
 +
 +    backend->type = CHARDEV_BACKEND_KIND_ARGO;
-+    if (domid > 0x7ff4) {
++    if (domid >= DOMID_FIRST_RESERVED) {
 +        error_setg(errp, "chardev: argo: domid invalid");
 +        return;
 +    }


### PR DESCRIPTION
qemu can go into an infinite loop if it tries to send a message bigger than the destination's ring size or available space.  argo_send() returns EMSGSIZE & argo_chr_write() returns 0.  The chardev code thinks nothing was sent, so it calls back into argo_chr_write() and the process repeats with no progress made.  Change argo_chr_write() to scale back the write size when receiving EMSGSIZE.

Also use the Xen provided define to check for invalid domids.