### PR TITLE
Shrink dom0 initramfs

### DIFF
--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -25,4 +25,8 @@ IMAGE_INSTALL = " \
 "
 IMAGE_LINGUAS = "en-us"
 
-inherit image
+inherit openxt-image
+
+PACKAGE_REMOVE = " \
+    kernel-image-* \
+"

--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 COMPATIBLE_MACHINE = "(xenclient-dom0)"
 
+IMAGE_FEATURES = ""
 IMAGE_FSTYPES = "cpio.gz"
 IMAGE_INSTALL = " \
     busybox \
@@ -27,6 +28,18 @@ IMAGE_LINGUAS = "en-us"
 
 inherit openxt-image
 
+NO_RECOMMENDATIONS = "1"
+BAD_RECOMMENDATIONS += " \
+    ldconfig \
+    busybox-syslog \
+    busybox-udhcpc \
+"
+
 PACKAGE_REMOVE = " \
     kernel-image-* \
 "
+post_rootfs_shell_commands() {
+    rm -f ${IMAGE_ROOTFS}/sbin/udhcpc;
+    rm -rvf ${IMAGE_ROOTFS}/usr/lib/opkg;
+}
+ROOTFS_POSTPROCESS_COMMAND += " post_rootfs_shell_commands; "

--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -11,7 +11,6 @@ IMAGE_FEATURES = ""
 IMAGE_FSTYPES = "cpio.gz"
 IMAGE_INSTALL = " \
     busybox \
-    lvm2 \
     initramfs-module-functions \
     initramfs-module-lvm \
     initramfs-module-udev \

--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -22,7 +22,6 @@ IMAGE_INSTALL = " \
     kernel-module-tpm \
     kernel-module-tpm-tis \
     kernel-module-tpm-tis-core \
-    module-init-tools \
 "
 IMAGE_LINGUAS = "en-us"
 

--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -21,9 +21,7 @@ IMAGE_INSTALL = " \
     kernel-module-tpm \
     kernel-module-tpm-tis \
     kernel-module-tpm-tis-core \
-    module-init-tools-depmod \
     module-init-tools \
-    policycoreutils-setfiles \
 "
 IMAGE_LINGUAS = "en-us"
 

--- a/recipes-core/images/xenclient-initramfs-image.bb
+++ b/recipes-core/images/xenclient-initramfs-image.bb
@@ -11,9 +11,6 @@ IMAGE_FSTYPES = "cpio.gz"
 IMAGE_INSTALL = " \
     busybox \
     lvm2 \
-    tpm-tools-sa \
-    tpm2-tss \
-    tpm2-tools \
     initramfs-module-functions \
     initramfs-module-lvm \
     initramfs-module-udev \

--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -57,7 +57,7 @@ RDEPENDS_initramfs-module-tpm = "${PN}-base initramfs-module-bootfs tpm-tools-sa
 FILES_initramfs-module-tpm = "/init.d/92-tpm"
 
 SUMMARY_initramfs-module-tpm2 = "initramfs support for tpm2"
-RDEPENDS_initramfs-module-tpm2 = "${PN}-base initramfs-module-bootfs tpm2-tools"
+RDEPENDS_initramfs-module-tpm2 = "${PN}-base initramfs-module-bootfs tpm2-tools-initrd"
 FILES_initramfs-module-tpm2 = "/init.d/92-tpm2"
 
 SUMMARY_initramfs-module-selinux = "initramfs support for selinux"

