### PR TITLE
audio-helper: recipe minor adjustments

### DIFF
--- a/recipes-openxt/xctools/audio-helper_git.bb
+++ b/recipes-openxt/xctools/audio-helper_git.bb
@@ -25,3 +25,5 @@ do_install(){
     install -m 755 ${B}/src/audio_helper ${D}/usr/lib/xen/bin/
     install -m 755 ${WORKDIR}/audio_helper_start ${D}/usr/lib/xen/bin/
 }
+
+RDEPENDS_${PN} += "dbd-tools"

--- a/recipes-openxt/xctools/audio-helper_git.bb
+++ b/recipes-openxt/xctools/audio-helper_git.bb
@@ -1,7 +1,10 @@
 DESCRIPTION = "Audio helper (Add stubdomain audio support)"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
-DEPENDS = " libargo alsa-lib "
+DEPENDS = " \
+    libargo \
+    alsa-lib \
+"
 
 require xctools.inc
 
@@ -9,21 +12,22 @@ SRC_URI += " \
     file://audio_helper_start \
 "
 
-FILES_${PN} += "/usr/lib/xen/bin/audio_helper \
-                /usr/lib/xen/bin/audio_helper_start "
-FILES_${PN}-dbg += " /usr/lib/xen/bin/.debug "
-
 S = "${WORKDIR}/git/audio_helper"
-
-ASNEEDED = ""
 
 inherit autotools
 inherit pkgconfig
 
 do_install(){
-    install -d ${D}/usr/lib/xen/bin
-    install -m 755 ${B}/src/audio_helper ${D}/usr/lib/xen/bin/
-    install -m 755 ${WORKDIR}/audio_helper_start ${D}/usr/lib/xen/bin/
+    install -d "${D}${libdir}/xen/bin"
+    install -m 755 "${B}/src/audio_helper" "${D}${libdir}/xen/bin/audio_helper"
+    install -m 755 "${WORKDIR}/audio_helper_start" "${D}${libdir}/xen/bin/audio_helper_start"
 }
 
+FILES_${PN} += " \
+    ${libdir}/xen/bin/audio_helper \
+    ${libdir}/xen/bin/audio_helper_start \
+"
+FILES_${PN}-dbg += " \
+    ${libdir}/xen/bin/.debug \
+"
 RDEPENDS_${PN} += "dbd-tools"


### PR DESCRIPTION
- Add the missing `RDEPENDS` on `dbd-tools`
- Do not override ASNEEDED as Yocto will take care of it
- Comply with the recommended styleguide.

##### Requires:
- https://github.com/OpenXT/xctools/pull/65
(this is due to `ASNEEDED = ""`, at the configuration step, libdl isn't passed in the `LDFLAGS`, this is handled in the refactored autotools by relying on libargo pkgconfig for the `LDFLAGS`)