### PR TITLE
S9: refpolicy: Fix typos in patches.

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/network-daemon-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/network-daemon-interfaces.diff
@@ -86,7 +86,7 @@ Index: refpolicy/policy/modules/system/modutils.te
 +	network_slave_use_fds(kmod_t)
 +')
 +
-++optional_policy(`
++optional_policy(`
  	nis_use_ypbind(kmod_t)
  ')
  

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.contrib.xen.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.contrib.xen.diff
@@ -363,7 +363,7 @@ Index: refpolicy/policy/modules/contrib/xen.te
  term_use_ptmx(xend_t)
  term_getattr_pty_fs(xend_t)
  
-++# runlevel stuff
++# runlevel stuff
 +init_rw_utmp(xend_t)
 +init_telinit(xend_t)
  init_stream_connect_script(xend_t)

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/sysutils-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/sysutils-interfaces.diff
@@ -9,7 +9,7 @@ Index: refpolicy/policy/modules/roles/sysadm.te
 +	lsusb_run(sysadm_t, sysadm_r)
 +')
 +
-++optional_policy(`
++optional_policy(`
  	lvm_admin(sysadm_t, sysadm_r)
  	lvm_run(sysadm_t, sysadm_r)
  ')


### PR DESCRIPTION
There are a few typos in some patches that left some leading '+'
characters, likely from reject files.

For some reason, building the policy does not fail almost all of the
time.

(cherry picked from commit 4c403d0bc4bf09ee8c48c6b44c933d9d8b180e25)
