### PR TITLE
xen: Remove locking.sh dependency on perl

### DIFF
--- a/recipes-extended/xen/files/0001-tools-helpers-Introduce-cmp-fd-file-inode-utility.patch
+++ b/recipes-extended/xen/files/0001-tools-helpers-Introduce-cmp-fd-file-inode-utility.patch
@@ -1,0 +1,113 @@
+From b3b5b2bd9c413c3e361d7f22b413c0a0019f4672 Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Thu, 5 Sep 2019 09:05:15 -0400
+Subject: [PATCH 1/2] tools/helpers: Introduce cmp-fd-file-inode utility
+
+This is a C implementation of the perl code inside of locking.sh to
+check that the locked file descriptor and lock file share the same inode
+and therefore match.  One change from the perl version is replacing
+printing "y" on success with exit values of 0 (shell True) and 1 (shell
+False).
+
+Requiring perl is a large dependency for the single use, so a dedicated
+utility removes that dependency for systems that otherwise would not
+install perl.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ .gitignore                        |  1 +
+ tools/helpers/Makefile            |  3 +++
+ tools/helpers/cmp-fd-file-inode.c | 42 +++++++++++++++++++++++++++++++
+ 3 files changed, 46 insertions(+)
+ create mode 100644 tools/helpers/cmp-fd-file-inode.c
+
+diff --git a/.gitignore b/.gitignore
+index 26bc583f74..d54dbb7eb6 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -177,6 +177,7 @@ tools/fuzz/x86_instruction_emulator/x86-emulate.[ch]
+ tools/helpers/_paths.h
+ tools/helpers/init-xenstore-domain
+ tools/helpers/xen-init-dom0
++tools/helpers/cmp-fd-file-inode
+ tools/hotplug/common/hotplugpath.sh
+ tools/hotplug/FreeBSD/rc.d/xencommons
+ tools/hotplug/FreeBSD/rc.d/xendriverdomain
+diff --git a/tools/helpers/Makefile b/tools/helpers/Makefile
+index f759528322..7daf5c46ca 100644
+--- a/tools/helpers/Makefile
++++ b/tools/helpers/Makefile
+@@ -8,6 +8,7 @@ include $(XEN_ROOT)/tools/Rules.mk
+ PROGS += xen-init-dom0
+ ifeq ($(CONFIG_Linux),y)
+ PROGS += init-xenstore-domain
++PROGS += cmp-fd-file-inode
+ endif
+ 
+ XEN_INIT_DOM0_OBJS = xen-init-dom0.o init-dom-json.o
+@@ -40,12 +41,14 @@ install: all
+ 	$(INSTALL_PROG) xen-init-dom0 $(DESTDIR)$(LIBEXEC_BIN)
+ ifeq ($(CONFIG_Linux),y)
+ 	$(INSTALL_PROG) init-xenstore-domain $(DESTDIR)$(LIBEXEC_BIN)
++	$(INSTALL_PROG) cmp-fd-file-inode $(DESTDIR)$(LIBEXEC_BIN)
+ endif
+ 
+ .PHONY: uninstall
+ uninstall:
+ ifeq ($(CONFIG_Linux),y)
+ 	rm -f $(DESTDIR)$(LIBEXEC_BIN)/init-xenstore-domain
++	rm -f $(DESTDIR)$(LIBEXEC_BIN)/cmp-fd-file-inode
+ endif
+ 	rm -f $(DESTDIR)$(LIBEXEC_BIN)/xen-init-dom0
+ 
+diff --git a/tools/helpers/cmp-fd-file-inode.c b/tools/helpers/cmp-fd-file-inode.c
+new file mode 100644
+index 0000000000..47029e3a66
+--- /dev/null
++++ b/tools/helpers/cmp-fd-file-inode.c
+@@ -0,0 +1,42 @@
++#include <stdio.h>
++#include <stdlib.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++
++void usage(const char * prog)
++{
++	printf(
++"%s <fd> <filename>\n"
++"Checks that the open file descriptor (referenced by number) has the same\n"
++"inode as the filename.\n"
++"Returns 0 on match and 1 on non-match\n", prog);
++}
++
++int main(int argc, char *argv[])
++{
++	struct stat fd_statbuf, file_statbuf;
++	int ret;
++	int fd;
++
++	if (argc < 3) {
++		usage(argv[0]);
++		return 1;
++	}
++
++	fd = strtoul(argv[1], NULL, 0);
++
++	ret = fstat(fd, &fd_statbuf);
++	if (ret) {
++		perror("fstat");
++		return -1;
++	}
++
++	ret = stat(argv[2], &file_statbuf);
++	if (ret) {
++		perror("stat");
++		return -1;
++	}
++
++	return !(fd_statbuf.st_ino == file_statbuf.st_ino);
++}
+-- 
+2.21.0
+

