### PR TITLE
layer: Point recipes to upstream repositories

### DIFF
--- a/recipes-devtools/bats-suite/bats-suite_git.bb
+++ b/recipes-devtools/bats-suite/bats-suite_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "OpenXT bats test scripts."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c93f84859222e5549645b5fee3d87947"
 
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/bats-suite.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/bats-suite.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/xen/xen-xsm-policy_git.bb
+++ b/recipes-extended/xen/xen-xsm-policy_git.bb
@@ -11,7 +11,7 @@ require xen-version.inc
 PV = "${XEN_REL}+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xsm-policy.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xsm-policy.git"
 
 FILES_${PN} += "/etc/xen/refpolicy/policy/policy.24"
 

--- a/recipes-openxt/argo-module-headers/argo-module-headers_git.bb
+++ b/recipes-openxt/argo-module-headers/argo-module-headers_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
 PV = "git${SRCPV}"
 
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/linux-xen-argo.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/linux-xen-argo.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git/argo-linux"

--- a/recipes-openxt/argo-module/argo-module_git.bb
+++ b/recipes-openxt/argo-module/argo-module_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
 PV = "git${SRCPV}"
 
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/linux-xen-argo.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/linux-xen-argo.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git/argo-linux"

--- a/recipes-openxt/carrier-detect/carrier-detect_git.bb
+++ b/recipes-openxt/carrier-detect/carrier-detect_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 DEPENDS = "libnl"
 
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xctools.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git/carrier-detect"

--- a/recipes-openxt/dbd/dbd_git.bb
+++ b/recipes-openxt/dbd/dbd_git.bb
@@ -11,7 +11,7 @@ DEPENDS = " \
 PV = "0+git${SRCPV}"
 
 SRC_URI = " \
-    git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+    git://github.com/OpenXT/manager.git \
     file://dbd.initscript \
     file://db.default \
     file://db-exists-dom0 \

--- a/recipes-openxt/drm-surfman-plugin/drm-surfman-plugin_git.bb
+++ b/recipes-openxt/drm-surfman-plugin/drm-surfman-plugin_git.bb
@@ -7,7 +7,7 @@ INSANE_SKIP_${PN} = "dev-so"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/surfman.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/surfman.git"
 
 S = "${WORKDIR}/git/plugins/drm/"
 

--- a/recipes-openxt/fbtap/fbtap_git.bb
+++ b/recipes-openxt/fbtap/fbtap_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "device which can allocate memory and can be abused e. g. to provi
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/fbtap.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/fbtap.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-openxt/libargo/libargo_git.bb
+++ b/recipes-openxt/libargo/libargo_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "xen argo-module-headers"
 PV = "git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/linux-xen-argo.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/linux-xen-argo.git"
 
 S = "${WORKDIR}/git/libargo"
 

--- a/recipes-openxt/libargo/linux-argo-headers_git.bb
+++ b/recipes-openxt/libargo/linux-argo-headers_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/linux-xen-argo.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/linux-xen-argo.git"
 
 S = "${WORKDIR}/git/argo-linux"
 

--- a/recipes-openxt/libdmbus/libdmbus_git.bb
+++ b/recipes-openxt/libdmbus/libdmbus_git.bb
@@ -9,7 +9,7 @@ DEPENDS = " \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xctools.git"
 
 S = "${WORKDIR}/git/libdmbus"
 

--- a/recipes-openxt/libedid/libedid_git.bb
+++ b/recipes-openxt/libedid/libedid_git.bb
@@ -6,7 +6,7 @@ DEPENDS = ""
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/libedid.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/libedid.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/libicbinn/libicbinn-resolved_git.bb
+++ b/recipes-openxt/libicbinn/libicbinn-resolved_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM="file://../COPYING;md5=321bf41f280cf805086dd5a720b37785"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/icbinn.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/icbinn.git"
 
 DEPENDS = "libicbinn"
 

--- a/recipes-openxt/libicbinn/libicbinn_git.bb
+++ b/recipes-openxt/libicbinn/libicbinn_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=321bf41f280cf805086dd5a720b37785"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/icbinn.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/icbinn.git"
 SRC_URI += "file://icbinn_svc.initscript"
 
 DEPENDS = "libargo libtirpc libxcdbus"

