### PR TITLE
OXT-1489 : cryptsetup: set parameters for swap file encryption

### DIFF
--- a/recipes-openxt/xenclient-cryptdisks/xenclient-cryptdisks/crypttab
+++ b/recipes-openxt/xenclient-cryptdisks/xenclient-cryptdisks/crypttab
@@ -1,4 +1,4 @@
 # <target name>	<source device>		<key file>                      <options>
 log             /dev/xenclient/log      /config/keys/log.key
 cores           /dev/xenclient/cores    /config/keys/cores.key
-swap            /dev/xenclient/swap     SWAP
+swap            /dev/xenclient/swap     SWAP                            --cipher aes-xts-plain64 --key-size 512 --hash sha512


### PR DESCRIPTION
Change swap file encryption from default cipher (plain dm-crypt) to the
cipher used for the config partition (aes-xts-plain64). Options specified
here are passed from cryptdisks.initscript to cryptsetup on each boot.

OXT-1489

Signed-off-by: Rich Persaud <rich.persaud@baesystems.com>