### PR TITLE
kernel-module-signing: Add signing key to SSTATE_HASH

### DIFF
--- a/classes/kernel-module-signing.bbclass
+++ b/classes/kernel-module-signing.bbclass
@@ -17,3 +17,9 @@ do_configure_append() {
                ${B}/.config
     fi
 }
+
+def get_signing_key(d):
+    path = d.getVar("KERNEL_MODULE_SIG_CERT") or os.path.join(d.getVar("STAGING_KERNEL_BUILDDIR"),"certs","signing_key.x509")
+    return path + ":" + str(os.path.exists(path))
+
+do_shared_workdir[file-checksums] = "${@get_signing_key(d)}"


### PR DESCRIPTION
The contents of the signing key are important to knowing if sstate can
be re-used.  There have been cases where the modules and kernel keys &
signatures have gotten out of sync.  Ensure the key is added to the
sstate to make modules depend on it.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

I'm put some scripts that I've used in the past to check module signatures here.  They are a little rough, but they do the job:
https://gist.github.com/jandryuk/62f18d802eb705f5ecf4ecd866318f3a