### PR TITLE
qemu: Fix initial qmp timeout issues

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -7,7 +7,7 @@
 +chardev-obj-$(CONFIG_XEN) += char-argo.o
 --- /dev/null
 +++ b/chardev/char-argo.c
-@@ -0,0 +1,354 @@
+@@ -0,0 +1,355 @@
 +/*
 + * QEMU System Emulator
 + *
@@ -320,19 +320,20 @@
 +            close(fd);
 +            return;
 +        }
++
++        s->connected = 1;
++        *be_opened = true;
++    } else {
++        s->connected = 0;
++        *be_opened = false;
 +    }
 +
 +
 +    s->fd = fd;
 +    s->bufcnt = 0;
 +    s->bufptr = 0;
-+    /* be isn't opened until we get a connection */
-+    *be_opened = false;
 +
 +    s->ioc = QIO_CHANNEL(qio_channel_file_new_fd(fd));
-+
-+    /* TODO currently starting up open */
-+    s->connected = 1;
 +
 +    fprintf(stderr, "Opened Argo chardev\n");
 +}


### PR DESCRIPTION
VM startup is always delayed 5 seconds when libxl fails to connect to
QMP.  Logs show:
libxl_qmp.c:530:qmp_next:Domain 1:timeout
libxl_qmp.c:823:libxl__qmp_initialize:Domain 1:Failed to connect to QMP

The root cause is a mismatch between the argo chardev being connected,
but the qmp monitor still being closed.  qmp-helper defaults to open
(skipping sending "live"), argo chardev receives the message, but the
qmp monitor is disabled.  The request isn't processed and request times
out.  qmp helpers sends "dead" and the argo chardev is closed which
brings the monitor and chardev into sync.  When the next connection
comes in, argo transitions to connected and the monitor is started by
qemu_chr_be_event(chr, CHR_EVENT_OPENED).

The oneline fix is
-+    *be_opened = false;
++    *be_opened = true;

so connected and be_opened are synchronized from the beginning.

However, conceptually it's unusual to start open when you have the
live/dead protocol.  Change the code so datagram connections (used by
QMP) start connected=0 and be_opened=false and streams start connected=1
and be_opened=true.  qmp-helper must be changed to send an initial live
message now.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

Depends on https://github.com/OpenXT/xctools/pull/64