### PR TITLE
zeus: kernel-module-signing: Add signing key to SSTATE_HASH

### DIFF
--- a/classes/kernel-module-signing.bbclass
+++ b/classes/kernel-module-signing.bbclass
@@ -17,3 +17,9 @@ do_configure_append() {
                ${B}/.config
     fi
 }
+
+def get_signing_key(d):
+    path = d.getVar("KERNEL_MODULE_SIG_CERT") or os.path.join(d.getVar("STAGING_KERNEL_BUILDDIR"),"certs","signing_key.x509")
+    return path + ":" + str(os.path.exists(path))
+
+do_shared_workdir[file-checksums] = "${@get_signing_key(d)}"


### PR DESCRIPTION
The contents of the signing key are important to knowing if sstate can
be re-used.  There have been cases where the modules and kernel keys &
signatures have gotten out of sync.  Ensure the key is added to the
sstate to make modules depend on it.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit ffaba32262d9557c6b75f08c8fd553b2cd67fb24)