### PR TITLE
xen: Port patches to tip of stable-4.12

### DIFF
--- a/recipes-extended/xen/files/0001-tools-helpers-Introduce-cmp-fd-file-inode-utility.patch
+++ b/recipes-extended/xen/files/0001-tools-helpers-Introduce-cmp-fd-file-inode-utility.patch
@@ -21,11 +21,9 @@ Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
  3 files changed, 46 insertions(+)
  create mode 100644 tools/helpers/cmp-fd-file-inode.c
 
-diff --git a/.gitignore b/.gitignore
-index 26bc583f74..d54dbb7eb6 100644
 --- a/.gitignore
 +++ b/.gitignore
-@@ -177,6 +177,7 @@ tools/fuzz/x86_instruction_emulator/x86-emulate.[ch]
+@@ -177,6 +177,7 @@ tools/fuzz/x86_instruction_emulator/x86-
  tools/helpers/_paths.h
  tools/helpers/init-xenstore-domain
  tools/helpers/xen-init-dom0
@@ -33,8 +31,6 @@ index 26bc583f74..d54dbb7eb6 100644
  tools/hotplug/common/hotplugpath.sh
  tools/hotplug/FreeBSD/rc.d/xencommons
  tools/hotplug/FreeBSD/rc.d/xendriverdomain
-diff --git a/tools/helpers/Makefile b/tools/helpers/Makefile
-index f759528322..7daf5c46ca 100644
 --- a/tools/helpers/Makefile
 +++ b/tools/helpers/Makefile
 @@ -8,6 +8,7 @@ include $(XEN_ROOT)/tools/Rules.mk
@@ -60,9 +56,6 @@ index f759528322..7daf5c46ca 100644
  endif
  	rm -f $(DESTDIR)$(LIBEXEC_BIN)/xen-init-dom0
  
-diff --git a/tools/helpers/cmp-fd-file-inode.c b/tools/helpers/cmp-fd-file-inode.c
-new file mode 100644
-index 0000000000..47029e3a66
 --- /dev/null
 +++ b/tools/helpers/cmp-fd-file-inode.c
 @@ -0,0 +1,42 @@
@@ -108,6 +101,3 @@ index 0000000000..47029e3a66
 +
 +	return !(fd_statbuf.st_ino == file_statbuf.st_ino);
 +}
--- 
-2.21.0
-

--- a/recipes-extended/xen/files/0002-Linux-locking.sh-Use-cmp-fd-file-inode-for-lock-chec.patch
+++ b/recipes-extended/xen/files/0002-Linux-locking.sh-Use-cmp-fd-file-inode-for-lock-chec.patch
@@ -11,8 +11,6 @@ Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
  tools/hotplug/Linux/locking.sh | 10 ++--------
  1 file changed, 2 insertions(+), 8 deletions(-)
 
-diff --git a/tools/hotplug/Linux/locking.sh b/tools/hotplug/Linux/locking.sh
-index c6a7e96ff9..de468c4bb5 100644
 --- a/tools/hotplug/Linux/locking.sh
 +++ b/tools/hotplug/Linux/locking.sh
 @@ -50,14 +50,8 @@ claim_lock()
@@ -32,6 +30,3 @@ index c6a7e96ff9..de468c4bb5 100644
  	# Some versions of bash appear to be buggy if the same
  	# $_lockfile is opened repeatedly. Close the current fd here.
          eval "exec $_lockfd<&-"
--- 
-2.21.0
-

--- a/recipes-extended/xen/files/Dell-980-txt-shutdown-acpi-access-width.patch
+++ b/recipes-extended/xen/files/Dell-980-txt-shutdown-acpi-access-width.patch
@@ -48,7 +48,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/acpi/power.c
 +++ b/xen/arch/x86/acpi/power.c
-@@ -379,8 +379,10 @@ static void tboot_sleep(u8 sleep_state)
+@@ -383,8 +383,10 @@ static void tboot_sleep(u8 sleep_state)
      /* sizes are not same (due to packing) so copy each one */
      TB_COPY_GAS(g_tboot_shared->acpi_sinfo.pm1a_cnt_blk,
                  acpi_sinfo.pm1a_cnt_blk);

--- a/recipes-extended/xen/files/allow-mwait-cstate.patch
+++ b/recipes-extended/xen/files/allow-mwait-cstate.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/cpuid.c
 +++ b/xen/arch/x86/cpuid.c
