### PR TITLE
S9: ocaml: use sysroot for dynamic libraries

### DIFF
--- a/recipes-extended/xen/files/ocaml-makefiles-sysroot.patch
+++ b/recipes-extended/xen/files/ocaml-makefiles-sysroot.patch
@@ -1,0 +1,13 @@
+Index: git/tools/ocaml/common.make
+===================================================================
+--- git.orig/tools/ocaml/common.make
++++ git/tools/ocaml/common.make
+@@ -12,7 +12,7 @@ OCAMLFIND ?= ocamlfind
+ CFLAGS += -fPIC -Werror -I$(shell ocamlc -where)
+ 
+ OCAMLOPTFLAG_G := $(shell $(OCAMLOPT) -h 2>&1 | sed -n 's/^  *\(-g\) .*/\1/p')
+-OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc $(CC) -w F -warn-error F
++OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc "$(CC)" -w F -warn-error F
+ OCAMLCFLAGS += -g $(OCAMLINCLUDE) -w F -warn-error F
+ 
+ VERSION := 4.1

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -115,6 +115,7 @@ SRC_URI_append = " \
     file://argo-add-viptables.patch \
     file://libxl-seabios-ipxe.patch \
     file://memory-scrub-on-domain-shutdown.patch \
+    file://ocaml-makefiles-sysroot.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-extended/xen/xen-ocaml-libs.bb
+++ b/recipes-extended/xen/xen-ocaml-libs.bb
@@ -89,16 +89,8 @@ do_compile() {
 		       LDLIBS_libxenevtchn='-lxenevtchn' \
 		       -C tools subdir-all-libxl
 
-    # ocamlopt/ocamlc -cc argument will treat everything following it as the
-    # executable name, so wrap everything.
-    cat - > ocaml-cc.sh <<EOF
-#! /bin/sh
-exec ${CC} "\$@"
-EOF
-    chmod +x ocaml-cc.sh
-
     oe_runmake V=1 \
-       CC="${B}/ocaml-cc.sh" \
+       OCAMLMKLIB="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'" \
        LDLIBS_libxenctrl='-lxenctrl' \
        LDLIBS_libxenstore='-lxenstore' \
        LDLIBS_libblktapctl='-lblktapctl' \

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bb
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bb
@@ -63,7 +63,9 @@ S = "${WORKDIR}/git"
 # TODO: ocamlc can figure it out in the build-system.
 CFLAGS_append = " -I${ocamlincdir}"
 do_compile() {
-        make V=1 XEN_DIST_ROOT="${STAGING_DIR_HOST}"
+    make V=1 \
+        XEN_DIST_ROOT="${STAGING_DIR_HOST}" \
+        OCAMLMKLIB="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
 }
 
 OCAML_INSTALL_LIBS = " \
@@ -94,7 +96,7 @@ do_install() {
         for ocaml_lib in ${OCAML_INSTALL_LIBS}; do
             # Use of DESTDIR is not consistent here.
             # root Makefile sur $(DESTDIR)/usr/bin while libs use $(DESTDIR)/$(ocamlfind printconf destdir)
-                oe_runmake -C $ocaml_lib V=1 install
+            oe_runmake -C $ocaml_lib V=1 install
         done
 }
 


### PR DESCRIPTION
Builds are now failing on recently created containers using the recommended Debian 8.11 environment for OCaml recipes producing dynamic libraries.

- xen-ocaml-libs should not rely on a handler defining CC, since OE   passes more than just the compiler path quote the $(CC) Makefile variable. As well, ocamlmklib should pass the flags down to the linker.
```
| x86_64-oe-linux-ar rcs libxenmmap_stubs.a  xenmmap_stubs.o && ocamlmklib -o `basename libxenmmap_stubs.a .a | sed -e 's/^lib//'`  xenmmap_stubs.o
| [...]/xen-ocaml-libs/4.12.2-pre-r0/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/6.4.0/ld: cannot find crti.o: No such file or directory
```
- xenclient-toolstack: ocamlmklib should pass the flags down to the linker.
```
| x86_64-oe-linux-ar rcs libstdext_stubs.a  unixext_stubs.o && ocamlmklib -o `basename libstdext_stubs.a .a | sed -e 's/^lib//'`  unixext_stubs.o
| [...]/xenclient-toolstack/0+gitAUTOINC+a5ca565cb6-r0/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/6.4.0/ld: cannot find crti.o: No such file or directory
```
This might be why master had to be switched to static libraries and could be forward ported, so it might be worth considering revisiting OXT-1704?

Requires: https://github.com/OpenXT/meta-openxt-ocaml-platform/pull/19