### PR TITLE
linux: usbback: Fix memory leak

### DIFF
--- a/recipes-kernel/linux/5.4/patches/usbback-base.patch
+++ b/recipes-kernel/linux/5.4/patches/usbback-base.patch
@@ -1308,7 +1308,7 @@ PATCHES
 +}
 --- /dev/null
 +++ b/drivers/usb/xen-usbback/usbback.c
-@@ -0,0 +1,1295 @@
+@@ -0,0 +1,1297 @@
 +/******************************************************************************
 + *
 + * Back-end of the driver for virtual block devices. This portion of the
@@ -1719,6 +1719,8 @@ PATCHES
 +
 +	ret = gnttab_unmap_refs(unmap, NULL, pages, invcount);
 +	BUG_ON(ret);
++
++	kfree(pages);
 +}
 +
 +/*


### PR DESCRIPTION
commit 50d475269b3f "linux: make usbback run in an HVM backend" added a
memory allocation to fast_flush_area, but failed to free it leaking
memory.  Add the corresponding kfree to plug the leak.