-@@ -799,33 +799,36 @@ void guest_cpuid(const struct vcpu *v, u
+@@ -820,33 +820,36 @@ void guest_cpuid(const struct vcpu *v, u
               *
               * These leaks are retained for backwards compatibility, but
               * restricted to the hardware domains kernel only.

--- a/recipes-extended/xen/files/argo-add-viptables.patch
+++ b/recipes-extended/xen/files/argo-add-viptables.patch
@@ -64,7 +64,7 @@ PATCHES
  /*
   * This hash function is used to distribute rings within the per-domain
   * hash tables (d->argo->ring_hash and d->argo_send_hash). The hash table
-@@ -1967,6 +1980,221 @@ notify(struct domain *currd,
+@@ -1957,6 +1970,221 @@ notify(struct domain *currd,
      return ret;
  }
  
@@ -286,7 +286,7 @@ PATCHES
  static long
  sendv(struct domain *src_d, xen_argo_addr_t *src_addr,
        const xen_argo_addr_t *dst_addr, xen_argo_iov_t *iovs, unsigned int niov,
-@@ -2012,6 +2240,17 @@ sendv(struct domain *src_d, xen_argo_add
+@@ -2002,6 +2230,17 @@ sendv(struct domain *src_d, xen_argo_add
          return ret;
      }
  
@@ -304,7 +304,7 @@ PATCHES
      read_lock(&L1_global_argo_rwlock);
  
      if ( !src_d->argo )
-@@ -2197,6 +2436,52 @@ do_argo_op(unsigned int cmd, XEN_GUEST_H
+@@ -2199,6 +2438,52 @@ do_argo_op(unsigned int cmd, XEN_GUEST_H
          break;
      }
  

--- a/recipes-extended/xen/files/argo-quiet-xsm-check-during-init.patch
+++ b/recipes-extended/xen/files/argo-quiet-xsm-check-during-init.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
 
 --- a/xen/common/argo.c
 +++ b/xen/common/argo.c
-@@ -2584,7 +2584,7 @@ argo_init(struct domain *d)
+@@ -2583,7 +2583,7 @@ argo_init(struct domain *d)
  {
      struct argo_domain *argo;
  
@@ -94,7 +94,7 @@ Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
      .argo_send = flask_argo_send,
 --- a/xen/xsm/dummy.c
 +++ b/xen/xsm/dummy.c
-@@ -155,6 +155,7 @@ void __init xsm_fixup_ops (struct xsm_operations *ops)
+@@ -155,6 +155,7 @@ void __init xsm_fixup_ops (struct xsm_op
      set_to_dummy_if_null(ops, domain_resource_map);
  #ifdef CONFIG_ARGO
      set_to_dummy_if_null(ops, argo_enable);

--- a/recipes-extended/xen/files/disable-cpuid-hle-rtm.patch
+++ b/recipes-extended/xen/files/disable-cpuid-hle-rtm.patch
@@ -54,7 +54,7 @@ PATCHES
 
 --- a/xen/arch/x86/cpu/intel.c
 +++ b/xen/arch/x86/cpu/intel.c
-@@ -343,6 +343,9 @@ static void init_intel(struct cpuinfo_x8
+@@ -346,6 +346,9 @@ static void init_intel(struct cpuinfo_x8
  	     ( c->cpuid_level >= 0x00000006 ) &&
  	     ( cpuid_eax(0x00000006) & (1u<<2) ) )
  		__set_bit(X86_FEATURE_ARAT, c->x86_capability);

--- a/recipes-extended/xen/files/efi-hardcode-openxt-cfg.patch
+++ b/recipes-extended/xen/files/efi-hardcode-openxt-cfg.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 1/3] Hardcode openxt.cfg as EFI config file
 
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
-@@ -1129,7 +1129,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1123,7 +1123,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      EFI_LOADED_IMAGE *loaded_image;
      EFI_STATUS status;
      unsigned int i, argc;

--- a/recipes-extended/xen/files/efi-load-options-no-default-image-name.patch
+++ b/recipes-extended/xen/files/efi-load-options-no-default-image-name.patch
@@ -1,6 +1,6 @@
 --- a/xen/arch/x86/efi/efi-boot.h
 +++ b/xen/arch/x86/efi/efi-boot.h
-@@ -725,10 +725,8 @@ static void __init efi_arch_handle_cmdli
+@@ -726,10 +726,8 @@ static void __init efi_arch_handle_cmdli
      {
          name.w = image_name;
          w2s(&name);

--- a/recipes-extended/xen/files/efi-require-shim.patch
+++ b/recipes-extended/xen/files/efi-require-shim.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Require the presence of the shim to boot under UEFI
 
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
-@@ -1265,6 +1265,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1259,6 +1259,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          else if ( !read_file(dir_handle, cfg_file_name, &cfg, NULL) )
              blexit(L"Configuration file not found.");
  

--- a/recipes-extended/xen/files/evtchn-do-not-set-pending-if-s3.patch
+++ b/recipes-extended/xen/files/evtchn-do-not-set-pending-if-s3.patch
@@ -59,7 +59,7 @@ PATCHES
 ################################################################################
 --- a/xen/common/event_2l.c
 +++ b/xen/common/event_2l.c
-@@ -18,6 +18,12 @@ static void evtchn_2l_set_pending(struct
+@@ -20,6 +20,12 @@ static void evtchn_2l_set_pending(struct
      struct domain *d = v->domain;
      unsigned int port = evtchn->port;
  

--- a/recipes-extended/xen/files/fix-memcpy-in-x86-emulate.patch
+++ b/recipes-extended/xen/files/fix-memcpy-in-x86-emulate.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/hvm/hvm.c
 +++ b/xen/arch/x86/hvm/hvm.c
-@@ -3165,6 +3165,37 @@ enum hvm_translation_result hvm_translat
+@@ -3193,6 +3193,37 @@ enum hvm_translation_result hvm_translat
      return HVMTRANS_okay;
  }
  
@@ -74,7 +74,7 @@ PATCHES
  #define HVMCOPY_from_guest (0u<<0)
  #define HVMCOPY_to_guest   (1u<<0)
  #define HVMCOPY_phys       (0u<<2)
-@@ -3231,9 +3262,9 @@ static enum hvm_translation_result __hvm
+@@ -3259,9 +3290,9 @@ static enum hvm_translation_result __hvm
              else
              {
                  if ( buf )

--- a/recipes-extended/xen/files/gpt-s3-resume-reason.patch
+++ b/recipes-extended/xen/files/gpt-s3-resume-reason.patch
@@ -33,7 +33,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/hvm/hvm.c
 +++ b/xen/arch/x86/hvm/hvm.c
-@@ -3952,6 +3952,9 @@ static void hvm_s3_suspend(struct domain
+@@ -3980,6 +3980,9 @@ static void hvm_s3_suspend(struct domain
      domain_unlock(d);
  }
  
@@ -43,7 +43,7 @@ PATCHES
  static void hvm_s3_resume(struct domain *d)
  {
      if ( test_and_clear_bool(d->arch.hvm.is_s3_suspended) )
-@@ -3960,6 +3963,10 @@ static void hvm_s3_resume(struct domain
+@@ -3988,6 +3991,10 @@ static void hvm_s3_resume(struct domain
  
          for_each_vcpu( d, v )
              hvm_set_guest_tsc(v, 0);

--- a/recipes-extended/xen/files/hvm-rtc.patch
+++ b/recipes-extended/xen/files/hvm-rtc.patch
@@ -44,7 +44,7 @@ PATCHES
 
 --- a/xen/arch/x86/acpi/power.c
 +++ b/xen/arch/x86/acpi/power.c
-@@ -132,6 +132,8 @@ static void thaw_domains(void)
+@@ -133,6 +133,8 @@ static void thaw_domains(void)
      for_each_domain ( d )
      {
          restore_vcpu_affinity(d);

--- a/recipes-extended/xen/files/hvmloader-legacy-seabios-optionroms.patch
+++ b/recipes-extended/xen/files/hvmloader-legacy-seabios-optionroms.patch
@@ -87,7 +87,7 @@ PATCHES
  ifeq ($(debug),y)
  OBJS += tests.o
  endif
-@@ -73,6 +73,7 @@ acpi:
+@@ -68,6 +68,7 @@ acpi:
  	$(MAKE) -C $(ACPI_PATH)  ACPI_BUILD_DIR=$(CURDIR) DSDT_FILES="$(DSDT_FILES)"
  
  rombios.o: roms.inc
@@ -232,12 +232,12 @@ PATCHES
 +        const struct hvm_modlist_entry *ipxe;
 +        uint32_t ipxe_paddr = 0;
          uint32_t paddr = bios_module->paddr;
-+
+ 
+-        bios->bios_load(bios, (void *)paddr, bios_module->size, NULL);
 +        ipxe = get_module_entry(hvm_start_info, "ipxe");
 +        if ( ipxe )
 +            ipxe_paddr = ipxe->paddr;
- 
--        bios->bios_load(bios, (void *)paddr, bios_module->size, NULL);
++
 +        bios->bios_load(bios, (void *)paddr, bios_module->size, (void*)ipxe_paddr);
      }
  #ifdef ENABLE_ROMBIOS

--- a/recipes-extended/xen/files/increase-ap-startup-time.patch
+++ b/recipes-extended/xen/files/increase-ap-startup-time.patch
@@ -41,7 +41,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/smpboot.c
 +++ b/xen/arch/x86/smpboot.c
-@@ -469,7 +469,14 @@ static int wakeup_secondary_cpu(int phys
+@@ -471,7 +471,14 @@ static int wakeup_secondary_cpu(int phys
           * While AP is in root mode handling the INIT the CPU will drop
           * any SIPIs
           */

--- a/recipes-extended/xen/files/kconfig-grant-table-exotic.patch
+++ b/recipes-extended/xen/files/kconfig-grant-table-exotic.patch
@@ -63,8 +63,6 @@ Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
  xen/common/grant_table.c        | 12 ++++++++++++
  3 files changed, 26 insertions(+)
 
-diff --git a/xen/common/Kconfig b/xen/common/Kconfig
-index a7c596bf9c..b262885f96 100644
 --- a/xen/common/Kconfig
 +++ b/xen/common/Kconfig
 @@ -40,6 +40,16 @@ config GRANT_TABLE_V2
@@ -84,11 +82,9 @@ index a7c596bf9c..b262885f96 100644
  config HAS_ALTERNATIVE
  	bool
  
-diff --git a/xen/common/compat/grant_table.c b/xen/common/compat/grant_table.c
-index c56b590a5c..5c91ec1a64 100644
 --- a/xen/common/compat/grant_table.c
 +++ b/xen/common/compat/grant_table.c
-@@ -193,6 +193,9 @@ int compat_grant_table_op(unsigned int cmd,
+@@ -193,6 +193,9 @@ int compat_grant_table_op(unsigned int c
              break;
  
          case GNTTABOP_transfer:
@@ -98,7 +94,7 @@ index c56b590a5c..5c91ec1a64 100644
              for ( n = 0; n < COMPAT_ARG_XLAT_SIZE / sizeof(*nat.xfer) && i < count && rc == 0; ++i, ++n )
              {
                  if ( unlikely(__copy_from_guest_offset(&cmp.xfer, cmp_uop, i, 1)) )
-@@ -224,6 +227,7 @@ int compat_grant_table_op(unsigned int cmd,
+@@ -224,6 +227,7 @@ int compat_grant_table_op(unsigned int c
                          rc = -EFAULT;
                  }
              }
@@ -106,11 +102,9 @@ index c56b590a5c..5c91ec1a64 100644
              break;
  
          case GNTTABOP_copy:
-diff --git a/xen/common/grant_table.c b/xen/common/grant_table.c
-index 7858aec2e0..20cd18e930 100644
 --- a/xen/common/grant_table.c
 +++ b/xen/common/grant_table.c
-@@ -1589,6 +1589,7 @@ fault:
+@@ -1616,6 +1616,7 @@ fault:
      return -EFAULT;
  }
  
@@ -118,7 +112,7 @@ index 7858aec2e0..20cd18e930 100644
  static void
  unmap_and_replace(
      struct gnttab_unmap_and_replace *op,
-@@ -1653,6 +1654,7 @@ fault:
+@@ -1680,6 +1681,7 @@ fault:
          unmap_common_complete(&common[i]);
      return -EFAULT;
  }
@@ -126,7 +120,7 @@ index 7858aec2e0..20cd18e930 100644
  
  static int
  gnttab_populate_status_frames(struct domain *d, struct grant_table *gt,
-@@ -2047,6 +2049,7 @@ gnttab_query_size(
+@@ -2080,6 +2082,7 @@ gnttab_query_size(
      return 0;
  }
  
@@ -134,7 +128,7 @@ index 7858aec2e0..20cd18e930 100644
  /*
   * Check that the given grant reference (rd,ref) allows 'ld' to transfer
   * ownership of a page frame. If so, lock down the grant entry.
-@@ -2328,6 +2331,7 @@ gnttab_transfer(
+@@ -2361,6 +2364,7 @@ gnttab_transfer(
  
      return 0;
  }
@@ -142,7 +136,7 @@ index 7858aec2e0..20cd18e930 100644
  
  /*
   * Undo acquire_grant_for_copy().  This has no effect on page type and
-@@ -3253,6 +3257,7 @@ gnttab_get_version(XEN_GUEST_HANDLE_PARAM(gnttab_get_version_t) uop)
+@@ -3286,6 +3290,7 @@ gnttab_get_version(XEN_GUEST_HANDLE_PARA
      return 0;
  }
  
@@ -150,7 +144,7 @@ index 7858aec2e0..20cd18e930 100644
  static s16
  swap_grant_ref(grant_ref_t ref_a, grant_ref_t ref_b)
  {
-@@ -3339,6 +3344,7 @@ gnttab_swap_grant_ref(XEN_GUEST_HANDLE_PARAM(gnttab_swap_grant_ref_t) uop,
+@@ -3372,6 +3377,7 @@ gnttab_swap_grant_ref(XEN_GUEST_HANDLE_P
      }
      return 0;
  }
@@ -158,7 +152,7 @@ index 7858aec2e0..20cd18e930 100644
  
  static int cache_flush(const gnttab_cache_flush_t *cflush, grant_ref_t *cur_ref)
  {
-@@ -3500,6 +3506,7 @@ do_grant_table_op(
+@@ -3533,6 +3539,7 @@ do_grant_table_op(
          break;
      }
  
@@ -166,7 +160,7 @@ index 7858aec2e0..20cd18e930 100644
      case GNTTABOP_unmap_and_replace:
      {
          XEN_GUEST_HANDLE_PARAM(gnttab_unmap_and_replace_t) unmap =
-@@ -3515,6 +3522,7 @@ do_grant_table_op(
+@@ -3548,6 +3555,7 @@ do_grant_table_op(
          }
          break;
      }
@@ -174,7 +168,7 @@ index 7858aec2e0..20cd18e930 100644
  
      case GNTTABOP_setup_table:
          rc = gnttab_setup_table(
-@@ -3522,6 +3530,7 @@ do_grant_table_op(
+@@ -3555,6 +3563,7 @@ do_grant_table_op(
          ASSERT(rc <= 0);
          break;
  
@@ -182,7 +176,7 @@ index 7858aec2e0..20cd18e930 100644
      case GNTTABOP_transfer:
      {
          XEN_GUEST_HANDLE_PARAM(gnttab_transfer_t) transfer =
-@@ -3537,6 +3546,7 @@ do_grant_table_op(
+@@ -3570,6 +3579,7 @@ do_grant_table_op(
          }
          break;
      }
@@ -190,7 +184,7 @@ index 7858aec2e0..20cd18e930 100644
  
      case GNTTABOP_copy:
      {
-@@ -3577,6 +3587,7 @@ do_grant_table_op(
+@@ -3609,6 +3619,7 @@ do_grant_table_op(
          rc = gnttab_get_version(guest_handle_cast(uop, gnttab_get_version_t));
          break;
  
@@ -198,7 +192,7 @@ index 7858aec2e0..20cd18e930 100644
      case GNTTABOP_swap_grant_ref:
      {
          XEN_GUEST_HANDLE_PARAM(gnttab_swap_grant_ref_t) swap =
-@@ -3592,6 +3603,7 @@ do_grant_table_op(
+@@ -3624,6 +3635,7 @@ do_grant_table_op(
          }
          break;
      }
@@ -206,6 +200,3 @@ index 7858aec2e0..20cd18e930 100644
  
      case GNTTABOP_cache_flush:
      {
--- 
-2.17.1
-

--- a/recipes-extended/xen/files/kconfig-grant-table-v2-interface.patch
+++ b/recipes-extended/xen/files/kconfig-grant-table-v2-interface.patch
@@ -61,8 +61,6 @@ Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>
  xen/common/grant_table.c        | 211 ++++++++++++++++++++------------
  3 files changed, 152 insertions(+), 81 deletions(-)
 
-diff --git a/xen/common/Kconfig b/xen/common/Kconfig
-index c838506241..a7c596bf9c 100644
 --- a/xen/common/Kconfig
 +++ b/xen/common/Kconfig
 @@ -22,6 +22,24 @@ config GRANT_TABLE
@@ -90,11 +88,9 @@ index c838506241..a7c596bf9c 100644
  config HAS_ALTERNATIVE
  	bool
  
-diff --git a/xen/common/compat/grant_table.c b/xen/common/compat/grant_table.c
-index ff1d678f01..c56b590a5c 100644
 --- a/xen/common/compat/grant_table.c
 +++ b/xen/common/compat/grant_table.c
-@@ -272,6 +272,9 @@ int compat_grant_table_op(unsigned int cmd,
+@@ -272,6 +272,9 @@ int compat_grant_table_op(unsigned int c
              break;
  
          case GNTTABOP_get_status_frames: {
@@ -104,7 +100,7 @@ index ff1d678f01..c56b590a5c 100644
              unsigned int max_frame_list_size_in_pages =
                  (COMPAT_ARG_XLAT_SIZE - sizeof(*nat.get_status)) /
                  sizeof(*nat.get_status->frame_list.p);
-@@ -319,6 +322,7 @@ int compat_grant_table_op(unsigned int cmd,
+@@ -319,6 +322,7 @@ int compat_grant_table_op(unsigned int c
                  else
                      i = 1;
              }
@@ -112,8 +108,6 @@ index ff1d678f01..c56b590a5c 100644
              break;
          }
  
-diff --git a/xen/common/grant_table.c b/xen/common/grant_table.c
-index 80728ea57d..7858aec2e0 100644
 --- a/xen/common/grant_table.c
 +++ b/xen/common/grant_table.c
 @@ -50,11 +50,13 @@ struct grant_table {
@@ -140,9 +134,9 @@ index 80728ea57d..7858aec2e0 100644
      };
      /* State grant table (see include/public/grant_table.h). */
      grant_status_t       **status;
-@@ -89,9 +93,19 @@ integer_runtime_param("gnttab_max_frames", opt_max_grant_frames);
- unsigned int __read_mostly opt_max_maptrack_frames = 1024;
- integer_runtime_param("gnttab_max_maptrack_frames", opt_max_maptrack_frames);
+@@ -120,9 +124,19 @@ static int parse_gnttab_max_maptrack_fra
+ custom_runtime_param("gnttab_max_maptrack_frames",
+                      parse_gnttab_max_maptrack_frames);
  
 +#ifdef CONFIG_GRANT_TABLE_V2
 +
@@ -160,7 +154,7 @@ index 80728ea57d..7858aec2e0 100644
  
  static unsigned int __read_mostly opt_gnttab_max_version = GNTTAB_MAX_VERSION;
  static bool __read_mostly opt_transitive_grants = true;
-@@ -218,19 +232,44 @@ nr_maptrack_frames(struct grant_table *t)
+@@ -249,19 +263,44 @@ nr_maptrack_frames(struct grant_table *t
  #define SHGNT_PER_PAGE_V1 (PAGE_SIZE / sizeof(grant_entry_v1_t))
  #define shared_entry_v1(t, e) \
      ((t)->shared_v1[(e)/SHGNT_PER_PAGE_V1][(e)%SHGNT_PER_PAGE_V1])
@@ -208,7 +202,7 @@ index 80728ea57d..7858aec2e0 100644
  }
  
  /* Active grant entry - used for shadowing GTF_permit_access grants. */
-@@ -629,17 +668,19 @@ get_maptrack_handle(
+@@ -660,17 +699,19 @@ get_maptrack_handle(
  /* Number of grant table entries. Caller must hold d's grant table lock. */
  static unsigned int nr_grant_entries(struct grant_table *gt)
  {
@@ -229,7 +223,7 @@ index 80728ea57d..7858aec2e0 100644
  #undef f2e
      }
  
-@@ -719,6 +760,7 @@ done:
+@@ -750,6 +791,7 @@ done:
      return rc;
  }
  
@@ -237,7 +231,7 @@ index 80728ea57d..7858aec2e0 100644
  static int _set_status_v2(const grant_entry_header_t *shah,
                            grant_status_t *status,
                            struct domain *rd,
-@@ -804,7 +846,7 @@ static int _set_status_v2(const grant_entry_header_t *shah,
+@@ -835,7 +877,7 @@ static int _set_status_v2(const grant_en
  done:
      return rc;
  }
@@ -246,7 +240,7 @@ index 80728ea57d..7858aec2e0 100644
  
  static int _set_status(const grant_entry_header_t *shah,
                         grant_status_t *status,
-@@ -815,11 +857,11 @@ static int _set_status(const grant_entry_header_t *shah,
+@@ -846,11 +888,11 @@ static int _set_status(const grant_entry
                         int mapflag,
                         domid_t ldomid)
  {
@@ -262,7 +256,7 @@ index 80728ea57d..7858aec2e0 100644
  }
  
  static struct active_grant_entry *grant_map_exists(const struct domain *ld,
-@@ -969,7 +1011,7 @@ map_grant_ref(
+@@ -998,7 +1040,7 @@ map_grant_ref(
  
      act = active_entry_acquire(rgt, op->ref);
      shah = shared_entry_header(rgt, op->ref);
@@ -271,7 +265,7 @@ index 80728ea57d..7858aec2e0 100644
  
      /* If already pinned, check the active domid and avoid refcnt overflow. */
      if ( act->pin &&
-@@ -984,16 +1026,14 @@ map_grant_ref(
+@@ -1013,16 +1055,14 @@ map_grant_ref(
           (!(op->flags & GNTMAP_readonly) &&
            !(act->pin & (GNTPIN_hstw_mask|GNTPIN_devw_mask))) )
      {
@@ -290,7 +284,7 @@ index 80728ea57d..7858aec2e0 100644
  
              rc = get_paged_frame(gfn, &mfn, &pg,
                                   op->flags & GNTMAP_readonly, rd);
-@@ -1437,11 +1477,7 @@ unmap_common_complete(struct gnttab_unmap_common *op)
+@@ -1459,11 +1499,7 @@ unmap_common_complete(struct gnttab_unma
  
      act = active_entry_acquire(rgt, op->ref);
      sha = shared_entry_header(rgt, op->ref);
@@ -303,7 +297,7 @@ index 80728ea57d..7858aec2e0 100644
  
      pg = mfn_to_page(op->mfn);
  
-@@ -1627,6 +1663,12 @@ static int
+@@ -1649,6 +1685,12 @@ static int
  gnttab_populate_status_frames(struct domain *d, struct grant_table *gt,
                                unsigned int req_nr_frames)
  {
@@ -316,7 +310,7 @@ index 80728ea57d..7858aec2e0 100644
      unsigned i;
      unsigned req_status_frames;
  
-@@ -1724,6 +1766,7 @@ gnttab_unpopulate_status_frames(struct domain *d, struct grant_table *gt)
+@@ -1746,6 +1788,7 @@ gnttab_unpopulate_status_frames(struct d
  
      return 0;
  }
@@ -324,7 +318,7 @@ index 80728ea57d..7858aec2e0 100644
  
  /*
   * Grow the grant table. The caller must hold the grant table's
-@@ -1770,7 +1813,7 @@ gnttab_grow_table(struct domain *d, unsigned int req_nr_frames)
+@@ -1792,7 +1835,7 @@ gnttab_grow_table(struct domain *d, unsi
      }
  
      /* Status pages - version 2 */
@@ -333,7 +327,7 @@ index 80728ea57d..7858aec2e0 100644
      {
          if ( gnttab_populate_status_frames(d, gt, req_nr_frames) )
              goto shared_alloc_failed;
-@@ -1820,7 +1863,9 @@ int grant_table_init(struct domain *d, unsigned int max_grant_frames,
+@@ -1848,7 +1891,9 @@ int grant_table_init(struct domain *d, i
      percpu_rwlock_resource_init(&gt->lock, grant_rwlock);
      spin_lock_init(&gt->maptrack_lock);
  
@@ -343,7 +337,7 @@ index 80728ea57d..7858aec2e0 100644
      gt->max_grant_frames = max_grant_frames;
      gt->max_maptrack_frames = max_maptrack_frames;
  
-@@ -1924,7 +1969,7 @@ gnttab_setup_table(
+@@ -1952,7 +1997,7 @@ gnttab_setup_table(
      }
  
      if ( (op.nr_frames > nr_grant_frames(gt) ||
@@ -352,7 +346,7 @@ index 80728ea57d..7858aec2e0 100644
             (grant_to_status_frames(op.nr_frames) > nr_status_frames(gt)))) &&
           gnttab_grow_table(d, op.nr_frames) )
      {
-@@ -2083,6 +2128,7 @@ gnttab_transfer(
+@@ -2111,6 +2156,7 @@ gnttab_transfer(
      mfn_t mfn;
      unsigned int max_bitsize;
      struct active_grant_entry *act;
@@ -360,7 +354,7 @@ index 80728ea57d..7858aec2e0 100644
  
      for ( i = 0; i < count; i++ )
      {
-@@ -2167,7 +2213,7 @@ gnttab_transfer(
+@@ -2195,7 +2241,7 @@ gnttab_transfer(
          }
  
          max_bitsize = domain_clamp_alloc_bitsize(
@@ -369,7 +363,7 @@ index 80728ea57d..7858aec2e0 100644
                 ? BITS_PER_LONG + PAGE_SHIFT : 32 + PAGE_SHIFT);
          if ( max_bitsize < BITS_PER_LONG + PAGE_SHIFT &&
               (mfn_x(mfn) >> (max_bitsize - PAGE_SHIFT)) )
-@@ -2259,22 +2305,12 @@ gnttab_transfer(
+@@ -2287,22 +2333,12 @@ gnttab_transfer(
          grant_read_lock(e->grant_table);
          act = active_entry_acquire(e->grant_table, gop.ref);
  
@@ -396,7 +390,7 @@ index 80728ea57d..7858aec2e0 100644
          smp_wmb();
          shared_entry_header(e->grant_table, gop.ref)->flags |=
              GTF_transfer_completed;
-@@ -2319,19 +2355,20 @@ release_grant_for_copy(
+@@ -2347,19 +2383,20 @@ release_grant_for_copy(
      act = active_entry_acquire(rgt, gref);
      sha = shared_entry_header(rgt, gref);
      mfn = act->mfn;
@@ -420,7 +414,7 @@ index 80728ea57d..7858aec2e0 100644
  
      if ( readonly )
      {
-@@ -2364,6 +2401,7 @@ release_grant_for_copy(
+@@ -2392,6 +2429,7 @@ release_grant_for_copy(
      }
  }
  
@@ -428,7 +422,7 @@ index 80728ea57d..7858aec2e0 100644
  /* The status for a grant indicates that we're taking more access than
     the pin requires.  Fix up the status to match the pin.  Called
     under the domain's grant table lock. */
-@@ -2379,6 +2417,7 @@ static void fixup_status_for_copy_pin(struct domain *rd,
+@@ -2407,6 +2445,7 @@ static void fixup_status_for_copy_pin(st
      if ( !act->pin )
          gnttab_clear_flag(rd, _GTF_reading, status);
  }
@@ -436,7 +430,7 @@ index 80728ea57d..7858aec2e0 100644
  
  /*
   * Grab a machine frame number from a grant entry and update the flags
-@@ -2398,7 +2437,6 @@ acquire_grant_for_copy(
+@@ -2426,7 +2465,6 @@ acquire_grant_for_copy(
      struct active_grant_entry *act;
      grant_status_t *status;
      uint32_t old_pin;
@@ -444,7 +438,7 @@ index 80728ea57d..7858aec2e0 100644
      grant_ref_t trans_gref;
      struct domain *td;
      mfn_t grant_mfn;
-@@ -2416,27 +2454,31 @@ acquire_grant_for_copy(
+@@ -2444,27 +2482,31 @@ acquire_grant_for_copy(
                   "Bad grant reference %#x\n", gref);
  
      act = active_entry_acquire(rgt, gref);
@@ -484,7 +478,7 @@ index 80728ea57d..7858aec2e0 100644
          if ( (!old_pin || (!readonly &&
                             !(old_pin & (GNTPIN_devw_mask|GNTPIN_hstw_mask)))) &&
               (rc = _set_status_v2(shah, status, rd, act, readonly, 0,
-@@ -2537,10 +2579,12 @@ acquire_grant_for_copy(
+@@ -2565,10 +2607,12 @@ acquire_grant_for_copy(
              act->is_sub_page = true;
          }
      }
@@ -499,7 +493,7 @@ index 80728ea57d..7858aec2e0 100644
                                 readonly, 0, ldom)) != GNTST_okay )
               goto unlock_out;
  
-@@ -2947,6 +2991,17 @@ static long
+@@ -2975,6 +3019,17 @@ static long
  gnttab_set_version(XEN_GUEST_HANDLE_PARAM(gnttab_set_version_t) uop)
  {
      gnttab_set_version_t op;
@@ -517,7 +511,7 @@ index 80728ea57d..7858aec2e0 100644
      struct domain *currd = current->domain;
      struct grant_table *gt = currd->grant_table;
      grant_entry_v1_t reserved_entries[GNTTAB_NR_RESERVED_ENTRIES];
-@@ -3090,8 +3145,10 @@ gnttab_set_version(XEN_GUEST_HANDLE_PARAM(gnttab_set_version_t) uop)
+@@ -3118,8 +3173,10 @@ gnttab_set_version(XEN_GUEST_HANDLE_PARA
          res = -EFAULT;
  
      return res;
@@ -528,7 +522,7 @@ index 80728ea57d..7858aec2e0 100644
  static long
  gnttab_get_status_frames(XEN_GUEST_HANDLE_PARAM(gnttab_get_status_frames_t) uop,
                           unsigned int count, unsigned int limit_max)
-@@ -3168,6 +3225,7 @@ gnttab_get_status_frames(XEN_GUEST_HANDLE_PARAM(gnttab_get_status_frames_t) uop,
+@@ -3196,6 +3253,7 @@ gnttab_get_status_frames(XEN_GUEST_HANDL
  
      return 0;
  }
@@ -536,7 +530,7 @@ index 80728ea57d..7858aec2e0 100644
  
  static long
  gnttab_get_version(XEN_GUEST_HANDLE_PARAM(gnttab_get_version_t) uop)
-@@ -3190,7 +3248,7 @@ gnttab_get_version(XEN_GUEST_HANDLE_PARAM(gnttab_get_version_t) uop)
+@@ -3218,7 +3276,7 @@ gnttab_get_version(XEN_GUEST_HANDLE_PARA
          return rc;
      }
  
@@ -545,7 +539,7 @@ index 80728ea57d..7858aec2e0 100644
  
      rcu_unlock_domain(d);
  
-@@ -3229,7 +3287,7 @@ swap_grant_ref(grant_ref_t ref_a, grant_ref_t ref_b)
+@@ -3257,7 +3315,7 @@ swap_grant_ref(grant_ref_t ref_a, grant_
      if ( act_b->pin )
          PIN_FAIL(out, GNTST_eagain, "ref b %#x busy\n", ref_b);
  
@@ -554,7 +548,7 @@ index 80728ea57d..7858aec2e0 100644
      {
          grant_entry_v1_t shared;
  
-@@ -3237,6 +3295,7 @@ swap_grant_ref(grant_ref_t ref_a, grant_ref_t ref_b)
+@@ -3265,6 +3323,7 @@ swap_grant_ref(grant_ref_t ref_a, grant_
          shared_entry_v1(gt, ref_a) = shared_entry_v1(gt, ref_b);
          shared_entry_v1(gt, ref_b) = shared;
      }
@@ -562,7 +556,7 @@ index 80728ea57d..7858aec2e0 100644
      else
      {
          grant_entry_v2_t shared;
-@@ -3251,6 +3310,7 @@ swap_grant_ref(grant_ref_t ref_a, grant_ref_t ref_b)
+@@ -3279,6 +3338,7 @@ swap_grant_ref(grant_ref_t ref_a, grant_
          shared_entry_v2(gt, ref_b) = shared;
          status_entry(gt, ref_b) = status;
      }
@@ -570,7 +564,7 @@ index 80728ea57d..7858aec2e0 100644
  
  out:
      if ( act_b != NULL )
-@@ -3510,11 +3570,13 @@ do_grant_table_op(
+@@ -3537,11 +3597,13 @@ do_grant_table_op(
          rc = gnttab_set_version(guest_handle_cast(uop, gnttab_set_version_t));
          break;
  
@@ -584,7 +578,7 @@ index 80728ea57d..7858aec2e0 100644
  
      case GNTTABOP_get_version:
          rc = gnttab_get_version(guest_handle_cast(uop, gnttab_get_version_t));
-@@ -3614,10 +3676,7 @@ gnttab_release_mappings(
+@@ -3644,10 +3706,7 @@ gnttab_release_mappings(
  
          act = active_entry_acquire(rgt, ref);
          sha = shared_entry_header(rgt, ref);
@@ -596,7 +590,7 @@ index 80728ea57d..7858aec2e0 100644
  
          pg = mfn_to_page(act->mfn);
  
-@@ -3773,17 +3832,18 @@ int mem_sharing_gref_to_gfn(struct grant_table *gt, grant_ref_t ref,
+@@ -3803,17 +3862,18 @@ int mem_sharing_gref_to_gfn(struct grant
  
      grant_read_lock(gt);
  
@@ -617,7 +611,7 @@ index 80728ea57d..7858aec2e0 100644
      else
      {
          const grant_entry_v2_t *sha2 = &shared_entry_v2(gt, ref);
-@@ -3794,16 +3854,12 @@ int mem_sharing_gref_to_gfn(struct grant_table *gt, grant_ref_t ref,
+@@ -3824,16 +3884,12 @@ int mem_sharing_gref_to_gfn(struct grant
          else
             *gfn = _gfn(sha2->full_page.frame);
      }
@@ -636,7 +630,7 @@ index 80728ea57d..7858aec2e0 100644
  
      grant_read_unlock(gt);
  
-@@ -3815,6 +3871,9 @@ int mem_sharing_gref_to_gfn(struct grant_table *gt, grant_ref_t ref,
+@@ -3845,6 +3901,9 @@ int mem_sharing_gref_to_gfn(struct grant
  static int gnttab_get_status_frame_mfn(struct domain *d,
                                         unsigned long idx, mfn_t *mfn)
  {
@@ -646,7 +640,7 @@ index 80728ea57d..7858aec2e0 100644
      const struct grant_table *gt = d->grant_table;
  
      ASSERT(gt->gt_version == 2);
-@@ -3843,6 +3902,7 @@ static int gnttab_get_status_frame_mfn(struct domain *d,
+@@ -3873,6 +3932,7 @@ static int gnttab_get_status_frame_mfn(s
      }
  
      *mfn = _mfn(virt_to_mfn(gt->status[idx]));
@@ -654,7 +648,7 @@ index 80728ea57d..7858aec2e0 100644
      return 0;
  }
  
-@@ -3852,7 +3912,7 @@ static int gnttab_get_shared_frame_mfn(struct domain *d,
+@@ -3882,7 +3942,7 @@ static int gnttab_get_shared_frame_mfn(s
  {
      const struct grant_table *gt = d->grant_table;
  
@@ -663,7 +657,7 @@ index 80728ea57d..7858aec2e0 100644
  
      if ( idx >= nr_grant_frames(gt) )
      {
-@@ -3883,7 +3943,7 @@ int gnttab_map_frame(struct domain *d, unsigned long idx, gfn_t gfn, mfn_t *mfn)
+@@ -3913,7 +3973,7 @@ int gnttab_map_frame(struct domain *d, u
  
      grant_write_lock(gt);
  
@@ -672,7 +666,7 @@ index 80728ea57d..7858aec2e0 100644
      {
          idx &= ~XENMAPIDX_grant_table_status;
          status = true;
-@@ -3929,7 +3989,7 @@ int gnttab_get_status_frame(struct domain *d, unsigned long idx,
+@@ -3959,7 +4019,7 @@ int gnttab_get_status_frame(struct domai
      int rc;
  
      grant_write_lock(gt);
@@ -681,7 +675,7 @@ index 80728ea57d..7858aec2e0 100644
          gnttab_get_status_frame_mfn(d, idx, mfn) : -EINVAL;
      grant_write_unlock(gt);
  
-@@ -3949,7 +4009,7 @@ static void gnttab_usage_print(struct domain *rd)
+@@ -3979,7 +4039,7 @@ static void gnttab_usage_print(struct do
  
      printk("grant-table for remote d%d (v%u)\n"
             "  %u frames (%u max), %u maptrack frames (%u max)\n",
@@ -690,7 +684,7 @@ index 80728ea57d..7858aec2e0 100644
             nr_grant_frames(gt), gt->max_grant_frames,
             nr_maptrack_frames(gt), gt->max_maptrack_frames);
  
-@@ -3968,17 +4028,8 @@ static void gnttab_usage_print(struct domain *rd)
+@@ -3998,17 +4058,8 @@ static void gnttab_usage_print(struct do
          }
  
          sha = shared_entry_header(gt, ref);

--- a/recipes-extended/xen/files/kconfig-grant-table.patch
+++ b/recipes-extended/xen/files/kconfig-grant-table.patch
@@ -60,11 +60,9 @@ Acked-by: Julien Grall <julien.grall@arm.com>
  xen/include/xen/grant_table.h | 48 +++++++++++++++++++++++++++++++++++
  9 files changed, 72 insertions(+), 3 deletions(-)
 
-diff --git a/xen/arch/arm/traps.c b/xen/arch/arm/traps.c
-index 8741aa1d59..d8b9a8a0f0 100644
 --- a/xen/arch/arm/traps.c
 +++ b/xen/arch/arm/traps.c
-@@ -1396,7 +1396,9 @@ static arm_hypercall_t arm_hypercall_table[] = {
+@@ -1365,7 +1365,9 @@ static arm_hypercall_t arm_hypercall_tab
      HYPERCALL_DEPRECATED(physdev_op_compat, 1),
      HYPERCALL(sysctl, 2),
      HYPERCALL(hvm_op, 2),
@@ -74,8 +72,6 @@ index 8741aa1d59..d8b9a8a0f0 100644
      HYPERCALL(multicall, 2),
      HYPERCALL(platform_op, 1),
      HYPERCALL_ARM(vcpu_op, 3),
-diff --git a/xen/arch/x86/hvm/Makefile b/xen/arch/x86/hvm/Makefile
-index 86b106f8e7..43e5f3a21f 100644
 --- a/xen/arch/x86/hvm/Makefile
 +++ b/xen/arch/x86/hvm/Makefile
 @@ -7,7 +7,7 @@ obj-y += dm.o
@@ -87,11 +83,9 @@ index 86b106f8e7..43e5f3a21f 100644
  obj-y += hpet.o
  obj-y += hvm.o
  obj-y += hypercall.o
-diff --git a/xen/arch/x86/hvm/hypercall.c b/xen/arch/x86/hvm/hypercall.c
-index 5bb1750595..00455ff115 100644
 --- a/xen/arch/x86/hvm/hypercall.c
 +++ b/xen/arch/x86/hvm/hypercall.c
-@@ -47,6 +47,7 @@ static long hvm_memory_op(int cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
+@@ -47,6 +47,7 @@ static long hvm_memory_op(int cmd, XEN_G
      return rc;
  }
  
@@ -107,21 +101,19 @@ index 5bb1750595..00455ff115 100644
  
  static long hvm_physdev_op(int cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
  {
-@@ -119,7 +121,9 @@ static long hvm_physdev_op(int cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
+@@ -119,7 +121,9 @@ static long hvm_physdev_op(int cmd, XEN_
  
  static const hypercall_table_t hvm_hypercall_table[] = {
      HVM_CALL(memory_op),
 +#ifdef CONFIG_GRANT_TABLE
      HVM_CALL(grant_table_op),
 +#endif
+     HYPERCALL(vm_assist),
      COMPAT_CALL(vcpu_op),
      HVM_CALL(physdev_op),
-     COMPAT_CALL(xen_version),
-diff --git a/xen/arch/x86/hypercall.c b/xen/arch/x86/hypercall.c
-index 93e78600da..cf44b82793 100644
 --- a/xen/arch/x86/hypercall.c
 +++ b/xen/arch/x86/hypercall.c
-@@ -47,7 +47,9 @@ const hypercall_args_t hypercall_args_table[NR_hypercalls] =
+@@ -47,7 +47,9 @@ const hypercall_args_t hypercall_args_ta
      ARGS(xen_version, 2),
      ARGS(console_io, 3),
      ARGS(physdev_op_compat, 1),
@@ -131,8 +123,6 @@ index 93e78600da..cf44b82793 100644
      ARGS(vm_assist, 2),
      COMP(update_va_mapping_otherdomain, 4, 5),
      ARGS(vcpu_op, 3),
-diff --git a/xen/arch/x86/pv/Makefile b/xen/arch/x86/pv/Makefile
-index 65bca04175..cf28434ba9 100644
 --- a/xen/arch/x86/pv/Makefile
 +++ b/xen/arch/x86/pv/Makefile
 @@ -5,7 +5,7 @@ obj-y += emulate.o
@@ -144,22 +134,18 @@ index 65bca04175..cf28434ba9 100644
  obj-y += hypercall.o
  obj-y += iret.o
  obj-y += misc-hypercalls.o
-diff --git a/xen/arch/x86/pv/hypercall.c b/xen/arch/x86/pv/hypercall.c
-index f452dd5c04..e9da8419ca 100644
 --- a/xen/arch/x86/pv/hypercall.c
 +++ b/xen/arch/x86/pv/hypercall.c
-@@ -53,7 +53,9 @@ const hypercall_table_t pv_hypercall_table[] = {
+@@ -53,7 +53,9 @@ const hypercall_table_t pv_hypercall_tab
      COMPAT_CALL(xen_version),
      HYPERCALL(console_io),
      COMPAT_CALL(physdev_op_compat),
 +#ifdef CONFIG_GRANT_TABLE
      COMPAT_CALL(grant_table_op),
 +#endif
-     COMPAT_CALL(vm_assist),
+     HYPERCALL(vm_assist),
      COMPAT_CALL(update_va_mapping_otherdomain),
      COMPAT_CALL(iret),
-diff --git a/xen/common/Kconfig b/xen/common/Kconfig
-index 04384628bb..c838506241 100644
 --- a/xen/common/Kconfig
 +++ b/xen/common/Kconfig
 @@ -11,6 +11,17 @@ config COMPAT
@@ -180,8 +166,6 @@ index 04384628bb..c838506241 100644
  config HAS_ALTERNATIVE
  	bool
  
-diff --git a/xen/common/Makefile b/xen/common/Makefile
-index 59ac7ded6e..bca48e6e22 100644
 --- a/xen/common/Makefile
 +++ b/xen/common/Makefile
 @@ -11,7 +11,7 @@ obj-y += event_2l.o
@@ -193,8 +177,6 @@ index 59ac7ded6e..bca48e6e22 100644
  obj-y += guestcopy.o
  obj-bin-y += gunzip.init.o
  obj-y += irq.o
-diff --git a/xen/include/xen/grant_table.h b/xen/include/xen/grant_table.h
-index 12e8a4b80b..6f9345d9ef 100644
 --- a/xen/include/xen/grant_table.h
 +++ b/xen/include/xen/grant_table.h
 @@ -29,6 +29,7 @@
@@ -205,7 +187,7 @@ index 12e8a4b80b..6f9345d9ef 100644
  struct grant_table;
  
  extern unsigned int opt_max_grant_frames;
-@@ -61,4 +62,51 @@ int gnttab_get_shared_frame(struct domain *d, unsigned long idx,
+@@ -60,4 +61,51 @@ int gnttab_get_shared_frame(struct domai
  int gnttab_get_status_frame(struct domain *d, unsigned long idx,
                              mfn_t *mfn);
  
@@ -257,6 +239,3 @@ index 12e8a4b80b..6f9345d9ef 100644
 +#endif /* CONFIG_GRANT_TABLE */
 +
  #endif /* __XEN_GRANT_TABLE_H__ */
--- 
-2.17.1
-

--- a/recipes-extended/xen/files/libxl-block-scripts-log-to-syslog.patch
+++ b/recipes-extended/xen/files/libxl-block-scripts-log-to-syslog.patch
@@ -1,6 +1,6 @@
---- xen.orig/tools/hotplug/Linux/xen-hotplug-common.sh.in	2019-08-28 14:13:57.845225343 -0400
-+++ xen/tools/hotplug/Linux/xen-hotplug-common.sh.in	2019-08-28 14:17:23.495223153 -0400
-@@ -20,8 +20,6 @@
+--- a/tools/hotplug/Linux/xen-hotplug-common.sh.in
++++ b/tools/hotplug/Linux/xen-hotplug-common.sh.in
+@@ -20,8 +20,6 @@ dir=$(dirname "$0")
  . "$dir/xen-script-common.sh"
  . "$dir/locking.sh"
  

--- a/recipes-extended/xen/files/libxl-crypto-key-dir.patch
+++ b/recipes-extended/xen/files/libxl-crypto-key-dir.patch
@@ -72,7 +72,7 @@ PATCHES
 +
      ("vnuma_nodes", Array(libxl_vnode_info, "num_vnuma_nodes")),
  
-     ("max_grant_frames",    uint32, {'init_val': 'LIBXL_MAX_GRANT_FRAMES_DEFAULT'}),
+     ("max_grant_frames",    uint32, {'init_val': 'LIBXL_MAX_GRANT_DEFAULT'}),
 @@ -700,7 +703,8 @@ libxl_device_disk = Struct("device_disk"
      ("colo_port", integer),
      ("colo_export", string),
@@ -85,7 +85,7 @@ PATCHES
  libxl_device_nic = Struct("device_nic", [
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -1519,6 +1519,7 @@ void parse_config_data(const char *confi
+@@ -1528,6 +1528,7 @@ void parse_config_data(const char *confi
      if (!xlu_cfg_get_long(config, "max_event_channels", &l, 0))
          b_info->event_channels = l;
  
@@ -93,7 +93,7 @@ PATCHES
      xlu_cfg_replace_string (config, "kernel", &b_info->kernel, 0);
      xlu_cfg_replace_string (config, "ramdisk", &b_info->ramdisk, 0);
      xlu_cfg_replace_string (config, "device_tree", &b_info->device_tree, 0);
-@@ -1948,6 +1949,13 @@ void parse_config_data(const char *confi
+@@ -1957,6 +1958,13 @@ void parse_config_data(const char *confi
              parse_disk_config(&config, buf2, disk);
  
              free(buf2);

--- a/recipes-extended/xen/files/libxl-display-manager-support.patch
+++ b/recipes-extended/xen/files/libxl-display-manager-support.patch
@@ -114,7 +114,7 @@ PATCHES
                                         ("sdl",              libxl_sdl_info),
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2590,6 +2590,16 @@ skip_usbdev:
+@@ -2599,6 +2599,16 @@ skip_usbdev:
              b_info->u.hvm.vga.kind = l ? LIBXL_VGA_INTERFACE_TYPE_STD :
                                           LIBXL_VGA_INTERFACE_TYPE_CIRRUS;
  

--- a/recipes-extended/xen/files/libxl-fix-flr.patch
+++ b/recipes-extended/xen/files/libxl-fix-flr.patch
@@ -73,7 +73,7 @@ PATCHES
  
  /* from libxl_dtdev */
  
-@@ -3909,6 +3916,7 @@ struct libxl__destroy_domid_state {
+@@ -3911,6 +3918,7 @@ struct libxl__destroy_domid_state {
      libxl__devices_remove_state drs;
      libxl__destroy_devicemodel_state ddms;
      libxl__ev_child destroyer;
@@ -107,7 +107,7 @@ PATCHES
              LOGD(DEBUG, domid, "pci backend at %s is not ready", be_path);
              return ERROR_FAIL;
          }
-@@ -1119,13 +1118,13 @@ out:
+@@ -1142,13 +1141,13 @@ out:
      return rc;
  }
  
@@ -123,7 +123,7 @@ PATCHES
      fd = open(reset, O_WRONLY);
      if (fd >= 0) {
          char *buf = GCSPRINTF(PCI_BDF, domain, bus, dev, func);
-@@ -1478,10 +1477,6 @@ skip1:
+@@ -1501,10 +1500,6 @@ skip1:
          fclose(f);
      }
  out:
@@ -134,7 +134,7 @@ PATCHES
  
      if (!isstubdom) {
          rc = xc_deassign_device(ctx->xch, domid, pcidev_encode_bdf(pcidev));
-@@ -1630,7 +1625,7 @@ out:
+@@ -1669,7 +1664,7 @@ out:
      return pcidevs;
  }
  
@@ -143,7 +143,7 @@ PATCHES
  {
      libxl_ctx *ctx = libxl__gc_owner(gc);
      libxl_device_pci *pcidevs;
-@@ -1648,8 +1643,9 @@ int libxl__device_pci_destroy_all(libxl_
+@@ -1687,8 +1682,9 @@ int libxl__device_pci_destroy_all(libxl_
          if (libxl__device_pci_remove_common(gc, domid, pcidevs + i, 1) < 0)
              rc = ERROR_FAIL;
      }

--- a/recipes-extended/xen/files/libxl-fixup-cmdline-ops.patch
+++ b/recipes-extended/xen/files/libxl-fixup-cmdline-ops.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl.h
 +++ b/tools/libxl/libxl.h
-@@ -1542,6 +1542,8 @@ int libxl_domain_remus_start(libxl_ctx *
+@@ -1551,6 +1551,8 @@ int libxl_domain_remus_start(libxl_ctx *
  
  int libxl_domain_shutdown(libxl_ctx *ctx, uint32_t domid);
  int libxl_domain_reboot(libxl_ctx *ctx, uint32_t domid);

--- a/recipes-extended/xen/files/libxl-iso-hotswap.patch
+++ b/recipes-extended/xen/files/libxl-iso-hotswap.patch
@@ -29,7 +29,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl.h
 +++ b/tools/libxl/libxl.h
-@@ -1946,6 +1946,9 @@ libxl_device_usbdev_list(libxl_ctx *ctx,
+@@ -1955,6 +1955,9 @@ libxl_device_usbdev_list(libxl_ctx *ctx,
  
  void libxl_device_usbdev_list_free(libxl_device_usbdev *list, int nr);
  
@@ -73,7 +73,7 @@ PATCHES
  
 --- a/tools/libxl/libxl_disk.c
 +++ b/tools/libxl/libxl_disk.c
-@@ -666,25 +666,137 @@ int libxl_device_disk_getinfo(libxl_ctx
+@@ -661,25 +661,137 @@ int libxl_device_disk_getinfo(libxl_ctx
      return rc;
  }
  
@@ -218,7 +218,7 @@ PATCHES
  
      disk_empty.format = LIBXL_DISK_FORMAT_EMPTY;
      disk_empty.vdev = libxl__strdup(NOGC, disk->vdev);
-@@ -725,43 +838,18 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+@@ -720,43 +832,18 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
              break;
          }
      }
@@ -263,7 +263,7 @@ PATCHES
      /* Note: CTX lock is already held at this point so lock hierarchy
       * is maintained.
       */
-@@ -779,85 +867,39 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
+@@ -774,85 +861,39 @@ int libxl_cdrom_insert(libxl_ctx *ctx, u
          if (rc) goto out;
      }
  

--- a/recipes-extended/xen/files/libxl-openxt-tweaks.patch
+++ b/recipes-extended/xen/files/libxl-openxt-tweaks.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2336,6 +2341,12 @@ retry_transaction:
+@@ -2336,6 +2336,12 @@ retry_transaction:
          if (errno == EAGAIN)
              goto retry_transaction;
  
@@ -49,7 +49,7 @@ PATCHES
      libxl__multidev_begin(ao, &sdss->multidev);
      sdss->multidev.callback = spawn_stub_launch_dm;
      /* OpenXT: Again, no disk for the stubdom itself */
-@@ -2354,7 +2365,6 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2354,7 +2360,6 @@ static void spawn_stub_launch_dm(libxl__
  {
      libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
      STATE_AO_GC(sdss->dm.spawn.ao);
@@ -57,7 +57,7 @@ PATCHES
      int i, num_console = STUBDOM_SPECIAL_CONSOLES;
      libxl__device_console *console;
  
-@@ -2404,21 +2414,16 @@ static void spawn_stub_launch_dm(libxl__
+@@ -2404,21 +2409,16 @@ static void spawn_stub_launch_dm(libxl__
  
      for (i = 0; i < num_console; i++) {
          console[i].devid = i;
@@ -83,7 +83,7 @@ PATCHES
                  /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
                   * will be in use */
                  console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
-@@ -2653,6 +2658,12 @@ void libxl__spawn_local_dm(libxl__egc *e
+@@ -2653,6 +2653,12 @@ void libxl__spawn_local_dm(libxl__egc *e
                           b_info->device_model_version==LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL &&
                           !libxl__vnuma_configured(b_info));
          free(path);

--- a/recipes-extended/xen/files/libxl-openxt-xci-cpuid-signature.patch
+++ b/recipes-extended/xen/files/libxl-openxt-xci-cpuid-signature.patch
@@ -57,7 +57,7 @@ PATCHES
                                         ("acpi_firmware",    string),
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -1686,6 +1686,8 @@ void parse_config_data(const char *confi
+@@ -1695,6 +1695,8 @@ void parse_config_data(const char *confi
              fprintf(stderr, "WARNING: Specifying \"altp2mhvm\" is deprecated. "
                      "Please use \"altp2m\" instead.\n");
  

--- a/recipes-extended/xen/files/libxl-pci-passthrough-fixes.patch
+++ b/recipes-extended/xen/files/libxl-pci-passthrough-fixes.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_device.c
 +++ b/tools/libxl/libxl_device.c
-@@ -2123,6 +2123,32 @@ void libxl__device_list_free(const struc
+@@ -2131,6 +2131,32 @@ void libxl__device_list_free(const struc
      free(list);
  }
  
@@ -115,7 +115,7 @@ PATCHES
  
          libxl__xs_writev(gc, t, be_path, libxl__xs_kvs_of_flexarray(gc, back));
  
-@@ -1241,10 +1247,23 @@ int libxl__device_pci_add(libxl__gc *gc,
+@@ -1264,10 +1270,23 @@ int libxl__device_pci_add(libxl__gc *gc,
      stubdomid = libxl_get_stubdom_id(ctx, domid);
      if (stubdomid != 0) {
          libxl_device_pci pcidev_s = *pcidev;

--- a/recipes-extended/xen/files/libxl-stubdom-options.patch
+++ b/recipes-extended/xen/files/libxl-stubdom-options.patch
@@ -79,7 +79,7 @@ PATCHES
          abort();
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2477,6 +2477,17 @@ skip_usbdev:
+@@ -2486,6 +2486,17 @@ skip_usbdev:
      }
  
  

--- a/recipes-extended/xen/files/libxl-syslog.patch
+++ b/recipes-extended/xen/files/libxl-syslog.patch
@@ -216,9 +216,9 @@ PATCHES
  #include <xen/io/xenbus.h>
 --- a/tools/xl/xl.c
 +++ b/tools/xl/xl.c
-@@ -24,6 +24,9 @@
- #include <inttypes.h>
+@@ -25,6 +25,9 @@
  #include <regex.h>
+ #include <limits.h>
  
 +/* OpenXT: we use syslog */
 +#include <syslog.h>
@@ -226,7 +226,7 @@ PATCHES
  #include <libxl.h>
  #include <libxl_utils.h>
  #include <libxlutil.h>
-@@ -343,6 +346,8 @@ static void xl_ctx_free(void)
+@@ -345,6 +348,8 @@ static void xl_ctx_free(void)
          free(lockfile);
          lockfile = NULL;
      }
@@ -235,7 +235,7 @@ PATCHES
  }
  
  int main(int argc, char **argv)
-@@ -385,6 +390,8 @@ int main(int argc, char **argv)
+@@ -387,6 +392,8 @@ int main(int argc, char **argv)
      logger = xtl_createlogger_stdiostream(stderr, minmsglevel,
          (progress_use_cr ? XTL_STDIOSTREAM_PROGRESS_USE_CR : 0));
      if (!logger) exit(EXIT_FAILURE);

--- a/recipes-extended/xen/files/libxl-xenmgr-support.patch
+++ b/recipes-extended/xen/files/libxl-xenmgr-support.patch
@@ -36,7 +36,7 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl.h
 +++ b/tools/libxl/libxl.h
-@@ -1540,6 +1540,7 @@ int libxl_domain_remus_start(libxl_ctx *
+@@ -1549,6 +1549,7 @@ int libxl_domain_remus_start(libxl_ctx *
                               const libxl_asyncop_how *ao_how)
                               LIBXL_EXTERNAL_CALLERS_ONLY;
  
@@ -108,7 +108,7 @@ PATCHES
          ret = ERROR_INVAL;
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -2358,6 +2358,24 @@ retry_transaction:
+@@ -2353,6 +2353,24 @@ retry_transaction:
      libxl__xs_printf(gc, XBT_NULL,
                       DEVICE_MODEL_XS_PATH(gc, dm_domid, guest_domid, "/xen_extended_power_mgmt"), "2");
  
@@ -227,7 +227,7 @@ PATCHES
                     *usbctrls, *usbdevs, *p9devs, *vdispls, *pvcallsifs_devs;
      XLU_ConfigList *channels, *ioports, *irqs, *iomem, *viridian, *dtdevs,
                     *mca_caps;
-@@ -1584,6 +1585,11 @@ void parse_config_data(const char *confi
+@@ -1593,6 +1594,11 @@ void parse_config_data(const char *confi
  
      xlu_cfg_get_defbool(config, "nestedhvm", &b_info->nested_hvm, 0);
  
@@ -239,7 +239,7 @@ PATCHES
      switch(b_info->type) {
      case LIBXL_DOMAIN_TYPE_HVM:
          kernel_basename = libxl_basename(b_info->kernel);
-@@ -2213,64 +2219,38 @@ skip_nic:
+@@ -2222,64 +2228,38 @@ skip_nic:
          fprintf(stderr, "WARNING: vif2: netchannel2 is deprecated and not supported by xl\n");
      }
  

--- a/recipes-extended/xen/files/memory-scrub-on-domain-shutdown.patch
+++ b/recipes-extended/xen/files/memory-scrub-on-domain-shutdown.patch
@@ -48,7 +48,7 @@ PATCHES
 
 --- a/xen/common/page_alloc.c
 +++ b/xen/common/page_alloc.c
-@@ -2211,10 +2211,15 @@ void free_xenheap_pages(void *v, unsigne
+@@ -2223,10 +2223,15 @@ void free_xenheap_pages(void *v, unsigne
  
      pg = virt_to_page(v);
  
@@ -65,7 +65,7 @@ PATCHES
  }
  
  #endif  /* CONFIG_SEPARATE_XENHEAP */
-@@ -2395,8 +2400,13 @@ void free_domheap_pages(struct page_info
+@@ -2407,8 +2412,13 @@ void free_domheap_pages(struct page_info
              drop_dom_ref = false;
              scrub = 1;
          }

--- a/recipes-extended/xen/files/openxt-xci-cpuid-signature.patch
+++ b/recipes-extended/xen/files/openxt-xci-cpuid-signature.patch
@@ -54,7 +54,7 @@ PATCHES
      cpuid(base + 2, &eax, &ebx, &ecx, &edx);
 --- a/xen/arch/x86/hvm/hvm.c
 +++ b/xen/arch/x86/hvm/hvm.c
-@@ -4162,6 +4162,10 @@ static int hvmop_set_param(
+@@ -4190,6 +4190,10 @@ static int hvmop_set_param(
               !(a.value & HVMPV_base_freq) )
              rc = -EINVAL;
          break;
@@ -67,7 +67,7 @@ PATCHES
           * Only actually required for VT-x lacking unrestricted_guest
 --- a/xen/arch/x86/traps.c
 +++ b/xen/arch/x86/traps.c
-@@ -862,10 +862,18 @@ void cpuid_hypervisor_leaves(const struc
+@@ -870,10 +870,18 @@ void cpuid_hypervisor_leaves(const struc
      switch ( idx )
      {
      case 0:

--- a/recipes-extended/xen/files/opt-disable-vmcs-shadowing.patch
+++ b/recipes-extended/xen/files/opt-disable-vmcs-shadowing.patch
@@ -34,7 +34,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/hvm/vmx/vmcs.c
 +++ b/xen/arch/x86/hvm/vmx/vmcs.c
-@@ -51,6 +51,9 @@ boolean_param("unrestricted_guest", opt_
+@@ -52,6 +52,9 @@ boolean_param("unrestricted_guest", opt_
  static bool_t __read_mostly opt_apicv_enabled = 1;
  boolean_param("apicv", opt_apicv_enabled);
  
@@ -44,7 +44,7 @@ PATCHES
  /*
   * These two parameters are used to config the controls for Pause-Loop Exiting:
   * ple_gap:    upper bound on the amount of time between two successive
-@@ -371,6 +374,11 @@ static int vmx_init_vmcs_config(void)
+@@ -424,6 +427,11 @@ static int vmx_init_vmcs_config(void)
      if ( !(_vmx_secondary_exec_control & SECONDARY_EXEC_ENABLE_VM_FUNCTIONS) )
          _vmx_secondary_exec_control &= ~SECONDARY_EXEC_ENABLE_VIRT_EXCEPTIONS;
  

--- a/recipes-extended/xen/files/parse-video-from-mbi.patch
+++ b/recipes-extended/xen/files/parse-video-from-mbi.patch
@@ -42,7 +42,7 @@ PATCHES
  }
 --- a/xen/arch/x86/setup.c
 +++ b/xen/arch/x86/setup.c
-@@ -95,6 +95,9 @@ unsigned long __initdata highmem_start;
+@@ -94,6 +94,9 @@ unsigned long __initdata highmem_start;
  size_param("highmem-start", highmem_start);
  #endif
  
@@ -52,7 +52,7 @@ PATCHES
  cpumask_t __read_mostly cpu_present_map;
  
  unsigned long __read_mostly xen_phys_start;
-@@ -507,7 +510,7 @@ struct boot_video_info {
+@@ -504,7 +507,7 @@ struct boot_video_info {
  extern struct boot_video_info boot_vid_info;
  #endif
  
@@ -61,7 +61,7 @@ PATCHES
  {
  #ifdef CONFIG_VIDEO
      struct boot_video_info *bvi = &bootsym(boot_vid_info);
-@@ -516,6 +519,30 @@ static void __init parse_video_info(void
+@@ -513,6 +516,30 @@ static void __init parse_video_info(void
      if ( efi_enabled(EFI_BOOT) )
          return;
  
@@ -92,7 +92,7 @@ PATCHES
      if ( (bvi->orig_video_isVGA == 1) && (bvi->orig_video_mode == 3) )
      {
          vga_console_info.video_type = XEN_VGATYPE_TEXT_MODE_3;
-@@ -760,7 +787,7 @@ void __init noreturn __start_xen(unsigne
+@@ -757,7 +784,7 @@ void __init noreturn __start_xen(unsigne
  
      probe_hypervisor();
  

--- a/recipes-extended/xen/files/shim-support-for-shim-lock-measure.patch
+++ b/recipes-extended/xen/files/shim-support-for-shim-lock-measure.patch
@@ -32,7 +32,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  } EFI_SHIM_LOCK_PROTOCOL;
  
  struct _EFI_APPLE_PROPERTIES;
-@@ -1131,7 +1140,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1125,7 +1134,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      unsigned int i, argc;
      CHAR16 **argv, *file_name, *cfg_file_name = L"openxt.cfg", *options = NULL;
      UINTN gop_mode = ~0;
@@ -41,7 +41,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
      EFI_GRAPHICS_OUTPUT_PROTOCOL *gop = NULL;
      union string section = { NULL }, name;
      bool base_video = false;
-@@ -1215,6 +1224,8 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1209,6 +1218,8 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      PrintStr(L"Xen " __stringify(XEN_VERSION) "." __stringify(XEN_SUBVERSION)
               XEN_EXTRAVERSION " (c/s " XEN_CHANGESET ") EFI loader\r\n");
  
@@ -50,7 +50,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
      efi_arch_relocate_image(0);
  
      if ( use_cfg_file )
-@@ -1253,6 +1264,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1247,6 +1258,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          }
          else if ( !read_file(dir_handle, cfg_file_name, &cfg, NULL) )
              blexit(L"Configuration file not found.");
@@ -62,7 +62,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
          pre_parse(&cfg);
  
          if ( section.w )
-@@ -1290,16 +1306,34 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1284,16 +1300,34 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          read_file(dir_handle, s2w(&name), &kernel, option_str);
          efi_bs->FreePool(name.w);
  
@@ -101,7 +101,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
          }
  
          name.s = get_value(&cfg, section.s, "xsm");
-@@ -1307,6 +1341,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1301,6 +1335,11 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          {
              read_file(dir_handle, s2w(&name), &xsm, NULL);
              efi_bs->FreePool(name.w);
@@ -146,8 +146,8 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
 +}
 +
  #endif /* CONFIG_ARM */
- #endif
  
+ const CHAR16 *wmemchr(const CHAR16 *s, CHAR16 c, UINTN n)
 --- a/xen/include/xen/efi.h
 +++ b/xen/include/xen/efi.h
 @@ -43,6 +43,7 @@ int efi_runtime_call(struct xenpf_efi_ru

--- a/recipes-extended/xen/files/stubdomain-msi-irq-access.patch
+++ b/recipes-extended/xen/files/stubdomain-msi-irq-access.patch
@@ -40,7 +40,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/irq.c
 +++ b/xen/arch/x86/irq.c
-@@ -2672,8 +2672,36 @@ int allocate_and_map_msi_pirq(struct dom
+@@ -2719,8 +2719,36 @@ int allocate_and_map_msi_pirq(struct dom
          irq = index;
          if ( irq == -1 )
          {
@@ -78,7 +78,7 @@ PATCHES
          }
  
          if ( irq < nr_irqs_gsi || irq >= nr_irqs )
-@@ -2716,8 +2744,20 @@ int allocate_and_map_msi_pirq(struct dom
+@@ -2763,8 +2791,20 @@ int allocate_and_map_msi_pirq(struct dom
          {
          case MAP_PIRQ_TYPE_MSI:
              if ( index == -1 )

--- a/recipes-extended/xen/files/tboot-measure-and-launch-from-xen-efi.patch
+++ b/recipes-extended/xen/files/tboot-measure-and-launch-from-xen-efi.patch
@@ -62,7 +62,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  Extra options to be passed to Xen can also be specified on the command line,
 --- a/xen/arch/arm/efi/efi-boot.h
 +++ b/xen/arch/arm/efi/efi-boot.h
-@@ -392,7 +392,8 @@ static void __init efi_arch_cfg_file_ear
+@@ -395,7 +395,8 @@ static void __init efi_arch_cfg_file_ear
          blexit(L"Unable to create new FDT");
  }
  
@@ -72,7 +72,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  {
  }
  
-@@ -415,6 +416,16 @@ static void __init efi_arch_memory_setup
+@@ -418,6 +419,16 @@ static void __init efi_arch_memory_setup
  {
  }
  
@@ -91,19 +91,16 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
                                             char *cfgfile_options)
 --- a/xen/arch/x86/efi/efi-boot.h
 +++ b/xen/arch/x86/efi/efi-boot.h
-@@ -8,16 +8,43 @@
- #include <asm/edd.h>
+@@ -9,16 +9,43 @@
  #include <asm/msr.h>
  #include <asm/processor.h>
+ #include <asm/setup.h>
 +#include <xen/libelf.h>
 +#include <xen/multiboot2.h>
 +#include <acpi/acconfig.h>
 +#include <acpi/actbl.h>
  
  static struct file __initdata ucode;
-+static struct file __initdata tboot_file;
-+static u32 __initdata tboot_entry;
-+static CHAR16* __initdata xen_self_filename;
  static multiboot_info_t __initdata mbi = {
      .flags = MBI_MODULES | MBI_LOADERNAME
  };
@@ -133,10 +130,13 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
 -static module_t __initdata mb_modules[5];
 +#define MB_MAX_MODULES 30
 +static module_t __initdata mb_modules[MB_MAX_MODULES + 1];
++static struct file __initdata tboot_file;
++static u32 __initdata tboot_entry;
++static CHAR16* __initdata xen_self_filename;
  
  static void __init edd_put_string(u8 *dst, size_t n, const char *src)
  {
-@@ -212,6 +239,231 @@ static void __init efi_arch_process_memo
+@@ -213,6 +240,231 @@ static void __init efi_arch_process_memo
  
  }
  
@@ -368,7 +368,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  static void *__init efi_arch_allocate_mmap_buffer(UINTN map_size)
  {
      return ebmalloc(map_size);
-@@ -227,12 +479,56 @@ static void __init efi_arch_pre_exit_boo
+@@ -228,12 +480,56 @@ static void __init efi_arch_pre_exit_boo
      }
  }
  
@@ -429,7 +429,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  
      /* Set system registers and transfer control. */
      asm volatile("pushq $0\n\tpopfq");
-@@ -262,22 +558,35 @@ static void __init noreturn efi_arch_pos
+@@ -263,22 +559,35 @@ static void __init noreturn efi_arch_pos
                     "lretq  %[stkoff]-16"
                     : [rip] "=&r" (efer/* any dead 64-bit variable */),
                       [cr4] "+&r" (cr4)
@@ -468,7 +468,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  
      name.s = get_value(&cfg, section, "ucode");
      if ( !name.s )
-@@ -289,6 +598,112 @@ static void __init efi_arch_cfg_file_lat
+@@ -290,6 +599,112 @@ static void __init efi_arch_cfg_file_lat
          read_file(dir_handle, s2w(&name), &ucode, NULL);
          efi_bs->FreePool(name.w);
      }
@@ -581,7 +581,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
  }
  
  static void __init efi_arch_handle_cmdline(CHAR16 *image_name,
-@@ -561,6 +976,10 @@ static void __init efi_arch_memory_setup
+@@ -564,6 +979,10 @@ static void __init efi_arch_memory_setup
      unsigned int i;
      EFI_STATUS status;
  
@@ -592,7 +592,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
      /* Allocate space for trampoline (in first Mb). */
      cfg.addr = 0x100000;
  
-@@ -709,6 +1128,146 @@ void __init efi_multiboot2(EFI_HANDLE Im
+@@ -714,6 +1133,146 @@ void __init efi_multiboot2(EFI_HANDLE Im
      efi_exit_boot(ImageHandle, SystemTable);
  }
  
@@ -905,7 +905,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
      tboot_copy_memory((unsigned char *)&dmar_table_length,
 --- a/xen/common/efi/boot.c
 +++ b/xen/common/efi/boot.c
-@@ -640,7 +640,7 @@ static bool __init read_file(EFI_FILE_HA
+@@ -630,7 +630,7 @@ static bool __init read_file(EFI_FILE_HA
          what = what ?: L"Seek";
      else
      {
@@ -914,7 +914,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
                           HYPERVISOR_VIRT_END - DIRECTMAP_VIRT_START);
          ret = efi_bs->AllocatePages(AllocateMaxAddress, EfiLoaderData,
                                      PFN_UP(size), &file->addr);
-@@ -752,6 +752,7 @@ static char *__init get_value(const stru
+@@ -742,6 +742,7 @@ static char *__init get_value(const stru
  
  static void __init efi_init(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
  {
@@ -922,7 +922,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
      efi_ih = ImageHandle;
      efi_bs = SystemTable->BootServices;
      efi_bs_revision = efi_bs->Hdr.Revision;
-@@ -1154,6 +1155,8 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1148,6 +1149,8 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
      __set_bit(EFI_RS, &efi_flags);
  #endif
  
@@ -931,7 +931,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
      efi_init(ImageHandle, SystemTable);
  
      use_cfg_file = efi_arch_use_config_file(SystemTable);
-@@ -1244,6 +1247,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1238,6 +1241,13 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
          /* Get the file system interface. */
          dir_handle = get_parent_handle(loaded_image, &file_name);
  
@@ -945,7 +945,7 @@ Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>
          /* Read and parse the config file. */
          if ( !cfg_file_name )
          {
-@@ -1388,7 +1398,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
+@@ -1382,7 +1392,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SY
              }
          }
  

--- a/recipes-extended/xen/files/tboot-xen-evtlog-support.patch
+++ b/recipes-extended/xen/files/tboot-xen-evtlog-support.patch
@@ -103,7 +103,7 @@ PATCHES
 + */
 --- a/xen/arch/x86/hvm/hypercall.c
 +++ b/xen/arch/x86/hvm/hypercall.c
-@@ -143,6 +143,9 @@ static const hypercall_table_t hvm_hyper
+@@ -148,6 +148,9 @@ static const hypercall_table_t hvm_hyper
  #endif
      HYPERCALL(xenpmu_op),
      COMPAT_CALL(dm_op),
@@ -115,7 +115,7 @@ PATCHES
  
 --- a/xen/arch/x86/hypercall.c
 +++ b/xen/arch/x86/hypercall.c
-@@ -72,6 +72,9 @@ const hypercall_args_t hypercall_args_ta
+@@ -74,6 +74,9 @@ const hypercall_args_t hypercall_args_ta
      ARGS(hvm_op, 2),
      ARGS(dm_op, 3),
  #endif
@@ -127,7 +127,7 @@ PATCHES
  };
 --- a/xen/arch/x86/pv/hypercall.c
 +++ b/xen/arch/x86/pv/hypercall.c
-@@ -85,6 +85,9 @@ const hypercall_table_t pv_hypercall_tab
+@@ -87,6 +87,9 @@ const hypercall_table_t pv_hypercall_tab
      HYPERCALL(hvm_op),
      COMPAT_CALL(dm_op),
  #endif
@@ -289,7 +289,7 @@ PATCHES
  extern int
 --- a/xen/common/Kconfig
 +++ b/xen/common/Kconfig
-@@ -182,6 +182,10 @@ choice
+@@ -222,6 +222,10 @@ choice
  		bool "SILO" if XSM_SILO
  endchoice
  

--- a/recipes-extended/xen/files/unmap-shared-info.patch
+++ b/recipes-extended/xen/files/unmap-shared-info.patch
@@ -71,7 +71,7 @@ PATCHES
  #include <asm/paging.h>
  #include <asm/shadow.h>
  #include <asm/page.h>
-@@ -4469,6 +4470,9 @@ int xenmem_add_to_physmap_one(
+@@ -4663,6 +4664,9 @@ int xenmem_add_to_physmap_one(
      int rc = 0;
      mfn_t mfn = INVALID_MFN;
      p2m_type_t p2mt;
@@ -81,7 +81,7 @@ PATCHES
  
      if ( !paging_mode_translate(d) )
          return -EACCES;
-@@ -4478,6 +4482,13 @@ int xenmem_add_to_physmap_one(
+@@ -4672,6 +4676,13 @@ int xenmem_add_to_physmap_one(
          case XENMAPSPACE_shared_info:
              if ( idx == 0 )
                  mfn = virt_to_mfn(d->shared_info);
@@ -95,7 +95,7 @@ PATCHES
              break;
          case XENMAPSPACE_grant_table:
              rc = gnttab_map_frame(d, idx, gpfn, &mfn);
-@@ -4507,25 +4518,26 @@ int xenmem_add_to_physmap_one(
+@@ -4701,25 +4712,26 @@ int xenmem_add_to_physmap_one(
              break;
      }
  
@@ -128,7 +128,7 @@ PATCHES
  
      if ( rc )
          goto put_both;
-@@ -4543,13 +4555,28 @@ int xenmem_add_to_physmap_one(
+@@ -4737,13 +4749,28 @@ int xenmem_add_to_physmap_one(
  
      /* Map at new location. */
      if ( !rc )


### PR DESCRIPTION
The upstream changes are:
```
3536f8dc39 gnttab: fix GNTTABOP_copy continuation handling
46bde0561b xen/gnttab: Fix error path in map_grant_ref()
1541b26e84 xen/rwlock: Add missing memory barrier in the unlock path of rwlock
45624a7332 xenoprof: limit consumption of shared buffer data
dc3fb833c6 xenoprof: clear buffer intended to be shared with guests
```