### PR TITLE
ovmf: Upgrade PREBOOT.EXE to 24.3.

### DIFF
--- a/recipes-core/ovmf/ovmf_git.bbappend
+++ b/recipes-core/ovmf/ovmf_git.bbappend
@@ -8,8 +8,9 @@ SRC_URI = "git://github.com/tianocore/edk2.git;branch=master \
 
 SRCREV="dd4cae4d82c7477273f3da455084844db5cca0c0"
 
-# PREBOOT.EXE, OS independent, latest version (currently 24.2).
-SRC_URI[PREBOOT.sha256sum] = "090137bc8af0b05c1ae2b27b8b7851d295cb1225880fb4657c7ddc470b261485"
+# PREBOOT.EXE, OS independent, latest version (currently 24.3).
+SRC_URI[PREBOOT.md5sum] = "8660641e184dafdeb78b8ca1fbd837f7"
+SRC_URI[PREBOOT.sha256sum] = "83dac749d74a6a54d7451bee79f9e1d605c4e2775d6b524d39030b248989092a"
 
 FILES_${PN} += "\
     /usr/share/firmware/ovmf.bin \


### PR DESCRIPTION
24.2 mirror changed again since 24.3 is provided.
Also add the md5sum of the archive, making this easier to check with the website.

This changed sometime since yesterday with 24.2 now being provided at https://downloadmirror.intel.com/29166/eng/PREBOOT.EXE.

`E3522X2.EFI` hasn't changed in the new version, this is the only file extracted from the archive.
```
7862a12529539905d4f57c94920d52b4  PREBOOT.0/APPS/EFI/EFIx64/E3522X2.EFI
```