### PR TITLE
grub-efi: Amend FILESEXTRAPATH to use local cfg

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.%.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files-openxt:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 GRUB_BUILDIN = " \
     all_video boot btrfs cat chain configfile echo \


### PR DESCRIPTION
The cfg file is used by grub-mkimage to let grub know where to find its configuration.
For the iso installer, the default one pointing to the ESP for grub.cfg will not work.