### PR TITLE
init.root-ro: Clear framebuffer after unlock

### DIFF
--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -266,6 +266,10 @@ reseal()
     or continue without resealing?" 10 44
 
     [ $? -eq 0 ] && seal "${1}"
+
+    # A successful seal reboots the machine.  If we are continuing, we can
+    # clear the framebuffer.
+    dialog --clear
 }
 
 # Unlock the config partition


### PR DESCRIPTION
Currently, the measured launch failure messages persist in the
framebuffer since nothing clears the framebuffer.  When shutting down,
OpenXT switches back to the framebuffer, you see the old mesage.

Use dialog to clear the screen since the messages are stale.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>