### PR TITLE
OXT-1732: dbus: limit build dependency to Xen argo header

### DIFF
--- a/recipes-core/dbus/dbus_1.%.bbappend
+++ b/recipes-core/dbus/dbus_1.%.bbappend
@@ -5,10 +5,10 @@ DEPENDS_append_class-native += " \
 # DBus will not link with libargo in the native case.
 # The argo kernel headers cannot be expected in the native environment since
 # libargo depends on Xen, and the hypervisor headers are not separated from the
-# main recipe.
+# main recipe. Limit dependency to argo header.
 DEPENDS_append_class-target += " \
     libselinux \
-    libargo \
+    argo-module-headers \
 "
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 


### PR DESCRIPTION
Limit OE recipe DEPENDS to socket definition in header file, instead
of libargo. Remove xen as build dependency of dbus. When xen changes,
avoid rebuilding dbus-dependent packages across multiple images.

Signed-off-by: Rich Persaud <rich.persaud@baesystems.com>

OXT-1306
OXT-1732