### PR TITLE
packagegroup-dom0: Remove explicit lib depends

### DIFF
--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -15,10 +15,6 @@ RDEPENDS_${PN} = " \
     xen-hypervisor \
     xen-efi \
     xen-flask-tools \
-    xen-libxenguest \
-    xen-libxenlight \
-    xen-libxenstat \
-    xen-libxlutil \
     xen-xenstat \
     xen-xenstored \
     xen-xl \
@@ -30,9 +26,7 @@ RDEPENDS_${PN} = " \
     e2fsprogs-tune2fs \
     e2fsprogs-resize2fs \
     kernel-modules \
-    libargo \
     libargo-bin \
-    libedid \
     lvm2 \
     bridge-utils \
     iptables \


### PR DESCRIPTION
With package dependency tracking, we shouldn't be explicitly installing
libraries.  Just install executables and let their dependencies bring in
their needed libraries.

For the dropped libraries:
xen-xl -> xen-libxenguest, xen-libxenlight, xen-libxlutil
xen-xenstat -> xen-libxenstat
surfman -> libedid
rpc-proxy -> libxchargo -> libargo

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>