### PR TITLE
uivm-agents: Amend shellcheck warnings.

### DIFF
--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/keymap-agent
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/keymap-agent
@@ -18,10 +18,12 @@ monitor_keymap_layout() {
     # Locale.
     local xgr_intf="com.citrix.xenclient.xenmgr"
     local xgr_lang_member="language_changed"
-    local xgr_watch="$(dbus_watch_expression signal ${xgr_intf} ${xgr_lang_member})"
+    local xgr_watch
+    local intf
 
     # Monitor dbus watches, use "interface.member"
-    while read type _ _ _ _ path intf member ; do
+    xgr_watch=$(dbus_watch_expression signal "${xgr_intf}" "${xgr_lang_member}")
+    while read -r _ _ _ _ _ _ intf member ; do
         case "${intf}.${member}" in
             "${xgr_intf}.${xgr_lang_member}")
                 set_keymap

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/nm-applets-agent
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/nm-applets-agent
@@ -67,33 +67,40 @@ nm_applet_pidfile() {
 #   reccord a pidfile for process management.
 start_nm_applet() {
     local dbus_path="$1"
-    local uuid="$(networkdomain_config_get_string ${dbus_path} uuid)"
-    local domid="$(networkdomain_config_get_uint32 ${dbus_path} domid)"
-    local name="$(networkdomain_config_get_string ${dbus_path} name)"
-    local pidfile="$(nm_applet_pidfile ${dbus_path})"
-    local locale="$(xenmgr_get_locale)"
+    local uuid
+    local domid
+    local name
+    local pidfile
+    local locale
 
+
+    uuid="$(networkdomain_config_get_string "${dbus_path}" uuid)"
     if [ -z "${uuid}" ]; then
         echo "Invalid UUID:${uuid} for nm-applet." >&2
         return 1
     fi
+    domid="$(networkdomain_config_get_uint32 "${dbus_path}" domid)"
     if [ -z "${domid}" ]; then
         echo "Invalid domid:${domid} for nm-applet." >&2
         return 1
     fi
+    name="$(networkdomain_config_get_string "${dbus_path}" name)"
     if [ -z "${name}" ]; then
         echo "Invalid name:${name} for nm-applet." >&2
         return 1
     fi
+    pidfile="$(nm_applet_pidfile "${dbus_path}")"
     if [ -e "${pidfile}" ]; then
         if pgrep -F "${pidfile}" >/dev/null; then
             echo "nm-applet already running for UUID:${uuid}" >&2
             return 1
         else
             echo "Spurious pidfile found for nm-applet UUID:${uuid}" >&2
-            rm -f ${pidfile}
+            rm -f "${pidfile}"
         fi
     fi
+
+    locale="$(xenmgr_get_locale)"
 
     INET_IS_ARGO=1 \
     DBUS_SYSTEM_BUS_ADDRESS="tcp:host=1.0.0.${domid},port=5555" \
@@ -116,7 +123,9 @@ _stop_nm_applet() {
 #   Stop nm-applet running for the Network backend refered to by dbus-path.
 stop_nm_applet() {
     local dbus_path="$1"
-    local pidfile="$(nm_applet_pidfile ${dbus_path})"
+    local pidfile
+
+    pidfile="$(nm_applet_pidfile "${dbus_path}")"
 
     _stop_nm_applet "${pidfile}"
 }
@@ -169,14 +178,18 @@ monitor_nm_applets() {
     # NetworkDomain change.
     local nwd_notify_intf="com.citrix.xenclient.networkdomain.notify"
     local nwd_state_member="backend_state_changed"
-    local nwd_watch="$(dbus_watch_expression signal ${nwd_notify_intf} ${nwd_state_member})"
+    local nwd_watch
     # Locale.
     local xgr_intf="com.citrix.xenclient.xenmgr"
     local xgr_lang_member="language_changed"
-    local xgr_watch="$(dbus_watch_expression signal ${xgr_intf} ${xgr_lang_member})"
+    local xgr_watch
+    local path intf member
+
+    nwd_watch="$(dbus_watch_expression signal ${nwd_notify_intf} ${nwd_state_member})"
+    xgr_watch="$(dbus_watch_expression signal ${xgr_intf} ${xgr_lang_member})"
 
     # Monitor dbus watches, use "interface.member"
-    while read type _ _ _ _ path intf member ; do
+    while read -r _ _ _ _ _ path intf member ; do
         case "${intf}.${member}" in
             "${nwd_notify_intf}.${nwd_state_member}") nm_applet_event "${path}" ;;
             "${xgr_intf}.${xgr_lang_member}") language_event ;;

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/resize-agent
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/resize-agent
@@ -37,10 +37,10 @@ makeup_modeline() {
 wait_xenfb() {
     local id="$1"
     local path="device/vfb/${id}/state"
-    local key=""
+    local key
 
     # Note: xenstore-watch will always return the watched key once initialy.
-    while read key; do
+    while read -r key; do
         entry=$(xenstore-read "${key}")
         if [ "${entry}" = "4" ]; then
             echo "vfb ${id} is ready."
@@ -65,15 +65,16 @@ monitor_display_size() {
     local path="/xc_tools/switcher/current_display_size"
     local key
     local output="FBDev"
-    local entry=""
-    local width=""
-    local height=""
-    local name=""
-    local current_name=""
+    local entry
+    local width
+    local height
+    local name
+    local current_name
+    local modeline
 
-    while read key; do
-        entry=($(xenstore-read "${key}"))
-        if [ -z "${entry}" ]; then
+    while read -r key; do
+        read -r -a entry <<< "$(xenstore-read "${key}")"
+        if [ -z "${entry[*]}" ]; then
             echo "Invalid display size recorded in \`${key}'." >&2
             continue
         fi
@@ -88,7 +89,8 @@ monitor_display_size() {
         fi
 
         if ! xrandr_mode_exists "${name}"; then
-            xrandr --newmode $(makeup_modeline "${name}" "${width}" "${height}")
+            read -r -a modeline <<< "$(makeup_modeline "${name}" "${width}" "${height}")"
+            xrandr --newmode "${modeline[@]}"
         fi
         xrandr --addmode "${output}" "${name}"
         xrandr --output "${output}" --mode "${name}"

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/ui-functions
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/ui-functions
@@ -20,13 +20,15 @@ xenmgr_config_ui_get_string() {
 # Usage: xenmgr_get_locale
 #   Print the locale configured for Xenmgr on stdout.
 xenmgr_get_locale() {
-    local xenmgr_lang="$(xenmgr_config_ui_get_string language)"
+    local xenmgr_lang
+    xenmgr_lang="$(xenmgr_config_ui_get_string language)"
+
     local lang="${xenmgr_lang%%-*}"
     local territory="${xenmgr_lang##*-}"
     local charset="UTF-8"
 
     # Fallback on en_US if something went wrong.
-    if [ -z "${lang}" -o -z "${territory}" ]; then
+    if [ -z "${lang}" ] || [ -z "${territory}" ]; then
         lang="en"
         territory="US"
     fi
@@ -41,7 +43,7 @@ dbus_watch_expression() {
     local member="$3"
     local watch=""
 
-    if [ -z "${type}" -o -z "${intf}" ]; then
+    if [ -z "${type}" ] || [ -z "${intf}" ]; then
         return
     fi
     watch="type='${type}',interface='${intf}'"

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/uim-toolbar-gtk-agent
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/uim-toolbar-gtk-agent
@@ -23,10 +23,12 @@ fi
 #   process management.
 start_uim_toolbar() {
     local pidfile="${UIM_PIDFILE}"
-    local locale="$(xenmgr_get_locale)" 
+    local locale
     local show_toolbar="0"
     local enable_anthy="0"
     local enable_py="0"
+    local login_state
+    local layout
 
     if [ -e "${pidfile}" ]; then
         if pgrep -F "${pidfile}" >/dev/null; then
@@ -38,8 +40,9 @@ start_uim_toolbar() {
         fi
     fi
 
-    local login_state="$(xenstore-read login/state 2>/dev/null)"
-    local layout="$(xenstore-read /xenclient/keyboard/layout)"
+    login_state="$(xenstore-read login/state 2>/dev/null)"
+    layout="$(xenstore-read /xenclient/keyboard/layout)"
+    locale="$(xenmgr_get_locale)"
     case "${login_state}" in
         "0"|"3"|"")
             case "${layout}" in
@@ -77,10 +80,12 @@ monitor_uim_toolbar() {
     # Locale.
     local xgr_intf="com.citrix.xenclient.xenmgr"
     local xgr_lang_member="language_changed"
-    local xgr_watch="$(dbus_watch_expression signal ${xgr_intf} ${xgr_lang_member})"
+    local xgr_watch
+    local intf member
 
     # Monitor dbus watches, use "interface.member"
-    while read type _ _ _ _ path intf member ; do
+    xgr_watch="$(dbus_watch_expression signal ${xgr_intf} ${xgr_lang_member})"
+    while read -r _ _ _ _ _ _ intf member ; do
         case "${intf}.${member}" in
             "${xgr_intf}.${xgr_lang_member}")
                 stop_uim_toolbar

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/uim-toolbar-gtk-agent
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig/uim-toolbar-gtk-agent
@@ -44,10 +44,10 @@ start_uim_toolbar() {
         "0"|"3"|"")
             case "${layout}" in
                 "jp")   enable_anthy="1"
-                        enable_toolbar="1"
+                        show_toolbar="1"
                     ;;
                 "cn")   enable_py="1"
-                        enable_toolbar="1"
+                        show_toolbar="1"
                     ;;
             esac
             ;;


### PR DESCRIPTION
Running Shellcheck reveals UIM toolbar would never display due to a typo in a variable name.

Amend the other warnings as well in a separate commit.