--- a/recipes-openxt/libicbinn/pyicbinn_git.bb
+++ b/recipes-openxt/libicbinn/pyicbinn_git.bb
@@ -8,7 +8,7 @@ S = "${WORKDIR}/git/pyicbinn"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/icbinn.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/icbinn.git"
 
 DEPENDS = "swig-native libicbinn-resolved xenclient-rpcgen-native"
 RDEPENDS_${PN} += "python-lang"

--- a/recipes-openxt/libsurfman/libsurfman_git.bb
+++ b/recipes-openxt/libsurfman/libsurfman_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "xen libevent"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/surfman.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/surfman.git"
 
 S = "${WORKDIR}/git/libsurfman"
 

--- a/recipes-openxt/libxcdbus/libxcdbus_git.bb
+++ b/recipes-openxt/libxcdbus/libxcdbus_git.bb
@@ -9,7 +9,7 @@ DEPENDS = " \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/libxcdbus.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/libxcdbus.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/libxenbackend/libxenbackend_git.bb
+++ b/recipes-openxt/libxenbackend/libxenbackend_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "xen"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/libxenbackend.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/libxenbackend.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/libxenmgr-core/libxenmgr-core_git.bb
+++ b/recipes-openxt/libxenmgr-core/libxenmgr-core_git.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/manager.git"
 
 S = "${WORKDIR}/git/xenmgr-core"
 

--- a/recipes-openxt/linuxfb-surfman-plugin/linuxfb-surfman-plugin_git.bb
+++ b/recipes-openxt/linuxfb-surfman-plugin/linuxfb-surfman-plugin_git.bb
@@ -7,7 +7,7 @@ INSANE_SKIP_${PN} = "dev-so"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/surfman.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/surfman.git \
           "
 
 S = "${WORKDIR}/git/plugins/linuxfb"

--- a/recipes-openxt/openxt-ocaml-libs/openxt-ocaml-libs_git.bb
+++ b/recipes-openxt/openxt-ocaml-libs/openxt-ocaml-libs_git.bb
@@ -12,9 +12,7 @@ DEPENDS += " \
 
 PV = "0+git${SRCPV}"
 
-SRC_URI = " \
-    git://${OPENXT_GIT_MIRROR}/toolstack.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
-"
+SRC_URI = "git://github.com/OpenXT/toolstack.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-openxt/rpc-proxy/rpc-proxy_git.bb
+++ b/recipes-openxt/rpc-proxy/rpc-proxy_git.bb
@@ -28,7 +28,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32 bash"
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+    git://github.com/OpenXT/manager.git \
     file://rpc-proxy.rules \
     file://rpc-proxy.initscript \
 "

--- a/recipes-openxt/surfman-sample/surfman-sample_git.bb
+++ b/recipes-openxt/surfman-sample/surfman-sample_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "libsurfman"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/surfman.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/surfman.git"
 
 S = "${WORKDIR}/git/plugins/sample"
 

--- a/recipes-openxt/surfman/surfman_git.bb
+++ b/recipes-openxt/surfman/surfman_git.bb
@@ -8,7 +8,7 @@ RDEPENDS_${PN} += "fbtap"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/surfman.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/surfman.git \
            file://surfman.initscript \
            file://surfman.conf"
 

--- a/recipes-openxt/sync-client/sync-client_git.bb
+++ b/recipes-openxt/sync-client/sync-client_git.bb
@@ -24,7 +24,7 @@ RDEPENDS_${PN} += "python \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/sync-client.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/sync-client.git \
            file://sync-client-daemon.initscript"
 
 INITSCRIPT_NAME = "sync-client-daemon"

--- a/recipes-openxt/sync-wui/sync-wui_git.bb
+++ b/recipes-openxt/sync-wui/sync-wui_git.bb
@@ -12,7 +12,7 @@ XENCLIENT_RELEASE ?= "unknown"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/sync-wui.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/sync-wui.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/uid/uid_git.bb
+++ b/recipes-openxt/uid/uid_git.bb
@@ -11,7 +11,7 @@ DEPENDS = " \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/uid.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/uid.git"
 
 SRC_URI += " \
     file://uid_dbus.conf \

