### PR TITLE
txt: amend module autoloading in dom0

### DIFF
--- a/conf/machine/xenclient-dom0.conf
+++ b/conf/machine/xenclient-dom0.conf
@@ -20,4 +20,5 @@ KERNEL_MODULE_PROBECONF += " \
 KERNEL_MODULE_AUTOLOAD += " \
     psmouse \
     hid-multitouch \
+    txt \
 "

--- a/conf/machine/xenclient-ndvm.conf
+++ b/conf/machine/xenclient-ndvm.conf
@@ -11,5 +11,3 @@ MACHINE_FEATURES = "ethernet pci ext2 x86"
 APPEND = "root=/dev/xvda2 ro console=hvc0 iommu=soft"
 
 USE_VT = "0"
-
-KERNEL_MODULE_AUTOLOAD += "xen-netback"

--- a/recipes-openxt/txt-info-module/txt-info-module_1.0.bb
+++ b/recipes-openxt/txt-info-module/txt-info-module_1.0.bb
@@ -17,7 +17,7 @@ S = "${WORKDIR}/sources"
 inherit module
 inherit module-signing
 
-KERNEL_MODULE_AUTOLOAD += "txt txt-info"
+KERNEL_MODULE_AUTOLOAD += "txt_info"
 
 RDEPENDS_${PN} += " \
     kernel-module-txt \


### PR DESCRIPTION
157ee22b modules: use KERNEL_MODULE_AUTOLOAD
introduced a regression where txt and txt_info end up not being loaded.

txt being in-tree, add it to the MACHINE configuration.
txt-info should be txt_info.
xen-netback is build-in, remove KERNEL_MODULE_AUTOLOAD.