### PR TITLE
OXT-1686 : create-ndvm: use HVM NDVM template

### DIFF
--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/create-ndvm
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/create-ndvm
@@ -41,7 +41,7 @@ die()
 [ $# -ge 1 ] && [ $# -le 2 ] || usage
 
 NAME="$1"
-MODE="${2:-pv}"
+MODE="${2:-hvm}"
 
 case "$NAME" in
     */*|.|..) die "name '$NAME' is not valid" ;;


### PR DESCRIPTION
On a system with multiple NICs, create-ndvm provisions multiple NDVMs.
Since the OpenXT default NDVM is now HVM, do the same here.

OXT-1686

Signed-off-by: Rich Persaud <rich.persaud@baesystems.com>

Requires: https://github.com/OpenXT/manager/pull/176