### PR TITLE
Introduce KERNEL_MODULE_OFFLINE_SIGNING

### DIFF
--- a/classes/image-qa-module-sigs.bbclass
+++ b/classes/image-qa-module-sigs.bbclass
@@ -1,4 +1,9 @@
 do_image_qa_module_sigs() {
+	if [ "${KERNEL_MODULE_OFFLINE_SIGNING}" = "1" ]; then
+		bbnote "KERNEL_MODULE_OFFLINE_SIGNING == 1: skipping module signature verification"
+		return
+	fi
+
 	local bzImage="${IMAGE_ROOTFS}/boot/bzImage"
 	if [ ! -f "$bzImage" ]; then
 		bzImage="${DEPLOY_DIR_IMAGE}/bzImage"


### PR DESCRIPTION
This came about because reviewing PRs https://github.com/OpenXT/xenclient-oe/pull/1395 and https://github.com/OpenXT/xenclient-oe/pull/1401 illustrated the fragility of the offline signing support.

Introduce KERNEL_MODULE_OFFLINE_SIGNING to force the user to make an
explicit choice to perform offline signing.  Silently creating
un-bootable images isn't user friendly.  This variable forces them to
make the choice.

Add various checks for invalid configurations to enforce using the
variable.