### PR TITLE
xen: refresh on top of stable-4.12

### DIFF
--- a/recipes-extended/xen/files/allow-stubdoms-cacheattr-control.patch
+++ b/recipes-extended/xen/files/allow-stubdoms-cacheattr-control.patch
@@ -74,7 +74,7 @@ PATCHES
 ################################################################################
 --- a/xen/arch/x86/hvm/mtrr.c
 +++ b/xen/arch/x86/hvm/mtrr.c
-@@ -831,12 +831,6 @@ int epte_get_entry_emt(struct domain *d,
+@@ -832,12 +832,6 @@ int epte_get_entry_emt(struct domain *d,
          return MTRR_TYPE_UNCACHABLE;
      }
  
@@ -84,10 +84,10 @@ PATCHES
 -        return MTRR_TYPE_WRBACK;
 -    }
 -
-     gmtrr_mtype = hvm_get_mem_pinned_cacheattr(d, _gfn(gfn), order);
-     if ( gmtrr_mtype >= 0 )
+     for ( i = 0; i < (1ul << order); i++ )
      {
-@@ -847,6 +841,12 @@ int epte_get_entry_emt(struct domain *d,
+         if ( is_xen_heap_page(mfn_to_page(mfn_add(mfn, i))) )
+@@ -859,6 +853,12 @@ int epte_get_entry_emt(struct domain *d,
      if ( gmtrr_mtype == -EADDRNOTAVAIL )
          return -1;
  


### PR DESCRIPTION
stable-4.12 received new commits.

- 1336ca1774 x86/hvm: set 'ipat' in EPT for special pages
changes the context of allow-stubdoms-cacheattr-control.patch. Refresh
the patch in consequence. The changes upstream should not affect the
changes introduced by the patch.

No functional change.
Fixes automatic builds.