### PR TITLE
S9: OXT-1787: ocaml/findlib: fix toolchain cross environment

### DIFF
--- a/recipes-extended/xen/files/ocaml-makefiles-sysroot.patch
+++ b/recipes-extended/xen/files/ocaml-makefiles-sysroot.patch
@@ -1,0 +1,13 @@
+Index: git/tools/ocaml/common.make
+===================================================================
+--- git.orig/tools/ocaml/common.make
++++ git/tools/ocaml/common.make
+@@ -12,7 +12,7 @@ OCAMLFIND ?= ocamlfind
+ CFLAGS += -fPIC -Werror -I$(shell ocamlc -where)
+ 
+ OCAMLOPTFLAG_G := $(shell $(OCAMLOPT) -h 2>&1 | sed -n 's/^  *\(-g\) .*/\1/p')
+-OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc $(CC) -w F -warn-error F
++OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc "$(CC)" -w F -warn-error F
+ OCAMLCFLAGS += -g $(OCAMLINCLUDE) -w F -warn-error F
+ 
+ VERSION := 4.1

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -115,6 +115,7 @@ SRC_URI_append = " \
     file://argo-add-viptables.patch \
     file://libxl-seabios-ipxe.patch \
     file://memory-scrub-on-domain-shutdown.patch \
+    file://ocaml-makefiles-sysroot.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-extended/xen/xen-ocaml-libs.bb
+++ b/recipes-extended/xen/xen-ocaml-libs.bb
@@ -89,16 +89,7 @@ do_compile() {
 		       LDLIBS_libxenevtchn='-lxenevtchn' \
 		       -C tools subdir-all-libxl
 
-    # ocamlopt/ocamlc -cc argument will treat everything following it as the
-    # executable name, so wrap everything.
-    cat - > ocaml-cc.sh <<EOF
-#! /bin/sh
-exec ${CC} "\$@"
-EOF
-    chmod +x ocaml-cc.sh
-
     oe_runmake V=1 \
-       CC="${B}/ocaml-cc.sh" \
        LDLIBS_libxenctrl='-lxenctrl' \
        LDLIBS_libxenstore='-lxenstore' \
        LDLIBS_libblktapctl='-lblktapctl' \

--- a/recipes-openxt/dbd/dbd_git.bb
+++ b/recipes-openxt/dbd/dbd_git.bb
@@ -16,19 +16,10 @@ SRC_URI = " \
     file://db.default \
 "
 
-RDEPENDS_${PN} += "bash"
-
 S = "${WORKDIR}/git/dbd"
 
-inherit update-rc.d haskell ocaml findlib xc-rpcgen
+inherit update-rc.d ocaml findlib xc-rpcgen
 
-INITSCRIPT_NAME = "dbd"
-INITSCRIPT_PARAMS = "defaults 25"
-
-FILES_${PN} += " \
-    ${datadir}/xenclient/db.default \
-    ${sysconfdir}/init.d/* \
-"
 
 do_configure() {
     # generate rpc stubs
@@ -41,16 +32,25 @@ do_configure() {
 }
 
 do_compile() {
-    make V=1 XEN_DIST_ROOT="${STAGING_DIR}" TARGET_PREFIX="${TARGET_PREFIX}" STAGING_DIR="${STAGING_DIR}" STAGING_BINDIR_CROSS="${STAGING_BINDIR_CROSS}" STAGING_LIBDIR="${STAGING_LIBDIR}" STAGING_INCDIR="${STAGING_INCDIR}" all
+    oe_runmake V=1 XEN_DIST_ROOT="${STAGING_DIR}" all
 }
 
 do_install() {
     # findlib.bbclass will create ${D}${sitelibdir} for generic ocamlfind
     # compliance with bitbake. This does not ship any library though.
     rm -rf ${D}${libdir}
-    make DESTDIR=${D} V=1 install
+    oe_runmake V=1 DESTDIR="${D}" install
     install -m 0755 -d ${D}${sysconfdir}/init.d
     install -m 0755 ${WORKDIR}/dbd.initscript ${D}${sysconfdir}/init.d/dbd
     install -m 0755 -d ${D}/usr/share/xenclient
     install -m 0644 ${WORKDIR}/db.default ${D}/usr/share/xenclient/db.default
 }
+
+INITSCRIPT_NAME = "dbd"
+INITSCRIPT_PARAMS = "defaults 25"
+
+FILES_${PN} += " \
+    ${datadir}/xenclient/db.default \
+    ${sysconfdir}/init.d/* \
+"
+RDEPENDS_${PN} += "bash"

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bb
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bb
@@ -63,7 +63,7 @@ S = "${WORKDIR}/git"
 # TODO: ocamlc can figure it out in the build-system.
 CFLAGS_append = " -I${ocamlincdir}"
 do_compile() {
-        make V=1 XEN_DIST_ROOT="${STAGING_DIR_HOST}"
+    oe_runmake V=1 XEN_DIST_ROOT="${STAGING_DIR_HOST}"
 }
 
 OCAML_INSTALL_LIBS = " \


### PR DESCRIPTION
- Amend quoting in xen OCaml tools build-system to pass down arguments provided through `$(CC)`.
- Use `oe_runmake` to inherit the `EXTRA_OEMAKE` definitions from `ocaml.bbclass`.

Require:
- https://github.com/OpenXT/uid/pull/4
- https://github.com/OpenXT/toolstack/pull/42
- https://github.com/OpenXT/manager/pull/178
- https://github.com/OpenXT/meta-openxt-ocaml-platform/pull/20