### PR TITLE
fc/fstools: fix real path for e2fsprogs

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.fstools.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.fstools.diff
@@ -1,13 +1,21 @@
 --- a/policy/modules/system/fstools.fc
 +++ b/policy/modules/system/fstools.fc
-@@ -54,6 +54,7 @@
- /usr/bin/zpios			--	gen_context(system_u:object_r:fsadm_exec_t,s0)
- /usr/bin/zstreamdump		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
- /usr/bin/ztest			--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+@@ -86,6 +86,7 @@
+ /usr/sbin/make_reiser4		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/mkdosfs		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/mke2fs		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 +/usr/sbin/mke2fs\.e2fsprogs	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
- 
- /usr/sbin/addpart		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
- /usr/sbin/badblocks		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/mke4fs		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/mkfs.*		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/mkraid		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+@@ -107,6 +108,7 @@
+ /usr/sbin/swapoff\.util-linux	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/swapon.*		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/tune2fs		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
++/usr/sbin/tune2fs\.e2fsprogs	--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/zdb			--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/zhack			--	gen_context(system_u:object_r:fsadm_exec_t,s0)
+ /usr/sbin/zinject		--	gen_context(system_u:object_r:fsadm_exec_t,s0)
 --- a/policy/modules/system/fstools.te
 +++ b/policy/modules/system/fstools.te
 @@ -142,6 +142,7 @@ storage_raw_read_removable_device(fsadm_


### PR DESCRIPTION
`/usr/sbin/tune2fs\.e2fsprogs` should be mentioned in fstools.fc to be labelled properly.