### PR TITLE
refpolicy-mcs: Give dev_search_xen perms to blktap_rw_blk_file

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/blktap.if
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/policy/modules/services/blktap.if
@@ -161,6 +161,7 @@ interface(`blktap_read_blk_file',`
 		type blktap_device_t;
 	')
 
+	dev_search_xen($1)
 	allow $1 blktap_device_t:blk_file read_file_perms;
 ')
 ########################################
@@ -178,6 +179,7 @@ interface(`blktap_rw_blk_file',`
 		type blktap_device_t;
 	')
 
+	dev_search_xen($1)
 	allow $1 blktap_device_t:blk_file rw_file_perms;
 ')
 ########################################


### PR DESCRIPTION
commit 861b0d7772012f73dcd266ce02a448f6b4e44dd0 "refpolicy-mcs: blktap
devnodes labeling" placed the blktap nodes within a xen_device_t labeled
directory.  This requires new xen_device_t permissions to actually
access the files.

Notably, non-stubdom domains can no longer start because qemu cannot
access the disk:

qemu-8: qemu-system-i386: -drive file=/dev/xen/blktap-2/tapdev9,if=none,id=ahcidisk-0,format=raw,cache=writeback: Could not open '/dev/xen/blktap-2/tapdev9': Permission denied
...
kernel:[  125.534414] audit: type=1400 audit(1569432775.150:4): avc:  denied  { search } for  pid=2872 comm="qemu-system-i38" name="blktap-2" dev="devtmpfs" ino=13085 scontext=system_u:system_r:qemu_t:s0:c236 tcontext=system_u:object_r:xen_device_t:s0 tclass=dir permissive=0

Give xen_device_t:dir search permissions (dev_search_xen) in the
blktap_rw_blk_file (and read) interface since all users need those
permissions to be useful.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>