### PR TITLE
S9: Update openxt.cfg to set runlevel for UEFI boot

### DIFF
--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
@@ -24,12 +24,12 @@ xsm=policy.24
 
 [openxt-support-console]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon runlevel=3
 ramdisk=initramfs.gz
 xsm=policy.24
 
 [openxt-support-console-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon 3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon runlevel=3
 ramdisk=initramfs.gz
 xsm=policy.24


### PR DESCRIPTION
This is the stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1263

commit c11da6014c6e1fb33ec2ba951edfb69765653a69 "[efi] Turn on efi
runtime services in the kernel" reverted setting of "runlevel=3" to the
older "3" (originally done in commit
e2a14f972b9ad022633f5e4db7964a7498b5c5f9 "dom0-tweaks: change runlevel
declaration" for the initramfs-framework conversion).  This breaks
booting console mode since we don't run in init level 3, so surfman
starts and a getty isn't started.  (autostart is not set, so VM aren't
started).

Correct the runlevel setting.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 82969ac0e3ba110cb4124a91786bf71f2e7dec3f)