### PR TITLE
OXT-1429: refpolicy-mcs: Let modutils search tracefs.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.modutils.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.modutils.diff
@@ -8,7 +8,15 @@
  dev_search_usbfs(kmod_t)
  dev_rw_mtrr(kmod_t)
  dev_read_urand(kmod_t)
-@@ -105,12 +106,16 @@ logging_search_logs(kmod_t)
+@@ -94,6 +95,7 @@ files_manage_kernel_modules(kmod_t)
+ 
+ fs_getattr_xattr_fs(kmod_t)
+ fs_dontaudit_use_tmpfs_chr_dev(kmod_t)
++fs_search_tracefs(kmod_t)
+ 
+ init_rw_initctl(kmod_t)
+ init_use_fds(kmod_t)
+@@ -105,12 +107,16 @@ logging_search_logs(kmod_t)
  
  miscfiles_read_localization(kmod_t)
  
@@ -25,7 +33,7 @@
  ifdef(`init_systemd',`
  	init_rw_stream_sockets(kmod_t)
  
-@@ -135,6 +140,10 @@ optional_policy(`
+@@ -135,6 +141,10 @@ optional_policy(`
  ')
  
  optional_policy(`


### PR DESCRIPTION
upstream already fixes this:
https://github.com/SELinuxProject/refpolicy/commit/05cd55fb515bf282c61bcd3fb8637a663955f28f#diff-ace9bc8479c90380ba33eaaed3dfc997R105
```
denied  { search } for  pid=332 comm="modprobe" name="events" dev="tracefs" ino=1041 scontext=system_u:system_r:kmod_t:s0 tcontext=system_u:object_r:tracefs_t:s0 tclass=dir permissive=1
```