### PR TITLE
S9: OXT-1662: init.root-ro: Leave console bound during boot

### DIFF
--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -408,8 +408,6 @@ unload_modules()
     exec 0<&-
     exec 1>&-
     exec 2>&-
-
-    echo -n 0 > /sys/class/vtconsole/vtcon1/bind 2>/dev/null
 }
 
 #


### PR DESCRIPTION
This is the stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1261

The call to unbind vtcon1 (frame buffer device) leaves the system
without an attached console during console mode boot.  When booting into
console mode and after entering the recovery password, this means that
the old frame buffer contents (the dialog output about resealing or
continuing boot) if left as the output on the display.  The boot output
is not displayed.

Console mode output formerly worked, but it seems to have changed when
fbcon switched from a module to a kernel built-in.  There was always an
unbind, but there used to be an rmmod as well.  My guess is `rmmod
fbcon` triggered the kernel to re-attached the dummy console.  Without
the module, we just leave an unattached console.

Even when "unbound" you could blindly log in and run `echo -n 1 >
/sys/class/vtconsole/vtcon1/bind` to re-bind the console.  I'm not sure
what it was buying us.

Just drop the unbind.

OXT-1662

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit cdd709a1d346dcdcbd0e1ab4ba8ca7fb5ff18503)