### PR TITLE
[networkmanager] Always use existing connection

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager-1.18.4/always-use-existing-connections.patch
+++ b/recipes-connectivity/networkmanager/networkmanager-1.18.4/always-use-existing-connections.patch
@@ -1,0 +1,59 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Always used saved connection profiles. If none exist, let networkmanager create
+default ones.
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+Now that networkmanager actively manages wired/wireless/and brbridged devices+
+connections, if we make changes to these connections and save them to disk (db)
+for future use, due to networkmanager's core logic, it creates new connections
+with the same ID but refuses to attempt to try to match them. This causes
+multiple connections with the same IDs to be shown in the nm-applet.
+
+The keyfile plugin we use to save/parse connection profiles will read and 
+generate connections before NetworkManager runs through its core autogeneration
+logic. This patch removes a flag that is set always set to FALSE during this 
+initialization and lets NetworkManager attempt to match on an existing connection
+profile.
+
+This allows connection setting changes, such as DNS entries or password credentials,
+to persist across ndvm and host platform reboots.
+
+################################################################################
+CHANGELOG
+################################################################################
+Authors:
+Chris Rogers <rogersc@ainfosec.com>
+
+################################################################################
+REMOVAL
+################################################################################
+None
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+None
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+db-nm-settings.patch
+
+################################################################################
+PATCHES
+################################################################################
+--- a/src/nm-manager.c
++++ b/src/nm-manager.c
+@@ -2580,7 +2580,7 @@ get_existing_connection (NMManager *self
+ 		return NULL;
+ 	}
+ 
+-	if (!matched && assume_state_guess_assume) {
++	if (!matched) {
+ 		gs_free NMSettingsConnection **sett_conns = NULL;
+ 		guint len, i, j;
+ 

--- a/recipes-connectivity/networkmanager/networkmanager_1.18.4.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.18.4.bbappend
@@ -11,6 +11,7 @@ SRC_URI += " \
     file://use-dom0-db-for-seen-bssids.patch \
     file://disable-ipv6-config.patch \
     file://fix-network-reenable.patch \
+    file://always-use-existing-connections.patch \
     file://NetworkManager.conf \
     file://nm_sync.sh \
     file://db_to_nm.awk \


### PR DESCRIPTION
  profiles. Networkmanager core logic always generates default
  connection profiles for managed devices. These fail to match
  any on-disk (db) saved connection profiles we may have from
  a previous boot and therefore create duplicate entries,
  ignoring any of the modified settings.

  This patch will allow NM to try to match on existing connection
  profiles during its initialization. This fixes a regression where we
  are unable to save modifications to network settings across
  reboots.

  OXT-1816

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>