### PR TITLE
xen: Add missing dummy XSM init code to quiet Argo XSM check patch

### DIFF
--- a/recipes-extended/xen/files/argo-quiet-xsm-check-during-init.patch
+++ b/recipes-extended/xen/files/argo-quiet-xsm-check-during-init.patch
@@ -92,3 +92,13 @@ Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
      .argo_register_single_source = flask_argo_register_single_source,
      .argo_register_any_source = flask_argo_register_any_source,
      .argo_send = flask_argo_send,
+--- a/xen/xsm/dummy.c
++++ b/xen/xsm/dummy.c
+@@ -155,6 +155,7 @@ void __init xsm_fixup_ops (struct xsm_operations *ops)
+     set_to_dummy_if_null(ops, domain_resource_map);
+ #ifdef CONFIG_ARGO
+     set_to_dummy_if_null(ops, argo_enable);
++    set_to_dummy_if_null(ops, argo_enable_noaudit);
+     set_to_dummy_if_null(ops, argo_register_single_source);
+     set_to_dummy_if_null(ops, argo_register_any_source);
+     set_to_dummy_if_null(ops, argo_send);


### PR DESCRIPTION
The recent change to quiet the AVC issued when a domain does not have
XSM argo enabled unfortunately omitted a change to add initialization
logic to the dummy policy, so when running with the dummy policy active,
it results in a crash in Xen on boot.
This change adds the needed initialization.

Fixes OXT-1692.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>