### PR TITLE
OXT-1746: openxt-image: fix bbfatal typo for disk signature

### DIFF
--- a/classes/openxt-image-disk.bbclass
+++ b/classes/openxt-image-disk.bbclass
@@ -118,7 +118,7 @@ validate_disk_signature() {
 		fi
 	fi
 
-        bb_fatal "DISK_SIGNATURE ${DISK_SIGNATURE} must be an 8 digit hex string"
+        bbfatal "DISK_SIGNATURE ${DISK_SIGNATURE} must be an 8 digit hex string"
 }
 
 CONVERSION_CMD_disk() {


### PR DESCRIPTION
Use correct spelling for command.

OXT-1746

Signed-off-by: Rich Persaud  <rich.persaud@baesystems.com>