### PR TITLE
vusb: Fix initscript stop

### DIFF
--- a/recipes-openxt/vusb/files/xenclient-vusb.initscript
+++ b/recipes-openxt/vusb/files/xenclient-vusb.initscript
@@ -32,7 +32,7 @@ start() {
 }
 stop() {
 	echo -n "Stopping vusb_daemon: "
-	while kill `pidof -o %PPID vusb_daemon` 2>/dev/null ; do : ; done
+	pkill vusb-daemon
 	echo "OK"
 }
 


### PR DESCRIPTION
The vusb initscript doesn't actually stop vusb-daemon since the
executable name is vusb-daemon, which pidof won't match with
vusb_daemon.  Fix the name string, but also consolidate on pkill which
combines the equivalent of kill & pidof.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>