### PR TITLE
layer: run sign_module in fakeroot

### DIFF
--- a/classes/module-signing.bbclass
+++ b/classes/module-signing.bbclass
@@ -20,7 +20,7 @@ export KERNEL_MODULE_SIG_CERT
 # Kernel builds will override this with ${B}/scripts/sign-file
 SIGN_FILE = "${STAGING_KERNEL_BUILDDIR}/scripts/sign-file"
 
-do_sign_modules() {
+fakeroot do_sign_modules() {
     if [ -n "${KERNEL_MODULE_SIG_KEY}" ] &&
        grep -q '^CONFIG_MODULE_SIG=y' ${STAGING_KERNEL_BUILDDIR}/.config; then
         SIG_HASH=$( grep CONFIG_MODULE_SIG_HASH= \


### PR DESCRIPTION
do_sign_module will change a module file inode, which in turn can trigger Pseudo to fail in linux-openxt:do_package.

Pseudo log will look like the following on .ko binaries:
Setup complete, sending SIGUSR1 to pid 1271422.
creat for '.../build-0/tmp-glibc/work/xenclient_dom0-oe-linux/linux-openxt/5.4.106-r0/image/lib/modules/5.4.106/kernel/lib/stPopED2'
replaces existing 64496726 ['.../build-0/tmp-glibc/work/xenclient_dom0-oe-linux/linux-openxt/5.4.106-r0/image/lib/modules/5.4.106/kernel/lib/crc-ccitt.ko'].
inode mismatch: '.../build-0/tmp-glibc/work/xenclient_dom0-oe-linux/linux-openxt/5.4.106-r0/image/lib/modules/5.4.106/kernel/arch/x86/crypto/aesni-intel.ko' ino 63584941 in db, 63585005 in request.

Explicitely sign the modules in the fakeroot environment to avoid corrupting the pseudo-db.