### PR TITLE
tpm-functions: Fix tpm_is_owned for tpm2

### DIFF
--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -329,7 +329,7 @@ tpm_create_handles() {
 #         2 if indeterminant
 tpm_is_owned() {
     local tpm="$(find /sys/class -name tpm0 2>/dev/null)/device"
-    local state=""
+    local state="0"
 
     is_tpm_2_0
     local tpm2=$?


### PR DESCRIPTION
This function, on an un-owned tpm2, throws an error:
[: -eq: unary operator expected

When the tpm2 is un-owned, `grep -q` return 1.  The conditional is
skipped, and state is still "" when it gets to the inversion on the way
out of the function.  Initialize the state to 0 to avoid this issue.

The tpm1 path is fine since it always sets state.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>