### PR TITLE
qemu-dm: Wire up chardev-argo domid option

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -304,7 +304,7 @@
 +        return;
 +    }
 +
-+    if (argo_bind(fd, &s->local_addr, 0)) {
++    if (argo_bind(fd, &s->local_addr, s->remote_addr.domain_id)) {
 +        error_setg(errp,
 +                   "%s failed to bind argo socket - err: %d",
 +                   ARGO_CHARDRV_NAME, errno);
@@ -372,10 +372,13 @@
          strcmp(filename, "testdev") == 0 ||
          strcmp(filename, "stdio")   == 0) {
          qemu_opt_set(opts, "backend", filename, &error_abort);
-@@ -855,6 +856,9 @@ QemuOptsList qemu_chardev_opts = {
+@@ -855,6 +856,12 @@ QemuOptsList qemu_chardev_opts = {
              .name = "reconnect",
              .type = QEMU_OPT_NUMBER,
          },{
++            .name = "domid",
++            .type = QEMU_OPT_NUMBER,
++        },{
 +            .name = "stream",
 +            .type = QEMU_OPT_BOOL,
 +        },{


### PR DESCRIPTION
The domid option is not current allowed since it is not listed in
qemu_chardev_opts.  qemu fails with "Invalid parameter 'domid'".

Add domid into qemu_chardev_opts so it is accepted as a option.

We also need to bind a connected ring pointed at the remote domid.
Otherwise when the remote tries to reply, it'll fail since the ring is
bound to dom0.

hypervisor: (XEN) d23v0 argo: vm23 connection refused, src (vm23:13ed) dst (vm32:3afd)
VM Windows10-dm (32): qemu-system-i386: [argo-chardrv] failed to connect argo socket - err: 111

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>