### PR TITLE
xen: Build hypevisor in do_compile

### DIFF
--- a/recipes-extended/xen/xen-hypervisor.bb
+++ b/recipes-extended/xen/xen-hypervisor.bb
@@ -90,6 +90,7 @@ do_compile() {
     export CPP="${HOST_PREFIX}cpp ${TOOLCHAIN_OPTIONS}"
 
     oe_runmake -C xen olddefconfig
+    oe_runmake -C xen
 }
 
 do_install() {


### PR DESCRIPTION
Right now, do_compile only regenerates the .config file.  The hypervisor
is actually built in do_install since it is called implicitly as a
dependency on install.  Add an explicit call to build xen in do_compile.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>