### PR TITLE
blktap2 blk-mq fixes

### DIFF
--- a/recipes-kernel/linux/5.4/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.4/patches/blktap2.patch
@@ -245,7 +245,7 @@ PATCHES
 +int blktap_device_try_destroy(struct blktap *tap);
 +int blktap_device_pause(struct blktap *);
 +int blktap_device_resume(struct blktap *tap);
-+void blktap_device_run_queue(struct blktap *);
++void blktap_device_run_queues(struct blktap *);
 +void blktap_device_end_request(struct blktap *, struct blktap_request *, blk_status_t);
 +
 +int blktap_page_pool_init(struct kobject *);
@@ -624,7 +624,7 @@ PATCHES
 +MODULE_LICENSE("Dual BSD/GPL");
 --- /dev/null
 +++ b/drivers/block/blktap/device.c
-@@ -0,0 +1,703 @@
+@@ -0,0 +1,713 @@
 +#include <linux/fs.h>
 +#include <linux/blkdev.h>
 +#include <linux/blk-mq.h>
@@ -844,6 +844,16 @@ PATCHES
 +
 +	blk_cleanup_queue(rq);
 +	blk_mq_free_tag_set(&tapdev->tag_set);
++}
++
++void blktap_device_run_queues(struct blktap *tap)
++{
++	struct blktap_device *tapdev = &tap->device;
++
++	if (!tapdev->gd)
++		return;
++
++	blk_mq_start_stopped_hw_queues(tapdev->gd->queue, true);
 +}
 +
 +static void
@@ -1760,7 +1770,7 @@ PATCHES
 +}
 --- /dev/null
 +++ b/drivers/block/blktap/ring.c
-@@ -0,0 +1,807 @@
+@@ -0,0 +1,812 @@
 +
 +#include <linux/device.h>
 +#include <linux/signal.h>
@@ -1854,6 +1864,8 @@ PATCHES
 +	}
 +
 +	ring->ring.rsp_cons = rc;
++
++	blktap_device_run_queues(tap);
 +}
 +
 +#define MMAP_VADDR(_start, _req, _seg)				\
@@ -2381,6 +2393,9 @@ PATCHES
 +
 +	poll_wait(filp, &tap->pool->wait, wait);
 +	poll_wait(filp, &ring->poll_wait, wait);
++
++	if (ring->vma)
++		blktap_device_run_queues(tap);
 +
 +	work = ring->ring.req_prod_pvt - ring->ring.sring->req_prod;
 +	RING_PUSH_REQUESTS(&ring->ring);

--- a/recipes-kernel/linux/5.4/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.4/patches/blktap2.patch
@@ -624,7 +624,7 @@ PATCHES
 +MODULE_LICENSE("Dual BSD/GPL");
 --- /dev/null
 +++ b/drivers/block/blktap/device.c
-@@ -0,0 +1,713 @@
+@@ -0,0 +1,717 @@
 +#include <linux/fs.h>
 +#include <linux/blkdev.h>
 +#include <linux/blk-mq.h>
@@ -1104,11 +1104,15 @@ PATCHES
 +	return err;
 +}
 +
-+static inline void flush_requests(struct blktap_ring *rinfo)
++static inline void flush_requests(struct blktap *tap)
 +{
++	struct blktap_ring *rinfo = &tap->ring;
 +	int notify;
 +
 +	RING_PUSH_REQUESTS_AND_CHECK_NOTIFY(&rinfo->ring, notify);
++
++	if (notify)
++		blktap_ring_kick_user(tap);
 +}
 +
 +static blk_status_t blktap_queue_rq(struct blk_mq_hw_ctx *hctx,
@@ -1136,7 +1140,7 @@ PATCHES
 +	}
 +
 +	if (qd->last)
-+		blktap_ring_kick_user(tap);
++		flush_requests(tap);
 +
 +	spin_unlock_irqrestore(&tapdev->lock, flags);
 +	return BLK_STS_OK;
@@ -1161,7 +1165,7 @@ PATCHES
 +{
 +	struct blktap *tap = hctx->queue->queuedata;
 +
-+	blktap_ring_kick_user(tap);
++	flush_requests(tap);
 +}
 +
 +static const struct blk_mq_ops blktap_mq_ops = {


### PR DESCRIPTION
These two patches address hangs seen with blktap tapdevs.

The first came about because hangs were observed where the tapdisk was sleeping in select(), and mkfs.ext3 was blocked waiting for responses.   /sys/class/blktap2/blktapN/debug showed no pending requests.  Code inspection showed we may have stopped the hardware queues but never restarted them

Then second came about from code inspection.  RING_PUSH_REQUESTS wasn't called before we signaled a wake up via poll.

With both patches IO operations from mkfs.ext3 make better progress and seemingly fairer progress when multiple commands are run in parallel.