### PR TITLE
OXT-1673: setools: python-importlib missing RDEPENDS.

### DIFF
--- a/recipes-security/setools/setools_4.%.bbappend
+++ b/recipes-security/setools/setools_4.%.bbappend
@@ -1,1 +1,4 @@
-RDEPENDS_${PN} += "python-2to3"
+RDEPENDS_${PN} += " \
+    python-2to3 \
+    python-importlib \
+"


### PR DESCRIPTION
Add missing RDEPENDS to setools.
More recent versions of python will package it in python-core, this is not the case here.