### PR TITLE
[networkmanager] Prune 'permissions' node

### DIFF
--- a/recipes-connectivity/networkmanager/files/db_to_nm.awk
+++ b/recipes-connectivity/networkmanager/files/db_to_nm.awk
@@ -8,6 +8,10 @@ BEGIN {
     print "[" group "]";
 }
 
+/^  permissions = .+$/ {
+    continue
+}
+
 /^  [a-zA-Z0-9-]+ = .+$/ {
     equals=index($0, "=");
     key=substr($0, 1, equals - 1)

--- a/recipes-connectivity/networkmanager/files/nm_to_db.awk
+++ b/recipes-connectivity/networkmanager/files/nm_to_db.awk
@@ -20,6 +20,9 @@ BEGIN {
     gsub(/'/, "'\\''", key);
     gsub(/'/, "'\\''", value);
 
+    if (key == "permissions" && group == "connection")
+        continue
+
     system("db-write-dom0 '/" node "/" file "/" group "/" key "' '" value "'");
 }
 


### PR DESCRIPTION
  when writing or reading a connection profile from the db.

  According to networkmanager:
  "When [permissions] is not empty, the connection can be active
  only when one of the specified users is logged into an active session."

  This commit ensures that wireless connections will automatically connect
  to the SSID that is stored in the connection profile by keeping
  'permissions' empty.

  OXT-1817

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>