### PR TITLE
xen-libxl patch cleanup

### DIFF
--- a/recipes-extended/xen/files/hvmloader-legacy-seabios-optionroms.patch
+++ b/recipes-extended/xen/files/hvmloader-legacy-seabios-optionroms.patch
@@ -145,7 +145,7 @@ PATCHES
  {
      unsigned int bios_dest = 0x100000 - bios_length;
  
-@@ -140,12 +155,79 @@ static void seabios_load(const struct bi
+@@ -140,12 +155,76 @@ static void seabios_load(const struct bi
      memcpy((void *)bios_dest, bios_addr, bios_length);
      seabios_config.bios_address = bios_dest;
      seabios_config.image_size = bios_length;
@@ -159,9 +159,6 @@ PATCHES
 +    int option_rom_sz = 0, vgabios_sz = 0, etherboot_sz = 0;
 +    uint32_t etherboot_phys_addr = 0, option_rom_phys_addr = 0;
 +    const char *load;
-+    load = xenstore_read("hvmloader/seabios-legacy-load-roms", "0");
-+    if (strcmp(load, "1") != 0)
-+        return;
 +    switch ( virtual_vga )
 +    {
 +    case VGA_cirrus:

--- a/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
+++ b/recipes-extended/xen/files/libxl-avoid-creating-unusable-cdrom-vbd-xs-nodes.patch
@@ -21,7 +21,7 @@ Mahantesh Salimath<salimathm@ainfosec.com>
 ################################################################################
 --- a/tools/libxl/libxl_create.c
 +++ b/tools/libxl/libxl_create.c
-@@ -1334,7 +1334,7 @@ static void domcreate_rebuild_done(libxl
+@@ -1315,7 +1315,7 @@ static void domcreate_rebuild_done(libxl
  
      /* convenience aliases */
      const uint32_t domid = dcs->guest_domid;
@@ -30,7 +30,7 @@ Mahantesh Salimath<salimathm@ainfosec.com>
  
      if (ret) {
          LOGD(ERROR, domid, "cannot (re-)build domain: %d", ret);
-@@ -1342,12 +1342,62 @@ static void domcreate_rebuild_done(libxl
+@@ -1323,12 +1323,62 @@ static void domcreate_rebuild_done(libxl
          goto error_out;
      }
  

--- a/recipes-extended/xen/files/libxl-disable-json-updates.patch
+++ b/recipes-extended/xen/files/libxl-disable-json-updates.patch
@@ -60,7 +60,7 @@ PATCHES
          return AO_INPROGRESS;                                           \
 --- a/tools/libxl/libxl_create.c
 +++ b/tools/libxl/libxl_create.c
-@@ -1721,25 +1721,6 @@ static void domcreate_complete(libxl__eg
+@@ -1695,25 +1695,6 @@ static void domcreate_complete(libxl__eg
  
      bool retain_domain = !rc || rc == ERROR_ABORTED;
  

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -36,18 +36,6 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2312,6 +2312,11 @@ void libxl__spawn_stub_dm(libxl__egc *eg
-                                    libxl__xs_get_dompath(gc, guest_domid)),
-                         "%s",
-                         libxl_bios_type_to_string(guest_config->b_info.u.hvm.bios));
-+        /* OpenXT: We use legacy roms, which is disabled by default in sebios */
-+        libxl__xs_printf(gc, XBT_NULL,
-+                        libxl__sprintf(gc, "%s/hvmloader/seabios-legacy-load-roms",
-+                                       libxl__xs_get_dompath(gc, guest_domid)),
-+                        "1");
-     }
-     ret = xc_domain_set_target(ctx->xch, dm_domid, guest_domid);
-     if (ret<0) {
 @@ -2336,6 +2341,12 @@ retry_transaction:
          if (errno == EAGAIN)
              goto retry_transaction;
@@ -95,15 +83,10 @@ PATCHES
                  /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
                   * will be in use */
                  console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
-@@ -2653,6 +2658,17 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2653,6 +2658,12 @@ void libxl__spawn_local_dm(libxl__egc *e
                           b_info->device_model_version==LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL &&
                           !libxl__vnuma_configured(b_info));
          free(path);
-+        /* OpenXT: We use legacy roms, which is disabled by default in sebios */
-+        libxl__xs_printf(gc, XBT_NULL,
-+                         libxl__sprintf(gc, "%s/hvmloader/seabios-legacy-load-roms",
-+                                       libxl__xs_get_dompath(gc, domid)),
-+                        "1");
 +        /* OpenXT: We add the device models extended power management type to enable acpi.
 +         * We do this here since we need the permission above.
 +         */

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -46,23 +46,7 @@ PATCHES
  int libxl_domain_sleep(libxl_ctx *ctx, uint32_t domid);
 --- a/tools/libxl/libxl_create.c
 +++ b/tools/libxl/libxl_create.c
-@@ -677,10 +677,14 @@ retry_transaction:
-     libxl__xs_mknod(gc, t,
-                     GCSPRINTF("%s/control", dom_path),
-                     roperm, ARRAY_SIZE(roperm));
--    if (info->type == LIBXL_DOMAIN_TYPE_HVM)
-+    if (info->type == LIBXL_DOMAIN_TYPE_HVM) {
-         libxl__xs_mknod(gc, t,
-                         GCSPRINTF("%s/hvmloader", dom_path),
-                         roperm, ARRAY_SIZE(roperm));
-+        libxl__xs_printf(gc, t,
-+                        GCSPRINTF("%s/hvmloader/seabios-legacy-load-roms", dom_path),
-+                        "1");
-+    }
- 
-     libxl__xs_mknod(gc, t,
-                     GCSPRINTF("%s/control/shutdown", dom_path),
-@@ -750,6 +769,11 @@ retry_transaction:
+@@ -750,6 +750,11 @@ retry_transaction:
      libxl__xs_writev(gc, t, dom_path, info->xsdata);
      libxl__xs_writev(gc, t, GCSPRINTF("%s/platform", dom_path), info->platformdata);
  

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -58,7 +58,7 @@ PATCHES
      xs_write(ctx->xsh, t, GCSPRINTF("%s/control/platform-feature-multiprocessor-suspend", dom_path), "1", 1);
      xs_write(ctx->xsh, t, GCSPRINTF("%s/control/platform-feature-xs_reset_watches", dom_path), "1", 1);
  
-@@ -1435,17 +1459,12 @@ static void domcreate_launch_dm(libxl__e
+@@ -1435,17 +1440,12 @@ static void domcreate_launch_dm(libxl__e
      {
          libxl__device_console console;
          libxl__device device;
@@ -76,7 +76,7 @@ PATCHES
          dcs->sdss.dm.guest_domid = domid;
          if (libxl_defbool_val(d_config->b_info.device_model_stubdomain))
              libxl__spawn_stub_dm(egc, &dcs->sdss);
-@@ -1485,23 +1492,17 @@ static void domcreate_launch_dm(libxl__e
+@@ -1485,23 +1485,17 @@ static void domcreate_launch_dm(libxl__e
              libxl__device_console_dispose(&vuart);
          }
  

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -46,28 +46,11 @@ PATCHES
  int libxl_domain_sleep(libxl_ctx *ctx, uint32_t domid);
 --- a/tools/libxl/libxl_create.c
 +++ b/tools/libxl/libxl_create.c
-@@ -676,11 +676,30 @@ retry_transaction:
-                     roperm, ARRAY_SIZE(roperm));
+@@ -677,10 +677,14 @@ retry_transaction:
      libxl__xs_mknod(gc, t,
                      GCSPRINTF("%s/control", dom_path),
--                    roperm, ARRAY_SIZE(roperm));
+                     roperm, ARRAY_SIZE(roperm));
 -    if (info->type == LIBXL_DOMAIN_TYPE_HVM)
-+                    rwperm, ARRAY_SIZE(rwperm));
-+    libxl__xs_mknod(gc, t,
-+                    GCSPRINTF("%s/error", dom_path),
-+                    rwperm, ARRAY_SIZE(rwperm));
-+    libxl__xs_mknod(gc, t,
-+                    GCSPRINTF("%s/drivers", dom_path),
-+                    rwperm, ARRAY_SIZE(rwperm));
-+    libxl__xs_mknod(gc, t,
-+                    GCSPRINTF("%s/attr", dom_path),
-+                    rwperm, ARRAY_SIZE(rwperm));
-+    libxl__xs_mknod(gc, t,
-+                    GCSPRINTF("%s/data", dom_path),
-+                    rwperm, ARRAY_SIZE(rwperm));
-+    libxl__xs_mknod(gc, t,
-+                    GCSPRINTF("%s/messages", dom_path),
-+                    rwperm, ARRAY_SIZE(rwperm));
 +    if (info->type == LIBXL_DOMAIN_TYPE_HVM) {
          libxl__xs_mknod(gc, t,
                          GCSPRINTF("%s/hvmloader", dom_path),

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -76,22 +76,7 @@ PATCHES
          dcs->sdss.dm.guest_domid = domid;
          if (libxl_defbool_val(d_config->b_info.device_model_stubdomain))
              libxl__spawn_stub_dm(egc, &dcs->sdss);
-@@ -1468,7 +1487,14 @@ static void domcreate_launch_dm(libxl__e
-         libxl__device_console console, vuart;
-         libxl__device device;
- 
-+        fprintf(stderr, "WARNING: before adding vkb device.\n");
-+        for (i = 0; i < d_config->num_vkbs; i++) {
-+            fprintf(stderr, "WARNING: adding vkb device.\n");
-+            libxl__device_add(gc, domid, &libxl__vkb_devtype, &d_config->vkbs[i]);
-+        }
-+
-         for (i = 0; i < d_config->num_vfbs; i++) {
-+            fprintf(stderr, "WARNING: adding vfb device.\n");
-             libxl__device_add(gc, domid, &libxl__vfb_devtype,
-                               &d_config->vfbs[i]);
-         }
-@@ -1485,23 +1511,17 @@ static void domcreate_launch_dm(libxl__e
+@@ -1485,23 +1492,17 @@ static void domcreate_launch_dm(libxl__e
              libxl__device_console_dispose(&vuart);
          }
  


### PR DESCRIPTION
I noticed some unnecessary changes in our libxl patches which are removed in this series.

@crogers1 Is there a particular reason for changing "/local/domain/N/control" to rw perms https://github.com/OpenXT/xenclient-oe/commit/db804d91b4d16e498ef8656094ddfc403933c546#diff-83c581625019ac0b6ff2913055c602acR52?  You introduced it originally, but I don't think it's necessary.