### PR TITLE
refpolicy: Fix typos in patches.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/network-daemon-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/network-daemon-interfaces.diff
@@ -74,7 +74,7 @@
 +	network_slave_use_fds(kmod_t)
 +')
 +
-++optional_policy(`
++optional_policy(`
  	nis_use_ypbind(kmod_t)
  ')
  

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.contrib.xen.diff
@@ -395,7 +395,7 @@
  term_use_ptmx(xend_t)
  term_getattr_pty_fs(xend_t)
  
-++# runlevel stuff
++# runlevel stuff
 +init_rw_utmp(xend_t)
 +init_telinit(xend_t)
  init_stream_connect_script(xend_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/sysutils-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/sysutils-interfaces.diff
@@ -7,7 +7,7 @@
 +	lsusb_run(sysadm_t, sysadm_r)
 +')
 +
-++optional_policy(`
++optional_policy(`
  	lvm_admin(sysadm_t, sysadm_r)
  	lvm_run(sysadm_t, sysadm_r)
  ')


### PR DESCRIPTION
There are a few typos in some patches that left some leading '+' characters, likely from reject files.

For some reason, building the policy does not fail almost all of the time.