### PR TITLE
rpcgen: Fix paths in do_install

### DIFF
--- a/recipes-openxt/xenclient-rpcgen/xenclient-rpcgen_git.bb
+++ b/recipes-openxt/xenclient-rpcgen/xenclient-rpcgen_git.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git/rpcgen"
 
 do_install() {
     install -d ${D}/${bindir}
-    install -m 0755 ${WORKDIR}/git/rpcgen/dist/build/xc-rpcgen/xc-rpcgen ${D}/${bindir}
+    install -m 0755 ${B}/dist/build/xc-rpcgen/xc-rpcgen ${D}/${bindir}
     install -m 0755 -d ${D}/${datadir}/${TEMPLATES_DIR} # share
-    install -m 0644 ${WORKDIR}/git/rpcgen/templates/* ${D}/${datadir}/${TEMPLATES_DIR}/
+    install -m 0644 ${S}/templates/* ${D}/${datadir}/${TEMPLATES_DIR}/
 }


### PR DESCRIPTION
Copy files from $B an $S where appropriate.

Referencing `$WORKDIR` does not sit well with `externalsrc` and should be avoided.