### PR TITLE
S9: blktap3: Update another LIBBLOCKCRYPTO_NAME variable

### DIFF
--- a/recipes-extended/xen/blktap3/fix-run-time-errors-and-memory-leaks.patch
+++ b/recipes-extended/xen/blktap3/fix-run-time-errors-and-memory-leaks.patch
@@ -241,3 +241,14 @@ PATCHES
  
  #define MAX_KEY_SIZE 512
  int CRYPTO_SUPPORTED_KEYSIZE[] = { 512, 256, -1};
+--- a/vhd/lib/vhd-util-copy.c
++++ b/vhd/lib/vhd-util-copy.c
+@@ -46,7 +46,7 @@
+ 
+ #include "libvhd.h"
+ 
+-#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so"
++#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so.0"
+ 
+ typedef int (*vhd_calculate_keyhash)(struct vhd_keyhash *keyhash,
+ 					     const uint8_t *key, size_t key_byte);


### PR DESCRIPTION
Stable-9 version of https://github.com/OpenXT/xenclient-oe/pull/1271

LIBBLOCKCRYPTO_NAME exists in vhd-util-copy.c as well as the other
places.  Update that copy as well.  Otherwise, you'll receive an error:
"failed to load crypto support library"

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>