### PR TITLE
OXT-1675: bats-suite: Mend recipe with modern setup.

### DIFF
--- a/recipes-core/packagegroups/packagegroup-openxt-test.bb
+++ b/recipes-core/packagegroups/packagegroup-openxt-test.bb
@@ -5,5 +5,5 @@ PR = "r0"
 inherit packagegroup
 
 RDEPENDS_${PN} = " \
-            ${@bb.utils.contains("DISTRO_FEATURES", "bats", "bats-testsuite", "", d)} \
+            ${@bb.utils.contains("DISTRO_FEATURES", "bats", "bats-suite", "", d)} \
             "

--- a/recipes-devtools/bats-suite/bats-suite_git.bb
+++ b/recipes-devtools/bats-suite/bats-suite_git.bb
@@ -1,11 +1,13 @@
-SUMMARY = "OpenXT bats test scripts"
+SUMMARY = "OpenXT bats test scripts."
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=9cfc4a8eac3fe9bdc740b8e3760c5ade"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c93f84859222e5549645b5fee3d87947"
 
-SRC_URI = "git://github.com/apertussolutions/openxt-bats-suite.git;protocol=git"
+SRC_URI = "git://${OPENXT_GIT_MIRROR}/bats-suite.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
+
+inherit allarch
 
 do_install () {
     if [ -e "${S}/dom0" ]; then
@@ -26,6 +28,9 @@ do_install () {
 }
 
 FILES_${PN} = " \
-	${libexecdir}/*"
+    ${libexecdir} \
+"
 
-RDEPENDS_${PN} = "bats"
+RDEPENDS_${PN} = " \
+    bats \
+"


### PR DESCRIPTION
The project was moved to the OpenXT organization, change SRC_URI accordingly.
Since the repository is named bats-suite, rename the recipe for consistency. Amend License md5 and apply recipe style-guide.