### PR TITLE
xen: refresh unmap-shared-info context

### DIFF
--- a/recipes-extended/xen/files/unmap-shared-info.patch
+++ b/recipes-extended/xen/files/unmap-shared-info.patch
@@ -50,7 +50,7 @@ PATCHES
   fail:
 --- a/xen/include/xen/sched.h
 +++ b/xen/include/xen/sched.h
-@@ -482,6 +482,10 @@ struct domain
+@@ -493,6 +493,10 @@ struct domain
      unsigned int last_alloc_node;
      spinlock_t node_affinity_lock;
  
@@ -71,7 +71,7 @@ PATCHES
  #include <asm/paging.h>
  #include <asm/shadow.h>
  #include <asm/page.h>
-@@ -4663,6 +4664,9 @@ int xenmem_add_to_physmap_one(
+@@ -4714,6 +4715,9 @@ int xenmem_add_to_physmap_one(
      int rc = 0;
      mfn_t mfn = INVALID_MFN;
      p2m_type_t p2mt;
@@ -81,7 +81,7 @@ PATCHES
  
      if ( !paging_mode_translate(d) )
          return -EACCES;
-@@ -4672,6 +4676,13 @@ int xenmem_add_to_physmap_one(
+@@ -4723,6 +4727,13 @@ int xenmem_add_to_physmap_one(
          case XENMAPSPACE_shared_info:
              if ( idx == 0 )
                  mfn = virt_to_mfn(d->shared_info);
@@ -95,7 +95,7 @@ PATCHES
              break;
          case XENMAPSPACE_grant_table:
              rc = gnttab_map_frame(d, idx, gpfn, &mfn);
-@@ -4701,25 +4712,26 @@ int xenmem_add_to_physmap_one(
+@@ -4752,25 +4763,26 @@ int xenmem_add_to_physmap_one(
              break;
      }
  
@@ -128,7 +128,7 @@ PATCHES
  
      if ( rc )
          goto put_both;
-@@ -4737,13 +4749,28 @@ int xenmem_add_to_physmap_one(
+@@ -4788,7 +4800,7 @@ int xenmem_add_to_physmap_one(
  
      /* Map at new location. */
      if ( !rc )
@@ -136,9 +136,10 @@ PATCHES
 +        rc = guest_physmap_add_page(d, _gfn(gpfn_new), mfn, PAGE_ORDER_4K);
  
   put_both:
-     /* In the XENMAPSPACE_gmfn case, we took a ref of the gfn at the top. */
-     if ( space == XENMAPSPACE_gmfn )
-         put_gfn(d, gfn);
+     /*
+@@ -4806,6 +4818,21 @@ int xenmem_add_to_physmap_one(
+         }
+     }
  
 +    if ( space == XENMAPSPACE_shared_info || unmap_shinfo )
 +    {


### PR DESCRIPTION
Refresh context following upstream change:
b402e2a14b IOMMU: hold page ref until after deferred TLB flush

Build fix.
No functional change.