### PR TITLE
qemu: small log output improvments 

### DIFF
--- a/recipes-extended/qemu-dm/qemu-dm/nic-link-state-propagation.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/nic-link-state-propagation.patch
@@ -179,7 +179,7 @@ PATCHES
 +    }
 +    xenstore_update_nic(nic);
 +
-+    fprintf(stderr, "Registered xenstore watch for NIC %s", name);
++    fprintf(stderr, "Registered xenstore watch for NIC %s\n", name);
 +
 +    return 0;
 +}

--- a/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/qmp-argo-char-driver.patch
@@ -293,7 +293,7 @@
 +    fd = argo_socket(s->stream ? SOCK_STREAM : SOCK_DGRAM);
 +    if (fd < 0) {
 +        error_setg(errp, "%s cannot create argo socket - err: %d",
-+                   ARGO_CHARDRV_NAME, fd);
++                   ARGO_CHARDRV_NAME, errno);
 +        return;
 +    }
 +


### PR DESCRIPTION
Attend minor log output issues:
- missing CR after reporting a Xenstore watch has been registered
- log `errno` value should `argo_socket` fail instead of the error code.

Split from initial submission: https://github.com/OpenXT/xenclient-oe/pull/1382