### PR TITLE
pyicbinn: link against libicbinn not libicbinn_resolved

### DIFF
--- a/recipes-openxt/libicbinn/pyicbinn_git.bb
+++ b/recipes-openxt/libicbinn/pyicbinn_git.bb
@@ -6,6 +6,6 @@ require icbinn.inc
 
 S = "${WORKDIR}/git/pyicbinn"
 
-DEPENDS = "swig-native libicbinn-resolved xenclient-rpcgen-native"
+DEPENDS = "swig-native libicbinn xenclient-rpcgen-native"
 
 inherit distutils3


### PR DESCRIPTION
libicbinn_resolved is a static library, so security_flags specifying
-fPIC causes a link error.  libicbinn_resolved is a weird wrapping of
libicbinn.  python has shared library support, so we can just use that
to link against libicbinn itself.

Update the recipe to depend against libicbinn.

OXT-1697
OXT-447

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

Goes along with https://github.com/OpenXT/icbinn/pull/7