### PR TITLE
dom0-tweaks: Correct UEFI kernel consoles

### DIFF
--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/openxt.cfg
@@ -24,12 +24,12 @@ xsm=policy.24
 
 [openxt-support-console]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,pci mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon runlevel=3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 console=tty0 fbcon runlevel=3
 ramdisk=initrd
 xsm=policy.24
 
 [openxt-support-console-amt]
 options=console=com1,vga dom0_mem=min:420M,max:420M,420M efi=rs,attr=uc com1=115200,8n1,amt mbi-video vga=current flask=enforcing loglvl=debug guest_loglvl=debug sync_console smt=0 ucode=-1 bootscrub=1 argo=yes,mac-permissive=1
-kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0,tty0 fbcon runlevel=3
+kernel=bzImage root=/dev/mapper/xenclient-root ro boot=/dev/mapper/xenclient-boot swiotlb=16384 xen_pciback.passthrough=1 consoleblank=0 video.delay_init=1 vt.global_cursor_default=0 rootfstype=ext3 bootfstype=ext3 console=hvc0 console=tty0 fbcon runlevel=3
 ramdisk=initrd
 xsm=policy.24


### PR DESCRIPTION
console=hvc0,tty0 is incorrect.  It should be two separate console
arguments.  This fixes kernel output during a UEFI console boot.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>