### PR TITLE
xenmgr-data: Call oe_runmake not make

### DIFF
--- a/recipes-openxt/xenmgr-data/xenmgr-data_git.bb
+++ b/recipes-openxt/xenmgr-data/xenmgr-data_git.bb
@@ -32,11 +32,11 @@ inherit xc-rpcgen
 do_configure[noexec] = "1"
 
 do_compile() {
-    make
+    oe_runmake
 }
 
 do_install() {
-    make DESTDIR=${D} install
+    oe_runmake DESTDIR=${D} install
 }
 
 FILES_${PN} = " \


### PR DESCRIPTION
This recipe is in bad shape.
At least fix the make invocation, the rest needs a lot more work (see
existing comment).