--- a/recipes-openxt/updatemgr/updatemgr_git.bb
+++ b/recipes-openxt/updatemgr/updatemgr_git.bb
@@ -32,7 +32,7 @@ RDEPENDS_${PN} += " \
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+    git://github.com/OpenXT/manager.git \
     file://updatemgr.initscript \
 "
 

--- a/recipes-openxt/upgrade-db/upgrade-db_git.bb
+++ b/recipes-openxt/upgrade-db/upgrade-db_git.bb
@@ -16,7 +16,7 @@ RDEPENDS_${PN} += " \
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/manager.git"
 
 S = "${WORKDIR}/git/upgrade-db"
 

--- a/recipes-openxt/vusb/vusb-daemon_git.bb
+++ b/recipes-openxt/vusb/vusb-daemon_git.bb
@@ -7,7 +7,7 @@ RDEPENDS_${PN} += "libxcxenstore"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/vusb-daemon.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/vusb-daemon.git \
            file://xenclient-vusb.initscript \
            "
 

--- a/recipes-openxt/xclibs/libxch-rpc_git.bb
+++ b/recipes-openxt/xclibs/libxch-rpc_git.bb
@@ -13,7 +13,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/xch-rpc"
 

--- a/recipes-openxt/xclibs/libxchargo_git.bb
+++ b/recipes-openxt/xclibs/libxchargo_git.bb
@@ -10,7 +10,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/xchargo"
 

--- a/recipes-openxt/xclibs/libxchdb_git.bb
+++ b/recipes-openxt/xclibs/libxchdb_git.bb
@@ -7,7 +7,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/xchdb"
 

--- a/recipes-openxt/xclibs/libxchutils_git.bb
+++ b/recipes-openxt/xclibs/libxchutils_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/xchutils"
 

--- a/recipes-openxt/xclibs/libxchwebsocket_git.bb
+++ b/recipes-openxt/xclibs/libxchwebsocket_git.bb
@@ -10,7 +10,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32 hkg-utf8-string"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/xchwebsocket"
 

--- a/recipes-openxt/xclibs/libxchxenstore_git.bb
+++ b/recipes-openxt/xclibs/libxchxenstore_git.bb
@@ -13,7 +13,7 @@ RDEPENDS_${PN} += " \
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/xchxenstore"
 

--- a/recipes-openxt/xclibs/libxclogging_git.bb
+++ b/recipes-openxt/xclibs/libxclogging_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://../COPYING;md5=321bf41f280cf805086dd5a720b37785"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 CFLAGS_append = " -Wno-unused"
 

--- a/recipes-openxt/xclibs/libxcxenstore_git.bb
+++ b/recipes-openxt/xclibs/libxcxenstore_git.bb
@@ -8,7 +8,7 @@ PV = "0+git${SRCPV}"
 PR = "r1"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/xclibs.git \
            "
 
 S = "${WORKDIR}/git/xcxenstore"

--- a/recipes-openxt/xclibs/udbus-intro_git.bb
+++ b/recipes-openxt/xclibs/udbus-intro_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/udbus-intro"
 

--- a/recipes-openxt/xclibs/udbus_git.bb
+++ b/recipes-openxt/xclibs/udbus_git.bb
@@ -12,7 +12,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32 hkg-utf8-string"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xclibs.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xclibs.git"
 
 S = "${WORKDIR}/git/udbus"
 

--- a/recipes-openxt/xctools/atapi-pt-helper_git.bb
+++ b/recipes-openxt/xctools/atapi-pt-helper_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "libargo"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xctools.git"
 
 FILES_${PN} += "/usr/lib/xen/bin/atapi_pt_helper"
 FILES_${PN}-dbg += " /usr/lib/xen/bin/.debug "

