### PR TITLE
argo-module-headers: Stub compile/configure for externalsrc

### DIFF
--- a/recipes-openxt/argo/argo-module-headers_git.bb
+++ b/recipes-openxt/argo/argo-module-headers_git.bb
@@ -14,6 +14,12 @@ do_install() {
     oe_runmake INSTALL_HDR_PATH=${D}${prefix} headers_install
 }
 
-# Skip build steps.
-do_compile[noexec] = "1"
-do_configure[noexec] = "1"
+# Skip build steps.  Exec empty functions so externalsrc can find sstate.
+#do_compile[noexec] = "1"
+do_compile() {
+    :
+}
+#do_configure[noexec] = "1"
+do_configure() {
+    :
+}


### PR DESCRIPTION
Using meta-openxt-externalsrc, xen-tools was being rebuilt during each
build.  If you ran bitbake-diffsigs it would complain that here was no
hash for argo-module-header:do_compile and do_configure.  While the
tasks were marked noexec, bitbake wouldn't write an sstate entry and it
would think it needed to re-run the whole dependency chain.

Execing placeholder stubs for do_compile & do_configure let bitbake
generate and find sstate to avoid the issue.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>