### PR TITLE
ovmf: Point SRC_URI to the correct URL.

### DIFF
--- a/recipes-core/ovmf/ovmf_git.bbappend
+++ b/recipes-core/ovmf/ovmf_git.bbappend
@@ -1,11 +1,11 @@
 SRC_URI += " \
-    https://downloadmirror.intel.com/29137/eng/PREBOOT.EXE;unpack=0;name=PREBOOT \
+    https://downloadmirror.intel.com/29334/eng/PREBOOT.EXE;unpack=0;name=PREBOOT \
 "
 DEPENDS_append += " \
     unzip-native \
 "
 
-# PREBOOT.EXE, OS independent, latest version (currently 24.3).
+# PREBOOT.EXE, OS independent, version 24.3.
 SRC_URI[PREBOOT.md5sum] = "8660641e184dafdeb78b8ca1fbd837f7"
 SRC_URI[PREBOOT.sha256sum] = "83dac749d74a6a54d7451bee79f9e1d605c4e2775d6b524d39030b248989092a"
 


### PR DESCRIPTION
The URL changed with the release of 24.5.
https://downloadcenter.intel.com/download/29334/Ethernet-Intel-Ethernet-Connections-Boot-Utility-Preboot-Images-and-EFI-Drivers

Remain on 24.3 to fix the build until someone upgrades to 24.5 and tests with the available drivers in 24.5.