--- a/recipes-openxt/xctools/audio-helper_git.bb
+++ b/recipes-openxt/xctools/audio-helper_git.bb
@@ -6,7 +6,7 @@ DEPENDS = " libargo alsa-lib "
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/xctools.git \
            file://audio_helper_start"
 
 FILES_${PN} += "/usr/lib/xen/bin/audio_helper \

--- a/recipes-openxt/xctools/compleat_git.bb
+++ b/recipes-openxt/xctools/compleat_git.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xctools.git"
 
 S = "${WORKDIR}/git/compleat"
 

--- a/recipes-openxt/xctools/qmp-helper_git.bb
+++ b/recipes-openxt/xctools/qmp-helper_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "libargo"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xctools.git"
 
 FILES_${PN} += "/usr/lib/xen/bin/qmp_helper"
 FILES_${PN}-dbg += " /usr/lib/xen/bin/.debug "

--- a/recipes-openxt/xctools/xcpmd_git.bb
+++ b/recipes-openxt/xctools/xcpmd_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "dbus xen pciutils libxcdbus libxcxenstore udev libnl yajl"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xctools.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/xctools.git \
 	   file://xcpmd.initscript \
 "
 

--- a/recipes-openxt/xec/xec_git.bb
+++ b/recipes-openxt/xec/xec_git.bb
@@ -14,7 +14,7 @@ RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/manager.git"
 
 S = "${WORKDIR}/git/xec"
 

--- a/recipes-openxt/xenclient-idl/xenclient-idl_git.bb
+++ b/recipes-openxt/xenclient-idl/xenclient-idl_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/idl.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/idl.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/xenclient-input-daemon/xenclient-input-daemon_git.bb
+++ b/recipes-openxt/xenclient-input-daemon/xenclient-input-daemon_git.bb
@@ -8,7 +8,7 @@ RDEPENDS_${PN} += "xenclient-keyboard-list libxcxenstore"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/input.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+SRC_URI = "git://github.com/OpenXT/input.git \
 	   file://input-daemon.initscript \
 "
 

--- a/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
@@ -6,7 +6,7 @@ PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://${OPENXT_GIT_MIRROR}/installer.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+    git://github.com/OpenXT/installer.git \
     file://network.ans \
     file://network_download_win.ans \
     file://network_manual.ans \

--- a/recipes-openxt/xenclient-nwd/xenclient-nwd_git.bb
+++ b/recipes-openxt/xenclient-nwd/xenclient-nwd_git.bb
@@ -16,7 +16,7 @@ DEPENDS = " \
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/network.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/network.git"
 
 S = "${WORKDIR}/git/nwd"
 

--- a/recipes-openxt/xenclient-nws/xenclient-nws_git.bb
+++ b/recipes-openxt/xenclient-nws/xenclient-nws_git.bb
@@ -21,7 +21,7 @@ RDEPENDS_${PN} += " \
 
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/network.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/network.git"
 
 S = "${WORKDIR}/git/nws"
 

--- a/recipes-openxt/xenclient-rpcgen/xenclient-rpcgen.inc
+++ b/recipes-openxt/xenclient-rpcgen/xenclient-rpcgen.inc
@@ -8,7 +8,7 @@ DEPENDS = " \
 "
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/idl.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/idl.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/xenfb2/xenfb2_git.bb
+++ b/recipes-openxt/xenfb2/xenfb2_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Linux Framebuffer PV driver"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM="file://../COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/xenfb2.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/xenfb2.git"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git/linux"

--- a/recipes-openxt/xenmgr-data/xenmgr-data_git.bb
+++ b/recipes-openxt/xenmgr-data/xenmgr-data_git.bb
@@ -20,7 +20,7 @@ DEPENDS = "dojosdk-native"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://${OPENXT_GIT_MIRROR}/toolstack-data.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH}"
+SRC_URI = "git://github.com/OpenXT/toolstack-data.git"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/xenmgr/xenmgr_git.bb
+++ b/recipes-openxt/xenmgr/xenmgr_git.bb
@@ -35,7 +35,7 @@ PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://${OPENXT_GIT_MIRROR}/manager.git;protocol=${OPENXT_GIT_PROTOCOL};branch=${OPENXT_BRANCH} \
+    git://github.com/OpenXT/manager.git \
     file://xenmgr_dbus.conf \
     file://xenstore-init-extra \
     file://xenmgr.initscript \

