### PR TITLE
S9: console-setup: switch to fetching from the git repository

### DIFF
--- a/recipes-support/console-setup/console-setup-ckbcomp-native_1.191.bb
+++ b/recipes-support/console-setup/console-setup-ckbcomp-native_1.191.bb
@@ -1,5 +1,3 @@
-SRC_URI[md5sum] = "aa522a2fc8f596fd71f51e581b7471dc"
-SRC_URI[sha256sum] = "4dbe2c9559ff68a61315efe4de2cb932396ede8c4a1df4b46b6fb0846cc59d5b"
 DESCRIPTION = "Convert XKB keymap to console keymap"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM="file://COPYRIGHT;md5=49cab1cfd397b014807c5b2bcc63e04f"
@@ -7,9 +5,11 @@ RDEPENDS_${PN} = "perl-native"
 
 # Don't bother building the whole package. We only want the ckbcomp script.
 
-SRC_URI = "${DEBIAN_MIRROR}/main/c/console-setup/console-setup_${PV}.tar.xz"
+SRC_URI = "git://salsa.debian.org/installer-team/console-setup.git;protocol=https"
+# The hash of the 1.191 tag:
+SRCREV = "681544fa6481fb62b362f4fadeda5bbdf3389307"
 
-S = "${WORKDIR}/console-setup"
+S = "${WORKDIR}/git"
 
 inherit native
 


### PR DESCRIPTION
Instead of tarballs from the Debian package repository,
which changes every Debian release.
Also, switch back to version 1.191.

OXT-1645

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit 17def59b26d9936bc494584ac012d4b6ebcbeaf4)
Signed-off-by: Jed <lejosnej@ainfosec.com>