### PR TITLE
libxl: Use upstream hotplug block scripts

### DIFF
--- a/recipes-extended/xen/files/block-vbd3
+++ b/recipes-extended/xen/files/block-vbd3
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+dir="$(dirname "$0")"
+name="$(basename "$0")"
+if [ ! -e "${dir}/block-common.sh" ]; then
+    logger -p "daemon.err" -t "${name}" -- \
+        "Failed to find xen hotplug script framework in \"${dir}\"."
+    exit 1
+fi
+
+. "${dir}/block-common.sh"
+
+case "${command}" in
+    "add")
+        success
+        ;;
+    *)
+        ;;
+esac

--- a/recipes-extended/xen/files/libxl-block-scripts-log-to-syslog.patch
+++ b/recipes-extended/xen/files/libxl-block-scripts-log-to-syslog.patch
@@ -1,0 +1,11 @@
+--- xen.orig/tools/hotplug/Linux/xen-hotplug-common.sh.in	2019-08-28 14:13:57.845225343 -0400
++++ xen/tools/hotplug/Linux/xen-hotplug-common.sh.in	2019-08-28 14:17:23.495223153 -0400
+@@ -20,8 +20,6 @@
+ . "$dir/xen-script-common.sh"
+ . "$dir/locking.sh"
+ 
+-exec 2>>@XEN_LOG_DIR@/xen-hotplug.log
+-
+ export PATH="${bindir}:${sbindir}:${LIBEXEC_BIN}:/sbin:/bin:/usr/bin:/usr/sbin:$PATH"
+ export LD_LIBRARY_PATH="${libdir}${LD_LIBRARY_PATH+:}$LD_LIBRARY_PATH"
+ export LANG="POSIX"

--- a/recipes-extended/xen/files/volatiles.99_xen
+++ b/recipes-extended/xen/files/volatiles.99_xen
@@ -1,2 +1,0 @@
-d root root 0755 /var/run/xen none
-d root root 0755 /var/log/xen none

--- a/recipes-extended/xen/files/xen-vbd3-backend.rules
+++ b/recipes-extended/xen/files/xen-vbd3-backend.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="xen-backend", KERNEL=="vbd3*", RUN+="/etc/xen/scripts/block-vbd3 $env{ACTION}"

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -86,6 +86,7 @@ SRC_URI_append = " \
     file://libxl-disable-vnc-query-when-disabled.patch \
     file://xl-shutdown-wait-for-domain-death.patch \
     file://libxl-allow-save-vnuma.patch \
+    file://libxl-block-scripts-log-to-syslog.patch \
     file://domain-reboot.patch \
     file://libxl-retry-qmp-pci-add.patch \
     ${BLKTAP_PATCHQUEUE} \

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -42,6 +42,10 @@ RDEPENDS_${PN}-base_remove = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', '', '${PN}-blktap ${PN}-libblktapctl ${PN}-libvhd', d)} \
     "
 
+RDEPENDS_xen-xl += " \
+    xen-scripts-block \
+"
+
 RRECOMMENDS_${PN}-base_remove = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', '', '${PN}-libblktap', d)} \
     "

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -53,7 +53,6 @@ RRECOMMENDS_${PN}-base_remove = " \
 SRC_URI_append = " \
     file://xen-init-dom0.initscript \
     file://xl.conf \
-    file://volatiles.99_xen \
     "
 
 PACKAGES = " \
@@ -71,9 +70,6 @@ PACKAGES_remove = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', '', '${PN}-blktap ${PN}-libblktap ${PN}-libblktapctl ${PN}-libblktapctl-dev ${PN}-libblktap-dev', d)} \
     "
 
-FILES_${PN}-xl += " \
-    ${sysconfdir}/default/volatiles \
-"
 FILES_${PN}-staticdev = " \
     ${libdir}/libxlutil.a \
     ${libdir}/libxenlight.a \
@@ -164,8 +160,4 @@ do_install() {
     # Since we don't have a xenstore stubdomain, remove the
     # xenstore stubdomain init program (libdir == /usr/lib)
     rm -f ${D}/${libdir}/xen/bin/init-xenstore-domain
-
-    install -d ${D}${sysconfdir}/default/volatiles
-    install -m 0644 ${WORKDIR}/volatiles.99_xen \
-        ${D}${sysconfdir}/default/volatiles/99_xen
 }

--- a/recipes-extended/xen/xen.bb
+++ b/recipes-extended/xen/xen.bb
@@ -8,6 +8,8 @@ XEN_TARGET_ARCH = "x86_64"
 SRC_URI_append = "\
     file://xenconsoled.initscript \
     file://xenstored.initscript \
+    file://xen-vbd3-backend.rules \
+    file://block-vbd3 \
 "
 
 PACKAGES += " \
@@ -98,6 +100,14 @@ INITSCRIPT_PARAMS_${PN}-xenstored-c = "defaults 05"
 FILES_${PN}-misc += " \
     ${sbindir}/xen-diag \
     "
+
+FILES_${PN}-scripts-block += " \
+    ${sysconfdir}/udev/rules.d/xen-vbd3-backend.rules \
+    ${sysconfdir}/xen/scripts/block-vbd3 \
+"
+RDEPENDS_${PN}-scripts-block += " \
+    udev \
+"
 
 EXTRA_OEMAKE += "ETHERBOOT_ROMS=${STAGING_DIR_HOST}/usr/share/firmware/intel.rom"
 
