### PR TITLE
Restore allarch after addition of MULTILIB

### DIFF
--- a/classes/multilib-allarch.bbclass
+++ b/classes/multilib-allarch.bbclass
@@ -1,0 +1,6 @@
+# Since we have multilib enabled for xen, regular allarch doesn't take affect
+# and the packages use the default tune.  Setting PACKAGE_ARCH forces allarch
+# like we want.
+PACKAGE_ARCH = "all"
+
+inherit allarch

--- a/recipes-connectivity/networkmanager-certs/networkmanager-certs.bb
+++ b/recipes-connectivity/networkmanager-certs/networkmanager-certs.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     file://populate-certs.sh \
 "
 
-inherit allarch update-rc.d
+inherit multilib-allarch update-rc.d
 
 do_install () {
     install -d ${D}/usr/bin

--- a/recipes-core/initrdscripts/initramfs-stubdomain_1.0.bb
+++ b/recipes-core/initrdscripts/initramfs-stubdomain_1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://init.sh \
 "
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -m 0755 ${WORKDIR}/init.sh ${D}/init

--- a/recipes-core/udev/udev-extraconf-dom0_1.0.bb
+++ b/recipes-core/udev/udev-extraconf-dom0_1.0.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     file://50-usb-powersave.rules \
 "
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -d ${D}${sysconfdir}/udev/rules.d

--- a/recipes-devtools/bats-suite/bats-suite_git.bb
+++ b/recipes-devtools/bats-suite/bats-suite_git.bb
@@ -7,7 +7,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install () {
     if [ -e "${S}/dom0" ]; then

--- a/recipes-devtools/bats/bats_git.bb
+++ b/recipes-devtools/bats/bats_git.bb
@@ -7,7 +7,7 @@ SRCREV = "03608115df2071fff4eaaff1605768c275e5f81f"
 
 S = "${WORKDIR}/git"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install () {
     ${S}/install.sh ${D}/${exec_prefix}

--- a/recipes-extended/rsyslog/rsyslog-conf-dom0.bb
+++ b/recipes-extended/rsyslog/rsyslog-conf-dom0.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "db tools"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM="file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-inherit allarch
+inherit multilib-allarch
 
 SRC_URI = "file://rsyslog.conf"
 

--- a/recipes-kernel/linux-firmware/linux-firmware_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bb
@@ -136,7 +136,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware
 
 S = "${WORKDIR}/git"
 
-inherit allarch update-alternatives
+inherit multilib-allarch update-alternatives
 
 # OE started complaining about the architecture of the binaries for some reason
 INSANE_SKIP = "arch"

--- a/recipes-openxt/argo/argo-module-headers_git.bb
+++ b/recipes-openxt/argo/argo-module-headers_git.bb
@@ -8,7 +8,7 @@ require argo.inc
 
 S = "${WORKDIR}/git/argo-linux"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     oe_runmake INSTALL_HDR_PATH=${D}${prefix} headers_install

--- a/recipes-openxt/idl/xenclient-idl_git.bb
+++ b/recipes-openxt/idl/xenclient-idl_git.bb
@@ -6,7 +6,7 @@ require idl.inc
 
 S = "${WORKDIR}/git"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -m 0755 -d ${D}${idldatadir}

--- a/recipes-openxt/xen-legacy-block-scripts/xen-legacy-block-scripts_1.0.bb
+++ b/recipes-openxt/xen-legacy-block-scripts/xen-legacy-block-scripts_1.0.bb
@@ -10,7 +10,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xen-tap-scripts/xen-tap-scripts_1.0.bb
+++ b/recipes-openxt/xen-tap-scripts/xen-tap-scripts_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xen-vif-scripts/xen-vif-scripts-dom0_1.0.bb
+++ b/recipes-openxt/xen-vif-scripts/xen-vif-scripts-dom0_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm_1.0.bb
+++ b/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
-inherit allarch deploy
+inherit multilib-allarch deploy
 
 do_install () {
     ${S}/install part1 ${D}/install

--- a/recipes-openxt/xenclient-repo-certs/xenclient-repo-certs_1.0.bb
+++ b/recipes-openxt/xenclient-repo-certs/xenclient-repo-certs_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = "file://${REPO_PROD_CACERT} \
 FILES_${PN} = "${datadir}/xenclient/repo-certs \
                ${bindir}/verify-repo-metadata"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     CERTDIR_PROD=${D}${datadir}/xenclient/repo-certs/prod

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig_0.0.2.bb
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig_0.0.2.bb
@@ -31,7 +31,7 @@ SRC_URI = " \
     file://keyboard \
 "
 
-inherit allarch
+inherit multilib-allarch
 
 do_install () {
     install -d ${D}/root/.config/xfce4

--- a/recipes-security/selinux/selinux-load_1.0.bb
+++ b/recipes-security/selinux/selinux-load_1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit allarch
+inherit multilib-allarch
 
 do_install() {
     install -d ${D}/sbin

--- a/recipes-support/lvm2/lvm2-conf-initramfs_1.0.bb
+++ b/recipes-support/lvm2/lvm2-conf-initramfs_1.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://lvm.conf"
 
-inherit allarch
+inherit multilib-allarch
 # The lvm2 recipe in openembedded-core uses multilib_script and MULTILIB_SCRIPTS
 # to handle installation of lvm.conf, and doing so here ensures that the file
 # is packaged in a compatible way.


### PR DESCRIPTION
commit b840fe8eff90 added multilib to the openxt-main distro, but an
unnoticed side effect was that allarch no longer worked.
allarch.bbclass doesn't set PACKAGE_ARCH to "all" when MULTILIB_VARIANTS
is set, so the rest of allarch.bbclass doesn't take effect.

Work around this by manually setting PACKAGE_ARCH="all" and then
inheriting allarch.  There could be a problem if any of these packages
depended on further arch specific packages, but none of ours do.

Wrap it into the small multilib-allarch.bbclass to centralize the
change.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>