### PR TITLE
icedtea: fix compilation on recent compilers

### DIFF
--- a/recipes-core/icedtea/icedtea7-native_2.%.bbappend
+++ b/recipes-core/icedtea/icedtea7-native_2.%.bbappend
@@ -1,0 +1,1 @@
+CXX_append += " -Wno-error=stringop-overflow -Wno-error=deprecated-declarations -Wno-error=return-type"


### PR DESCRIPTION
icedtea is compiled with -Werror, and compilation fails on recent
versions of gcc which introduce new warnings.
This PR keeps the warnings but avoids error-ing on them.

Signed-off-by: Jed <lejosnej@ainfosec.com>