### PR TITLE
Introduce initramfs-framework functions module

### DIFF
--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -15,6 +15,7 @@ IMAGE_INSTALL = " \
     tpm-tools-sa \
     tpm2-tss \
     tpm2-tools \
+    initramfs-module-functions \
     initramfs-module-lvm \
     initramfs-module-bootfs \
     initramfs-module-tpm \

--- a/recipes-core/initrdscripts/initramfs-framework/functions
+++ b/recipes-core/initrdscripts/initramfs-framework/functions
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Copyright (C) 2019 Apertus Solutions, LLC
+# Licensed on MIT
+
+# Process any break kernel parameters
+check_break() {
+    local h="${1}"
+    local b="${2}"
+
+    if [ -n "${bootparam_break}" ]; then
+        for i in $(echo "${bootparam_break}" | sed "s/,/ /g"); do
+            if [ "${i}" = "${b}" ]; then
+                msg "Launching ${b} break ${h} hook"
+                sh
+            fi
+        done
+    fi
+}
+
+# Log message using User-level message facility to kernel log buffer
+log() {
+    local level="${1}"
+    local pri=$(( 8 + 6 )) # Default to info
+
+    case "${level}" in
+        "emerg") pri=$(( 8 + 0 )); shift ;;
+        "alert") pri=$(( 8 + 1 )); shift ;;
+        "crit") pri=$(( 8 + 2 )); shift ;;
+        "err") pri=$(( 8 + 3 )); shift ;;
+        "warning") pri=$(( 8 + 4 )); shift ;;
+        "notice") pri=$(( 8 + 5 )); shift ;;
+        "info") pri=$(( 8 + 6 )); shift ;;
+        "debug") pri=$(( 8 + 7 )); shift ;;
+    esac
+    echo "<${pri}> $@" > /dev/kmsg
+}
+
+functions_enabled() {
+    msg "Loading utility functions"
+
+    add_module_pre_hook check_break
+    add_module_post_hook check_break
+    return 1
+}
+
+functions_run() {
+    :
+}

--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
+    file://functions \
     file://lvm \
     file://bootfs \
     file://tpm \
@@ -10,6 +11,9 @@ SRC_URI += " \
 
 do_install_append() {
     install -d ${D}/init.d
+
+    # functions
+    install -m 0755 ${WORKDIR}/functions ${D}/init.d/00-functions
 
     # lvm
     install -m 0755 ${WORKDIR}/lvm ${D}/init.d/89-lvm
@@ -28,12 +32,17 @@ do_install_append() {
 }
 
 PACKAGES += " \
+            initramfs-module-functions \
             initramfs-module-lvm \
             initramfs-module-bootfs \
             initramfs-module-tpm \
             initramfs-module-tpm2 \
             initramfs-module-selinux \
             "
+
+SUMMARY_initramfs-module-functions = "initramfs support for functions"
+RDEPENDS_initramfs-module-functions = "${PN}-base"
+FILES_initramfs-module-functions = "/init.d/00-functions"
 
 SUMMARY_initramfs-module-lvm = "initramfs support for lvm"
 RDEPENDS_initramfs-module-lvm = "${PN}-base lvm2"


### PR DESCRIPTION
This PR introduces a functions module which provides a `break` function to interrupt module processing as well a `log` function to send log messages to the kernel log buffer so they can be written to disk stored logs.