--- a/recipes-extended/xen/files/0002-Linux-locking.sh-Use-cmp-fd-file-inode-for-lock-chec.patch
+++ b/recipes-extended/xen/files/0002-Linux-locking.sh-Use-cmp-fd-file-inode-for-lock-chec.patch
@@ -1,0 +1,37 @@
+From 64c923ac73ce7050307084699db8072fc43826ac Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Thu, 5 Sep 2019 09:16:48 -0400
+Subject: [PATCH 2/2] Linux/locking.sh: Use cmp-fd-file-inode for lock check
+
+Replace perl with cmp-fd-file-inode when checking that the lock file
+descriptor and lockfile inodes match.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tools/hotplug/Linux/locking.sh | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/tools/hotplug/Linux/locking.sh b/tools/hotplug/Linux/locking.sh
+index c6a7e96ff9..de468c4bb5 100644
+--- a/tools/hotplug/Linux/locking.sh
++++ b/tools/hotplug/Linux/locking.sh
+@@ -50,14 +50,8 @@ claim_lock()
+         # actually a synthetic symlink in /proc and we aren't
+         # guaranteed that our stat(2) won't lose the race with an
+         # rm(1) between reading the synthetic link and traversing the
+-        # file system to find the inum.  Perl is very fast so use that.
+-        rightfile=$( perl -e '
+-            open STDIN, "<&'$_lockfd'" or die $!;
+-            my $fd_inum = (stat STDIN)[1]; die $! unless defined $fd_inum;
+-            my $file_inum = (stat $ARGV[0])[1];
+-            print "y\n" if $fd_inum eq $file_inum;
+-                             ' "$_lockfile" )
+-        if [ x$rightfile = xy ]; then break; fi
++        # file system to find the inum.
++        if cmp-fd-file-inode $_lockfd $_lockfile ; then break; fi
+ 	# Some versions of bash appear to be buggy if the same
+ 	# $_lockfile is opened repeatedly. Close the current fd here.
+         eval "exec $_lockfd<&-"
+-- 
+2.21.0
+

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -102,6 +102,8 @@ SRC_URI_append = " \
     file://argo-quiet-xsm-check-during-init.patch \
     file://libxl-seabios-ipxe.patch \
     file://memory-scrub-on-domain-shutdown.patch \
+    file://0001-tools-helpers-Introduce-cmp-fd-file-inode-utility.patch \
+    file://0002-Linux-locking.sh-Use-cmp-fd-file-inode-for-lock-chec.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-extended/xen/xen-libxl.bb
+++ b/recipes-extended/xen/xen-libxl.bb
@@ -22,6 +22,7 @@ python () {
                 'libxlutil-dev',
                 'libxenlight',
                 'libxenlight-dev'
+                'cmp-fd-file-inode',
                 ]:
         d.renameVar("FILES_xen-libxl-" + PKG, "FILES_xen-" + PKG)
 
@@ -63,6 +64,7 @@ PACKAGES = " \
     xen-libxenlight \
     xen-libxenlight-dev \
     xen-libxl-staticdev \
+    xen-cmp-fd-file-inode \
     ${PN}-dbg \
     "
 
@@ -85,6 +87,9 @@ FILES_${PN}-dbg += " \
     ${sbindir}/.debug \
     ${libdir}/.debug \
     /usr/src/debug \
+"
+FILES_xen-cmp-fd-file-inode = " \
+    ${libdir}/xen/bin/cmp-fd-file-inode \
 "
 
 CFLAGS_prepend += "${@bb.utils.contains('DISTRO_FEATURES', 'blktap2', '', '-I${STAGING_INCDIR}/blktap',d)}"

--- a/recipes-extended/xen/xen.bb
+++ b/recipes-extended/xen/xen.bb
@@ -88,7 +88,7 @@ FILES_${PN}-xen-shim = "\
     "
 
 RDEPENDS_${PN}-scripts-common += " \
-    perl \
+    ${PN}-cmp-fd-file-inode \
 "
 
 INITSCRIPT_PACKAGES =+ "${PN}-console ${PN}-xenstored-c"


### PR DESCRIPTION
Add cmp-fd-file-inode tool to remove dependency on perl.

We put it in its own package and make xen-scripts-common depend on it.
We can't just include it in the xen-scripts-common package because
cmp-fd-file-inode is built in xen-lixl.bb and xen-scripts-common is
built in xen.bb.

This removes the perl dependency in https://github.com/OpenXT/xenclient-oe/pull/1255