### PR TITLE
class: Remove always_rebuild... class.

### DIFF
--- a/classes/always_rebuild_xc_git_recipes.bbclass
+++ b/classes/always_rebuild_xc_git_recipes.bbclass
@@ -1,9 +1,0 @@
-python() {
-    src_uris = (d.getVar("SRC_URI", True) or "").split()
-    xc_git = d.getVar("OPENXT_GIT_MIRROR", True)
-    recipe = os.path.basename(d.getVar("FILE", True) or "")
-    for src_uri in src_uris:
-        if src_uri.startswith(xc_git):
-    	    bb.note("Recipe %s uses XC Git - disabling pstaging" % recipe)
-            d.setVar('PSTAGING_DISABLED','1')
-}


### PR DESCRIPTION
No functional change.

This was maybe intended to have `PSTAGING_DISABLED` for OpenXT recipes (`SRC_URI` has `OPENXT_GIT_MIRROR` source). This is not used and it is not quite clear what `PSTAGING` was.

This class is not inherited anywhere, it will still be parsed by bitbake when the layer is added though. Since it is no longer used, it should be removed.