### PR TITLE
idl: Fetch files from ${S}

### DIFF
--- a/recipes-openxt/xenclient-idl/xenclient-idl_git.bb
+++ b/recipes-openxt/xenclient-idl/xenclient-idl_git.bb
@@ -13,5 +13,5 @@ inherit allarch
 
 do_install() {
     install -m 0755 -d ${D}${idldatadir}
-    install -m 0644 ${WORKDIR}/git/interfaces/* ${D}${idldatadir}
+    install -m 0644 ${S}/interfaces/* ${D}${idldatadir}
 }


### PR DESCRIPTION
When installing the RPC .xml descriptions, they are fetched from the
sources, which should be ${S}, not ${WORKDIR}/git.
This breaks EXTERNALSRC otherwise.