@@ -197,6 +207,12 @@ do_install() {
             echo "d $i 0755 root root - -"  >> ${D}${sysconfdir}/tmpfiles.d/xen.conf
         done
     fi
+
+    # install vbd3 work-around block script and udev rule.
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0755 ${WORKDIR}/xen-vbd3-backend.rules ${D}${sysconfdir}/udev/rules.d/xen-vbd3-backend.rules
+    install -m 0755 ${WORKDIR}/block-vbd3 ${D}${sysconfdir}/xen/scripts/block-vbd3
+
     rm -rf ${D}/${sbindir}/xen-livepatch
     rm -rf ${D}/${bindir}/xen-cpuid
     rm -rf ${D}/${sysconfdir}/init.d/xencommons

--- a/recipes-extended/xen/xen.bb
+++ b/recipes-extended/xen/xen.bb
@@ -85,6 +85,10 @@ FILES_${PN}-xen-shim = "\
     ${libdir}/xen/boot/xen-shim \
     "
 
+RDEPENDS_${PN}-scripts-common += " \
+    perl \
+"
+
 INITSCRIPT_PACKAGES =+ "${PN}-console ${PN}-xenstored-c"
 INITSCRIPT_NAME_${PN}-console = "xenconsoled"
 INITSCRIPT_PARAMS_${PN}-console = "defaults 20"
@@ -166,7 +170,33 @@ do_install() {
         -i ${D}${sysconfdir}/init.d/xenstored.${PN}-xenstored-c
 
     # These files are not packaged, removing them to silence QA warnings
-    #   sbindir == /usr/sbin, bindir == /usr/bin, sysconfig == /etc
+    VOLATILE_DIRS=" \
+        ${localstatedir}/run/xenstored \
+        ${localstatedir}/run/xend \
+        ${localstatedir}/run/xend/boot \
+        ${localstatedir}/run/xen \
+        ${localstatedir}/log/xen \
+        ${localstatedir}/lock/xen \
+        ${localstatedir}/lock/subsys \
+        ${localstatedir}/lib/xen \
+        "
+
+    # install volatiles using populate_volatiles mechanism
+    install -d ${D}${sysconfdir}/default/volatiles
+    for i in $VOLATILE_DIRS; do
+        echo "d root root 0755 $i none"  >> ${D}${sysconfdir}/default/volatiles/99_xen
+    done
+
+    # workaround for xendomains script which searchs sysconfig if directory exists
+    install -d ${D}${sysconfdir}/sysconfig
+    ln -sf ${sysconfdir}/default/xendomains ${D}${sysconfdir}/sysconfig/xendomains
+
+    if ${@bb.utils.contains(DISTRO_FEATURES, 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/tmpfiles.d
+        for i in $VOLATILE_DIRS; do
+            echo "d $i 0755 root root - -"  >> ${D}${sysconfdir}/tmpfiles.d/xen.conf
+        done
+    fi
     rm -rf ${D}/${sbindir}/xen-livepatch
     rm -rf ${D}/${bindir}/xen-cpuid
     rm -rf ${D}/${sysconfdir}/init.d/xencommons

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bb
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bb
@@ -10,7 +10,7 @@ DEPENDS_append_xenclient-nilfvm += " ${@deb_bootstrap_deps(d)} "
 inherit autotools-brokensep ocaml findlib
 inherit ${@"xenclient-simple-deb"if(d.getVar("MACHINE",1)=="xenclient-nilfvm")else("null")}
 
-PACKAGES = "${PN}-dbg ${PN}-doc ${PN}-locale ${PN}-dev ${PN}-staticdev ${PN} \
+PACKAGES = "${PN}-dbg ${PN}-doc ${PN}-locale ${PN}-dev ${PN}-staticdev ${PN}-block-scripts ${PN} \
             ${PN}-libs-dbg ${PN}-libs-staticdev ${PN}-libs-dev ${PN}-libs \
             "
 # This is a little hybrid between usual package and findlib installation.
@@ -22,6 +22,12 @@ FILES_${PN} = " \
 "
 FILES_${PN}-dbg += " \
     /usr/src/debug \
+"
+FILES_${PN}-block-scripts = " \
+    ${sysconfdir}/xen/scripts/block \
+    ${sysconfdir}/xen/scripts/tap \
+    ${sysconfdir}/udev/rules.d/xen-block-backend.rules \
+    ${sysconfdir}/udev/rules.d/xen-tap-backend.rules \
 "
 FILES_${PN}-libs = " \
     ${sitelibdir}/*/*${SOLIBSDEV} \


### PR DESCRIPTION
When creating a stubdom that wants access to use a raw partition,
the custom xenclient-toolstack block scripts fail.  Using the
scripts from upstream fixes the issue.

Package the legacy udev rules separately for backwards compatibility.

Also, the patch for `xen-hotplug-common.sh` was applied to silence
selinux warnings from the custom logger and now we use syslog

OXT-1356

Signed-off-by: Tim Konick <konickt@ainfosec.com>