### PR TITLE
Move writing hotplug-status from libxl to xen hotplug scripts

### DIFF
--- a/recipes-extended/xen/files/libxl-blktap3-support.patch
+++ b/recipes-extended/xen/files/libxl-blktap3-support.patch
@@ -265,7 +265,7 @@ PATCHES
              case LIBXL_DISK_BACKEND_QDISK:
                  flexarray_append(back, "params");
                  flexarray_append(back, GCSPRINTF("%s:%s",
-@@ -545,6 +546,16 @@ static int libxl__disk_from_xenstore(lib
+@@ -540,6 +541,16 @@ static int libxl__disk_from_xenstore(lib
      }
      libxl_string_to_backend(ctx, tmp, &(disk->backend));
  
@@ -282,7 +282,7 @@ PATCHES
      disk->vdev = xs_read(ctx->xsh, XBT_NULL,
                           GCSPRINTF("%s/dev", libxl_path), &len);
      if (!disk->vdev) {
-@@ -769,6 +780,7 @@ int libxl_cdrom_change(libxl_ctx *ctx, u
+@@ -763,6 +774,7 @@ int libxl_cdrom_change(libxl_ctx *ctx, u
  
      libxl__ao_complete(egc, ao, 0);
  out:

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -73,7 +73,7 @@ PATCHES
  
 --- a/tools/libxl/libxl_disk.c
 +++ b/tools/libxl/libxl_disk.c
-@@ -666,25 +666,138 @@ int libxl_device_disk_getinfo(libxl_ctx
+@@ -666,25 +666,137 @@ int libxl_device_disk_getinfo(libxl_ctx
      return rc;
  }
  
@@ -168,7 +168,6 @@ PATCHES
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/frontend-id", be_path), "%u", stubdomid);
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/dev", be_path), "%s", "hdc");
 +        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/tapdisk-params", be_path), "%s", libxl__sprintf(gc, "aio:%s", iso));
-+        libxl__xs_printf(gc, t, libxl__sprintf(gc, "%s/hotplug-status", be_path), "%s", "connected");
 +
 +        roperm[0].id = stubdomid;
 +        roperm[1].id = 0;

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -122,16 +122,6 @@ PATCHES
  
          GCNEW(aodev);
          libxl__prepare_ao_device(ao, aodev);
-@@ -1993,7 +2009,8 @@ void libxl__device_add_async(libxl__egc
-     aodev->action = LIBXL__DEVICE_ACTION_ADD;
-     libxl__wait_device_connection(egc, aodev);
- 
--    if (device->backend_kind == LIBXL__DEVICE_KIND_VIF)
-+    if (device->backend_kind == LIBXL__DEVICE_KIND_VIF ||
-+        device->backend_kind == LIBXL__DEVICE_KIND_VWIF)
-         libxl__xs_printf(gc, XBT_NULL,
-                          GCSPRINTF("%s/hotplug-status",
-                                    libxl__device_backend_path(gc, device)),
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
 @@ -1491,9 +1491,12 @@ static int libxl__build_device_model_arg

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -154,20 +154,6 @@ PATCHES
      }
      default:
          ret = ERROR_INVAL;
---- a/tools/libxl/libxl_disk.c
-+++ b/tools/libxl/libxl_disk.c
-@@ -451,6 +451,11 @@ static void device_disk_add(libxl__egc *
-     aodev->action = LIBXL__DEVICE_ACTION_ADD;
-     libxl__wait_device_connection(egc, aodev);
- 
-+    libxl__xs_printf(gc, XBT_NULL,
-+                     GCSPRINTF("%s/hotplug-status",
-+                               libxl__device_backend_path(gc, device)),
-+                     "connected");
-+
-     rc = 0;
- 
- out:
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
 @@ -2358,6 +2358,24 @@ retry_transaction:
@@ -510,49 +496,6 @@ PATCHES
                  if (common_domname
                      && strcmp(d_config.c_info.name, common_domname)) {
                      d_config.c_info.name = strdup(common_domname);
---- a/tools/libxl/libxl_console.c
-+++ b/tools/libxl/libxl_console.c
-@@ -688,11 +688,16 @@ out:
-     return AO_INPROGRESS;
- }
- 
-+static LIBXL_DEFINE_UPDATE_DEVID(vfb)
-+static LIBXL_DEFINE_DEVICE_FROM_TYPE(vfb)
-+
- static int libxl__set_xenstore_vfb(libxl__gc *gc, uint32_t domid,
-                                    libxl_device_vfb *vfb,
-                                   flexarray_t *back, flexarray_t *front,
-                                   flexarray_t *ro_front)
- {
-+    libxl__device *device;
-+
-     flexarray_append_pair(back, "vnc",
-                           libxl_defbool_val(vfb->vnc.enable) ? "1" : "0");
-     flexarray_append_pair(back, "vnclisten", vfb->vnc.listen);
-@@ -711,6 +716,13 @@ static int libxl__set_xenstore_vfb(libxl
-     if (vfb->sdl.display) {
-         flexarray_append_pair(back, "display", vfb->sdl.display);
-     }
-+    GCNEW(device);
-+    libxl__device_from_vfb(gc, domid, vfb, device);
-+    libxl__xs_printf(gc, XBT_NULL,
-+                     GCSPRINTF("%s/hotplug-status",
-+                               libxl__device_backend_path(gc, device)),
-+                     "connected");
-+
- 
-     return 0;
- }
-@@ -728,9 +740,6 @@ static int libxl__set_xenstore_vfb(libxl
- #define libxl_device_vfb_list NULL
- #define libxl_device_vfb_compare NULL
- 
--static LIBXL_DEFINE_UPDATE_DEVID(vfb)
--static LIBXL_DEFINE_DEVICE_FROM_TYPE(vfb)
--
- /* vfb */
- LIBXL_DEFINE_DEVICE_REMOVE(vfb)
- 
 --- a/tools/libxl/libxl_qmp.c
 +++ b/tools/libxl/libxl_qmp.c
 @@ -1019,6 +1019,11 @@ int libxl__qmp_system_wakeup(libxl__gc *

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -553,21 +553,6 @@ PATCHES
  /* vfb */
  LIBXL_DEFINE_DEVICE_REMOVE(vfb)
  
---- a/tools/libxl/libxl_device.c
-+++ b/tools/libxl/libxl_device.c
-@@ -1993,6 +1993,12 @@ void libxl__device_add_async(libxl__egc
-     aodev->action = LIBXL__DEVICE_ACTION_ADD;
-     libxl__wait_device_connection(egc, aodev);
- 
-+    if (device->backend_kind == LIBXL__DEVICE_KIND_VIF)
-+        libxl__xs_printf(gc, XBT_NULL,
-+                         GCSPRINTF("%s/hotplug-status",
-+                                   libxl__device_backend_path(gc, device)),
-+                         "connected");
-+
-     rc = 0;
- 
- out:
 --- a/tools/libxl/libxl_qmp.c
 +++ b/tools/libxl/libxl_qmp.c
 @@ -1019,6 +1019,11 @@ int libxl__qmp_system_wakeup(libxl__gc *

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/xenclient-dom0/vif
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/xenclient-dom0/vif
@@ -34,6 +34,8 @@ online)
                       --type=method_call / com.citrix.xenclient.networkslave.backend_vif_notify \
                       string:"${vif}" uint32:${DOMID} uint32:${DEVID}
         fi
+
+	xenstore-write "${XENBUS_PATH}/hotplug-status" "connected"
 	;;
 offline)
         logger -s "backend_vif_notify bridge for  backend/${TYPE}/${DOMID}/${DEVID}: remove"

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/xenclient-ndvm/vif
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/xenclient-ndvm/vif
@@ -93,6 +93,8 @@ case "$1" in
             done
         fi
         #end firewall
+
+        xenstore-write "${XENBUS_PATH}/hotplug-status" "connected"
         ;;
 
     offline)

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/xenclient-nilfvm/vif
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/xenclient-nilfvm/vif
@@ -47,6 +47,8 @@ case "$1" in
         brctl addif $BRIDGE ${vif}
         ifconfig ${vif} inet 0.0.0.0 promisc up
         #end bridge
+
+        xenstore-write "${XENBUS_PATH}/hotplug-status" "connected"
         ;;
     offline)
         xenstore-rm "${XAPI}/hotplug"


### PR DESCRIPTION
Upstream xen lets the xen hotplug scripts write the xenstore hotplug-status node.  I believe the idea is that the node is only written connected once the device is actually hooked up in the backend.  For instance, a vif is only connected once attached to a bridge.

Moving the write of hotplug-status out of libxl removes a little bit of our libxl patch queue.

Goes along with https://github.com/OpenXT/toolstack/pull/37