### PR TITLE
Revert "refpolicy: Silence mount AVC"

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.mount.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.mount.diff
@@ -1,12 +1,11 @@
 --- a/policy/modules/system/mount.te
 +++ b/policy/modules/system/mount.te
-@@ -81,6 +81,14 @@ dev_dontaudit_getattr_memory_dev(mount_t
+@@ -81,6 +81,13 @@ dev_dontaudit_getattr_memory_dev(mount_t
  dev_getattr_sound_dev(mount_t)
  # Early devtmpfs, before udev relabel
  dev_dontaudit_rw_generic_chr_files(mount_t)
 +dev_getattr_generic_blk_files(mount_t)
 +dev_getattr_fs(mount_t)
-+dontaudit mount_t device_t:blk_file read;
 +
 +xen_dontaudit_rw_unix_stream_sockets(mount_t)
 +files_read_mnt_symlinks(mount_t)


### PR DESCRIPTION
If mount is seeing device_t, something is wrong - Print the avc.

After the dunfell uprev, mount may have started failing from this
permission issue when trying to extract the kernel from a partitioned
disk.  This was seen with the usbvm in PV mode.  ndvm may also show it,
but it defaults to HVM.  An xenmgr change should fix this, so drop this
dontaudit.

This reverts commit a76ead77ddbe29abd40637d2aebeddee337e27e8.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

This goes along with https://github.com/OpenXT/manager/pull/183