### PR TITLE
busybox: Enable poweroff command

### DIFF
--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -10,6 +10,7 @@ SRC_URI += " \
     file://login.cfg \
     file://misc.cfg \
     file://netutils.cfg \
+    file://poweroff.cfg \
     file://process.cfg \
     file://shells.cfg \
     file://syslog.cfg \

--- a/recipes-core/busybox/files/poweroff.cfg
+++ b/recipes-core/busybox/files/poweroff.cfg
@@ -1,0 +1,2 @@
+# Used by stubdom
+CONFIG_POWEROFF=y


### PR DESCRIPTION
The stubdom uses the busybox poweroff command to shutdown, but it is
currently missing.  In that case, the /init script ends and the kernel
panics instead of shutting down.  Install poweroff to restore graceful
shutdown.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>