### PR TITLE
[xen] Update kconfig-grant-table patch

### DIFF
--- a/recipes-extended/xen/files/kconfig-grant-table-v2-interface.patch
+++ b/recipes-extended/xen/files/kconfig-grant-table-v2-interface.patch
@@ -278,7 +278,7 @@ index 80728ea57d..7858aec2e0 100644
 -        if ( (rc = _set_status(shah, status, rd, rgt->gt_version, act,
 +        if ( (rc = _set_status(shah, status, rd, get_gt_version(rgt), act,
                                 op->flags & GNTMAP_readonly, 1,
-                                ld->domain_id) != GNTST_okay) )
+                                ld->domain_id)) != GNTST_okay )
              goto act_release_out;
  
          if ( !act->pin )


### PR DESCRIPTION
  The patch context is now incorrect due to a change in upstream commit
  46bde0561b4a6eca4deee2dc1797086353e95be9. This fixes a paren error
  causing our patch to fail to apply.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>