### PR TITLE
S9: qemu chardev-argo fixes

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -7,7 +7,7 @@
 +chardev-obj-$(CONFIG_XEN) += char-argo.o
 --- /dev/null
 +++ b/chardev/char-argo.c
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,345 @@
 +/*
 + * QEMU System Emulator
 + *
@@ -85,17 +85,31 @@
 +static int argo_chr_write(Chardev *chr, const uint8_t *buf, int len)
 +{
 +    ArgoChardev *s = ARGO_CHARDEV(chr);
++    int write_len = len;
 +    int ret;
 +
++ again:
 +    if (s->stream) {
-+        ret = argo_send(s->fd, buf, len, 0);
++        ret = argo_send(s->fd, buf, write_len, 0);
 +    } else {
-+        ret = argo_sendto(s->fd, buf, len, 0, &s->remote_addr);
++        ret = argo_sendto(s->fd, buf, write_len, 0, &s->remote_addr);
 +    }
-+    if (ret != len) {
-+        fprintf(stderr, "%s error: argo_sendto() failed (%s) - %d %d.\n",
-+                ARGO_CHARDRV_NAME, strerror(errno), ret, len);
-+        return 0;
++
++    if (ret == -1 && errno == EMSGSIZE) {
++        /*
++         * try again with a smaller chunk, but avoid 0 since argo_send returns
++         * 0 for that case and we'll end up looping.  Instead return -1 since
++         * we haven't made progress and the message will get dropped.
++         */
++        write_len /= 2;
++        if (write_len) {
++            goto again;
++        }
++    }
++
++    if (ret == -1) {
++        fprintf(stderr, "%s error: argo_sendto() errno=%d (%s) len=%d write_len=%d.\n",
++                ARGO_CHARDRV_NAME, errno, strerror(errno), len, write_len);
 +    }
 +
 +    return ret;

--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -238,7 +238,7 @@
 +    localport = localport_str ? strtoul(localport_str, NULL, 0) : 0;
 +
 +    backend->type = CHARDEV_BACKEND_KIND_ARGO;
-+    if (domid > 0x7ff4) {
++    if (domid >= DOMID_FIRST_RESERVED) {
 +        error_setg(errp, "chardev: argo: domid invalid");
 +        return;
 +    }


### PR DESCRIPTION
argo can return EMSGSIZE when a messages is too big to fit in the
destination ring.  In current code, QEMU will enter an infinite loop and
spam the log.  argo_send returns -1, and then argo_chr_write writes an
error message and returns 0.  The 0 return makes QEMU think there is
still len bytes to send.  Some code paths may just drop the message, but
for the QMP monitor, it will try to resend in a loop without making
progress.

The new code will try backing off the write size until a single
argo_send() succeeds.  Calling argo_send with write_len == 0 is avoided
since that will return zero.  Instead -1 is returned with -EMSGSIZE
which will be returned to the called.  In that case, the monitor code
will drop the message.

While space could become available, we don't know when.  Returning an
error avoids locking up QEMU if the destination ring fills and never
empties.

This issue can be triggered by a QMP command that generates a large
response, such as:
xl qemu-monitor-command $VM 'info mtree'

In the second commit, use the Xen provided define to check for invalid domids.

This is the stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1241