### PR TITLE
OXT-1694: ZEUS: qemu-dm: updates following switch to dedicated Linux argo header

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/atapi-pass-through.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/atapi-pass-through.patch
@@ -1073,7 +1073,7 @@ Ross Philipson, <philipsonr@ainfosec.com>, 10/13/2016
 +
 +#define ATAPI_CDROM_PORT 5000
 +#define ARGO_ATAPI_PT_RING_SIZE \
-+  (XEN_ARGO_ROUNDUP((((4096)*64) - sizeof(xen_argo_ring_t)-XEN_ARGO_ROUNDUP(1))))
++  (XEN_ARGO_ROUNDUP((((4096)*64) - ARGO_RING_OVERHEAD)))
 +
 +#define MAX_ARGO_MSG_SIZE (ARGO_ATAPI_PT_RING_SIZE)
 +

--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -7,7 +7,7 @@
 +chardev-obj-$(CONFIG_XEN) += char-argo.o
 --- /dev/null
 +++ b/chardev/char-argo.c
-@@ -0,0 +1,355 @@
+@@ -0,0 +1,356 @@
 +/*
 + * QEMU System Emulator
 + *
@@ -41,6 +41,7 @@
 +#include "chardev/char-io.h"
 +#include "sys/ioctl.h"
 +#include <libargo.h>
++#include <xen/xen.h>
 +#include <sys/param.h>
 +
 +
@@ -56,7 +57,7 @@
 +#define ARGO_QH_PORT 5100
 +#define ARGO_CHARDRV_PORT 15100
 +#define ARGO_CHARDRV_RING_SIZE \
-+  (XEN_ARGO_ROUNDUP((((4096)*4) - sizeof(xen_argo_ring_t)-XEN_ARGO_ROUNDUP(1))))
++  (XEN_ARGO_ROUNDUP((((4096)*4) - ARGO_RING_OVERHEAD)))
 +
 +#define ARGO_CHARDRV_NAME  "[argo-chardrv]"
 +


### PR DESCRIPTION
This change was pushed to master and affected https://github.com/OpenXT/linux-xen-argo.
The recipes have not been switched to track sub-project revisions yet, so `zeus` builds will break.

Given the scope of this change and since OpenXT does not maintain a versioned release in its `zeus` branch at the moment I recommend this change to be cherry-picked in `zeus`.

> xen_argo_ring_t is no longer automatically exposed to userspace via a libargo include, so don't base the ring size calculation on it; use the ARGO_RING_OVERHEAD macro for the calculation.
> char-argo.c now needs its own include of xen.h rather than relying
on transitive inclusion.