### PR TITLE
qemu: Avoid QMP events filling the argo ring

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -7,7 +7,7 @@
 +chardev-obj-$(CONFIG_XEN) += char-argo.o
 --- /dev/null
 +++ b/chardev/char-argo.c
-@@ -0,0 +1,345 @@
+@@ -0,0 +1,354 @@
 +/*
 + * QEMU System Emulator
 + *
@@ -88,6 +88,11 @@
 +    int write_len = len;
 +    int ret;
 +
++    if (!s->connected) {
++        /* This is important to drop events when not connected. */
++        return len;
++    }
++
 + again:
 +    if (s->stream) {
 +        ret = argo_send(s->fd, buf, write_len, 0);
@@ -167,6 +172,9 @@
 +    if (!s->stream) {
 +        if (s->connected == 0 && !strncmp((char*)(s->buf), ARGO_MAGIC_CONNECT, 4)) {
 +            fprintf(stderr, "argo_recvfrom() returned ARGO_MAGIC_CONNECT, connecting.\n");
++            /* update "connected" first since qemu_chr_be_event calls monitor
++               code which can call back into argo_chr_write to send data. */
++            s->connected = 1;
 +            argo_chr_update_read_handler(chr);
 +            qemu_chr_be_event(chr, CHR_EVENT_OPENED);
 +            if (!chr->gsource) {
@@ -174,10 +182,12 @@
 +                                                 argo_chr_read_poll,
 +                                                 argo_chr_read, chr, chr->gcontext);
 +            }
-+            s->connected = 1;
 +            return FALSE;
 +        }
 +        if (s->connected == 1 && !strncmp((char*)(s->buf), ARGO_MAGIC_DISCONNECT, 4)) {
++            /* update "connected" first since qemu_chr_be_event calls monitor
++               code which can call back into argo_chr_write to send data. */
++            s->connected = 0;
 +            argo_chr_update_read_handler(chr);
 +            qemu_chr_be_event(chr, CHR_EVENT_CLOSED);
 +            if (!chr->gsource) {
@@ -186,7 +196,6 @@
 +                                                 argo_chr_read, chr, chr->gcontext);
 +            }
 +            fprintf(stderr, "argo_recvfrom() returned ARGO_MAGIC_DISCONNECT, closing.\n");
-+            s->connected = 0;
 +            return FALSE;
 +        }
 +    }


### PR DESCRIPTION
We've observed a hang where qemu is blocked in argo_send for a QMP
RTC_CHANGE event.  This seems to happen with NTP time updates on Windows
10.

qmp_helper, when not connected, sits blocked in an accept() call and
does not service its Argo connection.  That means events like the above
will fill up the argo ring.  qemu's argo socket is blocking, so when an
additional event comes in, argo_send blocks in the kernel and qemu
hangs.

We already have some connected state logic for QMP, so re-use that.
When not connected, just drop the writes.  Normal writes happen as
response to requests while a client is connected, and a client will stay
connected until it receives its response.  Events may come through while
a client is connected or not.  With a client connected, it's up to the
client to handle them.  Without a client, we can just drop them.

To make this work, argo_chr_read had to move forward the setting &
clearing of connected.  Without that change, on connect, argo_chr_write
could be called while connected=0 and valid responses were dropped.
That is because qemu_chr_be_event() -> monitor_qmp_event() ->
qmp_send_response()-> argo_chr_write().  Setting connected=1 before
argo_chr_update_read_handler(chr) and qemu_chr_be_event() avoids that.

OXT-1699

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>