--- a/recipes-openxt/trousers/trousers_0.3.14.bb
+++ b/recipes-openxt/trousers/trousers_0.3.14.bb
@@ -66,6 +66,7 @@ do_install_append() {
 PACKAGES =+ " \
     ${PN}-data \
     ${PN}-conf \
+    libtspi-sa \
 "
 FILES_${PN} += " \
     /boot/system/tpm \
@@ -79,6 +80,9 @@ FILES_${PN}-conf = " \
 "
 CONFFILES_${PN}-conf = " \
     ${sysconfdir}/tcsd.conf \
+"
+FILES_libtspi-sa = " \
+    ${libdir}/libtspi_sa${SOLIBS} \
 "
 
 RRECOMMENDS_${PN}_append += "${PN}-conf"

--- a/recipes-security/tpm-tools/files/tpm-tools-quote-standalone.patch
+++ b/recipes-security/tpm-tools/files/tpm-tools-quote-standalone.patch
@@ -1,8 +1,6 @@
-Index: tpm-tools-1.3.1/lib/tpm_tspi_sa.c
-===================================================================
---- tpm-tools-1.3.1.orig/lib/tpm_tspi_sa.c	2010-08-01 18:25:43.000000000 +0000
-+++ tpm-tools-1.3.1/lib/tpm_tspi_sa.c	2010-08-01 18:26:10.000000000 +0000
-@@ -620,6 +620,63 @@
+--- a/lib/tpm_tspi_sa.c
++++ b/lib/tpm_tspi_sa.c
+@@ -620,6 +620,63 @@ tpmPcrExtend(TSS_HTPM a_hTpm, UINT32 a_I
  	return result;
  }
  
@@ -66,10 +64,8 @@ Index: tpm-tools-1.3.1/lib/tpm_tspi_sa.c
  #ifdef TSS_LIB_IS_12
  /*
   * These getPasswd functions will wrap calls to the other functions and check to see if the TSS
-Index: tpm-tools-1.3.1/src/sa/Makefile.am
-===================================================================
---- tpm-tools-1.3.1.orig/src/sa/Makefile.am	2010-08-01 18:25:06.000000000 +0000
-+++ tpm-tools-1.3.1/src/sa/Makefile.am	2010-08-01 18:25:32.000000000 +0000
+--- a/src/sa/Makefile.am
++++ b/src/sa/Makefile.am
 @@ -21,7 +21,7 @@
  #       http://www.opensource.org/licenses/cpl1.0.php.
  #
@@ -79,8 +75,8 @@ Index: tpm-tools-1.3.1/src/sa/Makefile.am
  
  if TSS_LIB_IS_12
  AM_CPPFLAGS	=	-I$(top_builddir)/include -D_LINUX -DTSS_LIB_IS_12 -DTSS_LIB_SA
-@@ -35,3 +35,4 @@
+@@ -35,3 +35,4 @@ tpm_sealdata_sa_SOURCES = ../cmds/tpm_se
  tpm_unsealdata_sa_SOURCES = ../cmds/tpm_unsealdata.c
- tpm_unsealdata_sa_LDADD = $(LDADD) $(top_builddir)/lib/libtpm_unseal.la
+ tpm_unsealdata_sa_LDADD = $(LDADD) $(top_builddir)/lib/libtpm_unseal_sa.la
  tpm_extendpcr_sa_SOURCES = ../cmds/tpm_extendpcr.c
 +tpm_quote_sa_SOURCES = ../cmds/tpm_quote.c

--- a/recipes-security/tpm-tools/files/tpm-tools-standalone.patch
+++ b/recipes-security/tpm-tools/files/tpm-tools-standalone.patch
@@ -10,15 +10,18 @@
  		man/Makefile            \
 --- a/lib/Makefile.am
 +++ b/lib/Makefile.am
-@@ -26,6 +26,7 @@ localedir		=	$(datadir)/locale
+@@ -24,8 +24,10 @@
+ localedir		=	$(datadir)/locale
+ 
  # Libraries to build
  lib_LTLIBRARIES		= 	libtpm_unseal.la 
  noinst_LTLIBRARIES	=	libtpm_tspi.la	\
 +				libtpm_tspi_sa.la \
++				libtpm_unseal_sa.la \
  				libtpm_utils.la
  
  #
-@@ -47,6 +48,11 @@ libtpm_tspi_la_SOURCES	=	tpm_tspi.c
+@@ -47,6 +49,11 @@ libtpm_tspi_la_SOURCES	=	tpm_tspi.c
  libtpm_tspi_la_LIBADD	=	libtpm_utils.la -ldl @INTLLIBS@
  
  #
@@ -30,6 +33,13 @@
  # PKCS#11 interface library
  if P11_SUPPORT
  noinst_LTLIBRARIES	+=	libtpm_pkcs11.la
+@@ -81,3 +88,6 @@ endif
+ libtpm_unseal_la_SOURCES =	tpm_unseal.c
+ libtpm_unseal_la_LDFLAGS =	-shared -version-info 1:0:0
+ libtpm_unseal_la_LIBADD  =	-ltspi  libtpm_tspi.la @INTLLIBS@
++
++libtpm_unseal_sa_la_SOURCES =   tpm_unseal.c
++libtpm_unseal_sa_la_LIBADD  =   libtpm_tspi_sa.la
 --- /dev/null
 +++ b/lib/tpm_tspi_sa.c
 @@ -0,0 +1,678 @@
@@ -749,7 +759,7 @@
 +
 +tpm_sealdata_sa_SOURCES = ../cmds/tpm_sealdata.c
 +tpm_unsealdata_sa_SOURCES = ../cmds/tpm_unsealdata.c
-+tpm_unsealdata_sa_LDADD = $(LDADD) $(top_builddir)/lib/libtpm_unseal.la
++tpm_unsealdata_sa_LDADD = $(LDADD) $(top_builddir)/lib/libtpm_unseal_sa.la
 +tpm_extendpcr_sa_SOURCES = ../cmds/tpm_extendpcr.c
 --- a/src/Makefile.am
 +++ b/src/Makefile.am

--- a/recipes-security/tss2/tpm2-tools_3.1.3.bb
+++ b/recipes-security/tss2/tpm2-tools_3.1.3.bb
@@ -17,3 +17,10 @@ SRC_URI = "git://github.com/01org/tpm2-tools.git;protocol=git;branch=3.X \
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
+
+PACKAGES =+ "tpm2-tools-initrd"
+FILES_${PN}-initrd = " \
+    ${bindir}/tpm2_pcrlist \
+    ${bindir}/tpm2_extendpcr \
+"
+RDEPENDS_${PN} += "${PN}-initrd"


### PR DESCRIPTION
This series shrinks the compressed initramfs.gz size from 25MB to 11MB.