### PR TITLE
xenclient-installer-part2-image: satisfy prelink need for image /etc

### DIFF
--- a/recipes-core/images/xenclient-installer-part2-image.bb
+++ b/recipes-core/images/xenclient-installer-part2-image.bb
@@ -47,3 +47,12 @@ IMAGE_PREPROCESS_COMMAND += " \
 
 # prevent ldconfig from being run
 LDCONFIGDEPEND = ""
+
+# With ${IMAGE_ROOTFS}/etc removed, prelink_image will fail, so bracket it
+# to provide a temporary etc directory:
+prelink_image_prepend() {
+    mkdir ${IMAGE_ROOTFS}/etc
+}
+prelink_image_append() {
+    rmdir ${IMAGE_ROOTFS}/etc
+}


### PR DESCRIPTION
The `pre_image_mangle` task removes some unpopulated directories from
the rootfs directory. Unfortunately the standard image prelink task
assumes the presence of the etc directory in the image rootfs and fails
when it is absent.

To satisfy this requirement and unblock the build, bracket the
prelink_image task with prepend/append to temporarily supply a
${IMAGE_ROOTFS}/etc directory.

OXT-1751

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>