--- a/recipes-security/acms/acms.bb
+++ b/recipes-security/acms/acms.bb
@@ -19,19 +19,19 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    ${OPENXT_MIRROR}/openxt/GM45_GS45_PM45-SINIT_51.zip;name=gm45 \
-    ${OPENXT_MIRROR}/openxt/Q45_Q43-SINIT_51.zip;name=q45 \
-    ${OPENXT_MIRROR}/openxt/Q35-SINIT_51.zip;name=q35 \
-    ${OPENXT_MIRROR}/openxt/i5_i7_DUAL-SINIT_51.zip;name=i5 \
-    ${OPENXT_MIRROR}/openxt/i7_QUAD-SINIT_51.zip;name=i7 \
-    ${OPENXT_MIRROR}/openxt/Xeon-5600-3500-SINIT-v1.1.zip;name=xeon_5600 \
-    ${OPENXT_MIRROR}/openxt/Xeon-E7-8800-4800-2800-SINIT-v1.1.zip;name=xeon_e7 \
-    ${OPENXT_MIRROR}/openxt/3rd-gen-i5-i7-sinit-67.zip;name=ivb_snb \
-    ${OPENXT_MIRROR}/openxt/4th-gen-i5-i7-sinit-75.zip;name=hsw \
-    ${OPENXT_MIRROR}/openxt/5th_gen_i5_i7-SINIT_79.zip;name=bdw \
-    ${OPENXT_MIRROR}/openxt/6th_gen_i5_i7-SINIT_71.zip;name=skl \
-    ${OPENXT_MIRROR}/openxt/7th_gen_i5_i7-SINIT_74.zip;name=kbl \
-    ${OPENXT_MIRROR}/openxt/8th_gen_i5_i7-SINIT_76.zip;name=cfl \
+    http://mirror.openxt.org/openxt/GM45_GS45_PM45-SINIT_51.zip;name=gm45 \
+    http://mirror.openxt.org/openxt/Q45_Q43-SINIT_51.zip;name=q45 \
+    http://mirror.openxt.org/openxt/Q35-SINIT_51.zip;name=q35 \
+    http://mirror.openxt.org/openxt/i5_i7_DUAL-SINIT_51.zip;name=i5 \
+    http://mirror.openxt.org/openxt/i7_QUAD-SINIT_51.zip;name=i7 \
+    http://mirror.openxt.org/openxt/Xeon-5600-3500-SINIT-v1.1.zip;name=xeon_5600 \
+    http://mirror.openxt.org/openxt/Xeon-E7-8800-4800-2800-SINIT-v1.1.zip;name=xeon_e7 \
+    http://mirror.openxt.org/openxt/3rd-gen-i5-i7-sinit-67.zip;name=ivb_snb \
+    http://mirror.openxt.org/openxt/4th-gen-i5-i7-sinit-75.zip;name=hsw \
+    http://mirror.openxt.org/openxt/5th_gen_i5_i7-SINIT_79.zip;name=bdw \
+    http://mirror.openxt.org/openxt/6th_gen_i5_i7-SINIT_71.zip;name=skl \
+    http://mirror.openxt.org/openxt/7th_gen_i5_i7-SINIT_74.zip;name=kbl \
+    http://mirror.openxt.org/openxt/8th_gen_i5_i7-SINIT_76.zip;name=cfl \
 "
 
 SRC_URI[gm45.md5sum] = "330c774e71fe390d7ab649d5e2b1d504"


### PR DESCRIPTION
Remove SRC_URI legacy customization.
Recipes should point to their upstream repository and it is up to site setup to provide or not local clones.

This PR moves away from using local clones through a (single) variable passed to each recipe and more than likely requires changes to auto-builders.
People interested in setting up a development tree can build from only cloning  the layers.
CI setup might want to find an alternative to build from local clones to test ongoing development, a possibility is to use [`externalsrc.bbclass`](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#ref-classes-externalsrc), e.g: https://github.com/eric-ch/meta-openxt-externalsrc.