### PR TITLE
qemu-dm: acpi-pm: Use device-model xenstore directory

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/acpi-pm-feature.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/acpi-pm-feature.patch
@@ -1111,7 +1111,7 @@ PATCHES
 +   char base[XEN_BUFSIZE];
 +   int err;
 +
-+   snprintf(base, sizeof(base), "/local/domain/%d/control", xen_domid);
++   snprintf(base, sizeof(base), "device-model/%d", xen_domid);
 +
 +   err = xenstore_add_watch(base, "hvm-shutdown", power_button_changed_cb, s);
 +
@@ -1139,7 +1139,7 @@ PATCHES
 +     * register bank, which is addr == 0.
 +     */
 +    if (((addr - (gpe_len / 2)) == 0) && (val & (1 << ACPI_PM_POWER_BUTTON))) {
-+        snprintf(base, sizeof(base), "/local/domain/%d/control", xen_domid);
++        snprintf(base, sizeof(base), "device-model/%d", xen_domid);
 +
 +        err = xenstore_write_int(base, "hvm-powerbutton-enable", 1);
 +        if (err) {


### PR DESCRIPTION
6dde8833f7de "xen: Remove duplicate xenstore writes" changed a domain's
control xenstore directory to read-only.  This broke stubdom qemu's
ability to write to "control/hvm-powerbutton-enable".  Without that
node, xenmgr wouldn't use the acpi shutdown paths.

Switch to writing hvm-powerbutton-enable and hvm-shutdown in the
device-model directory of qemu-dm's domain.  That is either the stubdom
or dom0.  Logically it makes sense to put this device-model information
underneath the device-model instead of the guest.  It also side steps
the permission issue.

This needs a corresponding change to xenmgr.

Goes along with https://github.com/OpenXT/manager/pull/175