### PR TITLE
[networkmanager] Clear user permissions

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager-1.18.4/clear-permissions-on-connection-profiles.patch
+++ b/recipes-connectivity/networkmanager/networkmanager-1.18.4/clear-permissions-on-connection-profiles.patch
@@ -1,0 +1,72 @@
+################################################################################
+SHORT DESCRIPTION:
+################################################################################
+Remove any permission entries from a connection before persisting it to disk
+
+################################################################################
+LONG DESCRIPTION:
+################################################################################
+When a wireless connection has permissions associated with it, networkmanager
+will bail out of its autoconnection operation, even if autoconnect is TRUE and
+the wireless connection profile has access point credentials saved.
+
+The ndvm only has one user and is run headless, so there's no reason to define
+permissions for a given connection with the root user. When we persist the
+connection profile to disk in the keyfile plugin, prune out any permissions
+that networkmanager may have assigned to the connection. On the subsequent boot,
+networkmanager will automatically connect to the access point saved in the
+connection profile without the user needing to manually select it.
+
+################################################################################
+CHANGELOG
+################################################################################
+Authors:
+Chris Rogers <rogersc@ainfosec.com>
+
+################################################################################
+REMOVAL
+################################################################################
+None
+
+################################################################################
+UPSTREAM PLAN
+################################################################################
+None
+
+################################################################################
+INTERNAL DEPENDENCIES
+################################################################################
+
+################################################################################
+PATCHES
+################################################################################
+
+--- a/src/nm-manager.c
+--- a/src/settings/plugins/keyfile/nms-keyfile-writer.c
++++ b/src/nm-manager.c
++++ b/src/settings/plugins/keyfile/nms-keyfile-writer.c
+@@ -359,12 +359,24 @@ nms_keyfile_writer_connection (NMConnect
+                                GError **error)
+ {
+ 	const char *keyfile_dir;
++	NMSettingConnection *s_con;
++	int num_perms = 0;
+ 
+ 	if (save_to_disk)
+ 		keyfile_dir = nms_keyfile_utils_get_path ();
+ 	else
+ 		keyfile_dir = NM_KEYFILE_PATH_NAME_RUN;
+ 
++	/* We don't support storing permissions on connections as this
++	 * prevents wireless connections from autoconnecting. Remove them.
++	 */
++	s_con = nm_connection_get_setting_connection(connection);
++	num_perms = nm_setting_connection_get_num_permissions(s_con);
++	if (num_perms > 0) {
++		for (int i = 0; i < num_perms; i++)
++			nm_setting_connection_remove_permission(s_con, i);
++	}
++
+ 	return _internal_write_connection (connection,
+ 	                                   keyfile_dir,
+ 	                                   nms_keyfile_utils_get_path (),

--- a/recipes-connectivity/networkmanager/networkmanager_1.18.4.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.18.4.bbappend
@@ -11,6 +11,7 @@ SRC_URI += " \
     file://use-dom0-db-for-seen-bssids.patch \
     file://disable-ipv6-config.patch \
     file://fix-network-reenable.patch \
+    file://clear-permissions-on-connection-profiles.patch \
     file://NetworkManager.conf \
     file://nm_sync.sh \
     file://db_to_nm.awk \


### PR DESCRIPTION
  from connection profile before persisting it to disk. This allows
  networkmanager to automatically connect a wireless connection based
  on the SSID and credentials stored in a saved connection profile.
  The ndvm only has one user and is run headless so assigning user
  permissions to a connection profile is pointless, in addition to
  causing this regression.

  OXT-1817

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>