### PR TITLE
openssh: post-zeus fixup

### DIFF
--- a/recipes-connectivity/openssh/files/sshd_config
+++ b/recipes-connectivity/openssh/files/sshd_config
@@ -54,12 +54,12 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-#PasswordAuthentication yes
-#PermitEmptyPasswords no
+PasswordAuthentication no
+PermitEmptyPasswords yes
 
 # Change to yes to enable challenge-response passwords (beware issues with
 # some PAM modules and threads)
-ChallengeResponseAuthentication no
+ChallengeResponseAuthentication yes
 
 # Kerberos options
 #KerberosAuthentication no


### PR DESCRIPTION
The zeus upgrade removed the machine-specific sshd config for dom0.
This commits brings back the relevant settings.
Those are required notably after an unattended install.
More info there:
https://github.com/OpenXT/xenclient-oe/pull/951
https://github.com/OpenXT/xenclient-oe/pull/979

Signed-off-by: Jed <lejosnej@ainfosec.com>