### PR TITLE
dbd: make dbd RRECOMMENDS dbd-tools

### DIFF
--- a/recipes-openxt/dbd/dbd_git.bb
+++ b/recipes-openxt/dbd/dbd_git.bb
@@ -82,6 +82,7 @@ FILES_${PN} += " \
     ${sysconfdir}/init.d/* \
 "
 RDEPENDS_${PN} += "bash"
+RRECOMMENDS_${PN} += "dbd-tools"
 
 FILES_${PN}-tools = " \
     ${bindir}/db-cmd \


### PR DESCRIPTION
commit 3b15d672292d "dbd: Unify and rewrite recipe" changed the
packaging of db-* tools.  Previously, dbd included those tools, but now
they aren't included in dom0.  Make dbd RRECOMMENDS dbd-tools so they
are once again installed.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>