### PR TITLE
ovmf: Upgrade PREBOOT.EXE to 24.5.

### DIFF
--- a/recipes-core/ovmf/ovmf_git.bbappend
+++ b/recipes-core/ovmf/ovmf_git.bbappend
@@ -5,9 +5,9 @@ DEPENDS_append += " \
     unzip-native \
 "
 
-# PREBOOT.EXE, OS independent, latest version (currently 24.3).
-SRC_URI[PREBOOT.md5sum] = "8660641e184dafdeb78b8ca1fbd837f7"
-SRC_URI[PREBOOT.sha256sum] = "83dac749d74a6a54d7451bee79f9e1d605c4e2775d6b524d39030b248989092a"
+# PREBOOT.EXE, OS independent, latest version (currently 24.5).
+SRC_URI[PREBOOT.md5sum] = "cca6fcb792d03d6ac5268706af2dd5da"
+SRC_URI[PREBOOT.sha256sum] = "292da2884e04c49fae8f74470a5014b8de1a8b8ebc20cba76ed1b35bc18b113e"
 
 do_extract_bootutil() {
     mkdir -p "${S}/Intel3.5/EFIX64"


### PR DESCRIPTION
The source now points to the new version.
https://downloadcenter.intel.com/download/29137/Intel-Ethernet-Connections-Boot-Utility-Preboot-Images-and-EFI-Drivers