### PR TITLE
Stable-9: linux 4.19: Apply XSA-300: No grant table and foreign mapping limits

### DIFF
--- a/recipes-kernel/linux/4.19/linux-openxt_4.19.53.bb
+++ b/recipes-kernel/linux/4.19/linux-openxt_4.19.53.bb
@@ -44,6 +44,7 @@ SRC_URI += "${KERNELORG_MIRROR}/linux/kernel/v${PV_MAJOR}.x/linux-${PV}.tar.xz;n
     file://xsa-155-qsb-023-xen-netfront-add-range-check-for-Tx-response-id.patch \
     file://xsa-155-qsb-023-xen-netfront-copy-response-out-of-shared-buffer-befo.patch \
     file://xsa-155-qsb-023-xen-netfront-do-not-use-data-already-exposed-to-back.patch \
+    file://xsa300-linux-5.2.patch \
     file://defconfig \
     "
 SRC_URI_append_xenclient-dom0 = "file://efi-tables-for-dom0.patch \

--- a/recipes-kernel/linux/4.19/patches/xsa300-linux-5.2.patch
+++ b/recipes-kernel/linux/4.19/patches/xsa300-linux-5.2.patch
@@ -1,0 +1,69 @@
+From ea49450ded575facc0e64e0d6adcb1ca8aaad0ba Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Wed, 19 Jun 2019 11:00:56 +0200
+Subject: [PATCH] xen: let alloc_xenballooned_pages() fail if not enough memory
+ free
+
+Instead of trying to allocate pages with GFP_USER in
+add_ballooned_pages() check the available free memory via
+si_mem_available(). GFP_USER is far less limiting memory exhaustion
+than the test via si_mem_available().
+
+This will avoid dom0 running out of memory due to excessive foreign
+page mappings especially on ARM and on x86 in PVH mode, as those don't
+have a pre-ballooned area which can be used for foreign mappings.
+
+As the normal ballooning suffers from the same problem don't balloon
+down more than si_mem_available() pages in one iteration. At the same
+time limit the default maximum number of retries.
+
+Reported-by: Julien Grall <julien.grall@arm.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+---
+ drivers/xen/balloon.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/xen/balloon.c b/drivers/xen/balloon.c
+index d37dd5bb7a8f..559768dc2567 100644
+--- a/drivers/xen/balloon.c
++++ b/drivers/xen/balloon.c
+@@ -538,8 +538,15 @@ static void balloon_process(struct work_struct *work)
+ 				state = reserve_additional_memory();
+ 		}
+ 
+-		if (credit < 0)
+-			state = decrease_reservation(-credit, GFP_BALLOON);
++		if (credit < 0) {
++			long n_pages;
++
++			n_pages = min(-credit, si_mem_available());
++			state = decrease_reservation(n_pages, GFP_BALLOON);
++			if (state == BP_DONE && n_pages != -credit &&
++			    n_pages < totalreserve_pages)
++				state = BP_EAGAIN;
++		}
+ 
+ 		state = update_schedule(state);
+ 
+@@ -578,6 +585,9 @@ static int add_ballooned_pages(int nr_pages)
+ 		}
+ 	}
+ 
++	if (si_mem_available() < nr_pages)
++		return -ENOMEM;
++
+ 	st = decrease_reservation(nr_pages, GFP_USER);
+ 	if (st != BP_DONE)
+ 		return -ENOMEM;
+@@ -710,7 +720,7 @@ static int __init balloon_init(void)
+ 	balloon_stats.schedule_delay = 1;
+ 	balloon_stats.max_schedule_delay = 32;
+ 	balloon_stats.retry_count = 1;
+-	balloon_stats.max_retry_count = RETRY_UNLIMITED;
++	balloon_stats.max_retry_count = 4;
+ 
+ #ifdef CONFIG_XEN_BALLOON_MEMORY_HOTPLUG
+ 	set_online_page_callback(&xen_online_page);
+-- 
+2.16.4
+


### PR DESCRIPTION
Applies the XSA-300 patch to the 4.19 Linux kernel.

https://xenbits.xen.org/xsa/advisory-300.html
fixes CVE-2019-17351

OXT-1703

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>