### PR TITLE
OXT-1787: ocaml/findlib: fix toolchain cross environment

### DIFF
--- a/recipes-extended/xen/files/ocaml-makefiles-sysroot.patch
+++ b/recipes-extended/xen/files/ocaml-makefiles-sysroot.patch
@@ -1,0 +1,13 @@
+Index: git/tools/ocaml/common.make
+===================================================================
+--- git.orig/tools/ocaml/common.make
++++ git/tools/ocaml/common.make
+@@ -12,7 +12,7 @@ OCAMLFIND ?= ocamlfind
+ CFLAGS += -fPIC -Werror -I$(shell ocamlc -where)
+ 
+ OCAMLOPTFLAG_G := $(shell $(OCAMLOPT) -h 2>&1 | sed -n 's/^  *\(-g\) .*/\1/p')
+-OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc $(CC) -w F -warn-error F
++OCAMLOPTFLAGS = $(OCAMLOPTFLAG_G) -ccopt "$(LDFLAGS)" -dtypes $(OCAMLINCLUDE) -cc "$(CC)" -w F -warn-error F
+ OCAMLCFLAGS += -g $(OCAMLINCLUDE) -w F -warn-error F
+ 
+ VERSION := 4.1

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -99,6 +99,7 @@ SRC_URI_append = " \
     file://0001-tools-helpers-Introduce-cmp-fd-file-inode-utility.patch \
     file://0002-Linux-locking.sh-Use-cmp-fd-file-inode-for-lock-chec.patch \
     file://ocamlfind-static.patch \
+    file://ocaml-makefiles-sysroot.patch \
 "
 
 COMPATIBLE_HOST = 'i686-oe-linux|(x86_64.*).*-linux|aarch64.*-linux'

--- a/recipes-extended/xen/xen-ocaml-libs.bb
+++ b/recipes-extended/xen/xen-ocaml-libs.bb
@@ -89,17 +89,7 @@ do_compile() {
 		       LDLIBS_libxenevtchn='-lxenevtchn' \
 		       -C tools subdir-all-libxl
 
-    # ocamlopt/ocamlc -cc argument will treat everything following it as the
-    # executable name, so wrap everything.
-    cat - > ocaml-cc.sh <<EOF
-#! /bin/sh
-exec ${CC} "\$@"
-EOF
-    chmod +x ocaml-cc.sh
-
     oe_runmake V=1 \
-       CC="${B}/ocaml-cc.sh" \
-       OCAMLOPT="ocamlopt.opt" \
        LDLIBS_libxenctrl='-lxenctrl' \
        LDLIBS_libxenstore='-lxenstore' \
        LDLIBS_libblktapctl='-lblktapctl' \

--- a/recipes-openxt/dbd/dbd_git.bb
+++ b/recipes-openxt/dbd/dbd_git.bb
@@ -40,8 +40,6 @@ do_configure() {
     xc-rpcgen --camel --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o ${B}/autogen ${STAGING_IDLDATADIR}/dbus.xml
 }
 
-PARALLEL_MAKE=""
-
 do_install() {
     oe_runmake DESTDIR="${D}" install
 


### PR DESCRIPTION
- Remove `ocaml-cc.sh` wrapper by quoting `$(CC)`
- `dbd` can now build with `-j`

#### Require:
- https://github.com/OpenXT/uid/pull/5
- https://github.com/OpenXT/toolstack/pull/43
- https://github.com/OpenXT/manager/pull/179
- https://github.com/OpenXT/meta-openxt-ocaml-platform/pull/21