### PR TITLE
tpm2-tss: OXT-1689: remove bash-isms from recipe

### DIFF
--- a/recipes-security/tss2/tpm2-tss_2.0.0.bb
+++ b/recipes-security/tss2/tpm2-tss_2.0.0.bb
@@ -28,7 +28,7 @@ FILES_resourcemgr = " \
 do_configure_prepend () {
     # Creates the src_vars.mk file used by automake to handle source-files for
     # each component. Modified to not call autotools and let OE handle that.
-    pushd ${S}
+    cd ${S}
     AUTORECONF=true ./bootstrap
-    popd
+    cd -
 }


### PR DESCRIPTION
Fixes the OpenXT build on Devuan Beowulf with default shell.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>