### PR TITLE
RFC: rpc-autogen: module for haskell bindings

### DIFF
--- a/recipes-openxt/dbus-gen-bindings/rpc-autogen_0.1.0.0.bb
+++ b/recipes-openxt/dbus-gen-bindings/rpc-autogen_0.1.0.0.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Generated Haskell DBus bindings used by OpenXT components."
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+SECTION = "devel"
+
+DEPENDS = " \
+    libxch-rpc \
+"
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "git://github.com/eric-ch/dbus-gen-bindings.git;protocol=https;branch=master"
+
+S = "${WORKDIR}/git/haskell"
+
+inherit haskell

--- a/recipes-openxt/manager/rpc-proxy_git.bb
+++ b/recipes-openxt/manager/rpc-proxy_git.bb
@@ -22,6 +22,7 @@ DEPENDS += " \
     hkg-lifted-base \
     hkg-monad-control \
     hkg-errors \
+    rpc-autogen \
 "
 RDEPENDS_${PN} += "glibc-gconv-utf-32 bash"
 
@@ -36,19 +37,10 @@ S = "${WORKDIR}/git/rpc-proxy"
 
 HPV = "1.0"
 require recipes-openxt/xclibs/xclibs-haskell.inc
-inherit update-rc.d haskell xc-rpcgen
+inherit update-rc.d haskell
 
 INITSCRIPT_NAME = "rpc-proxy"
 INITSCRIPT_PARAMS = "defaults 30"
-
-# ToDo: move xc-rpcgen into compile?
-
-do_configure_append() {
-	# generate rpc stubs
-	mkdir -p Rpc/Autogen
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -s -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/rpc_proxy.xml
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/dbus.xml
-}
 
 do_install_append() {
 	install -m 0755 -d ${D}/etc

--- a/recipes-openxt/manager/updatemgr_git.bb
+++ b/recipes-openxt/manager/updatemgr_git.bb
@@ -23,6 +23,7 @@ DEPENDS = " \
     hkg-monad-control \
     hkg-transformers-base \
     hkg-monad-loops \
+    rpc-autogen \
 "
 RDEPENDS_${PN} += " \
     glibc-gconv-utf-32 \
@@ -37,23 +38,11 @@ SRC_URI += " \
 
 S = "${WORKDIR}/git/updatemgr"
 
-inherit update-rc.d haskell xc-rpcgen
+inherit update-rc.d haskell
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME_${PN} = "updatemgr"
 INITSCRIPT_PARAMS_${PN} = "defaults 80"
-
-do_configure_append() {
-	# generate rpc stubs
-	mkdir -p ${S}/Rpc/Autogen
-	# Server objects
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -s -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/updatemgr.xml
-	# Client objects
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/db.xml
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/xenmgr.xml
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/xenmgr_vm.xml
-	xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/xenmgr_host.xml
-}
 
 do_install_append() {
 	install -m 0755 -d ${D}${sysconfdir}/init.d

--- a/recipes-openxt/manager/xenmgr_git.bb
+++ b/recipes-openxt/manager/xenmgr_git.bb
@@ -22,6 +22,7 @@ DEPENDS = " \
     hkg-mtl \
     hkg-split \
     xenmgr-data \
+    rpc-autogen \
 "
 
 require manager.inc
@@ -34,25 +35,7 @@ SRC_URI += " \
 
 S = "${WORKDIR}/git/xenmgr"
 
-inherit haskell update-rc.d xc-rpcgen
-
-do_configure_append() {
-    # generate rpc stubs
-    mkdir -p Rpc/Autogen
-    # Server objects
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -s -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/xenmgr.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -s -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/xenmgr_vm.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -s -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/xenmgr_host.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -s -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/vm_nic.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -s -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/vm_disk.xml"
-
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/input_daemon.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -c -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/guest.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -c -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/dbus.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -c -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/network_daemon.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -c -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/network.xml"
-    xc-rpcgen --haskell --templates-dir="${STAGING_RPCGENDATADIR_NATIVE}" -c -o "Rpc/Autogen" --module-prefix="Rpc.Autogen" "${STAGING_IDLDATADIR}/ctxusb_daemon.xml"
-}
+inherit haskell update-rc.d
 
 do_install_append() {
     install -m 0755 ${S}/setup-ica-vm ${D}${bindir}/setup-ica-vm

--- a/recipes-openxt/network/xenclient-nwd_git.bb
+++ b/recipes-openxt/network/xenclient-nwd_git.bb
@@ -12,40 +12,20 @@ DEPENDS = " \
     hkg-network \
     libxchdb \
     libxchxenstore \
+    rpc-autogen \
 "
 
 require network.inc
 
 S = "${WORKDIR}/git/nwd"
 
-inherit haskell update-rc.d xc-rpcgen
+inherit haskell update-rc.d
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME_${PN} = "network-daemon"
 INITSCRIPT_PARAMS_${PN} = "defaults 28 15"
 
 FILES_${PN} += "/usr/bin/network-daemon"
-
-do_configure_append() {
-    # generate rpc stubs
-    mkdir -p ${S}/Rpc/Autogen
-
-    # Server objects
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_daemon.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_domain.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_nm.xml
-
-    # Client objects
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_slave.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_nm.xml
-
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/dbus.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/xenmgr.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/xenmgr_vm.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/vm_nic.xml
-}
 
 do_install_append() {
     install -m 0755 -d ${D}${sysconfdir}/init.d

--- a/recipes-openxt/network/xenclient-nws_git.bb
+++ b/recipes-openxt/network/xenclient-nws_git.bb
@@ -13,6 +13,7 @@ DEPENDS = " \
     hkg-text \
     hkg-mtl \
     hkg-network \
+    rpc-autogen \
 "
 RDEPENDS_${PN} += " \
     glibc-gconv-utf-32 \
@@ -23,34 +24,13 @@ require network.inc
 
 S = "${WORKDIR}/git/nws"
 
-inherit haskell update-rc.d xc-rpcgen
+inherit haskell update-rc.d
 
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME_${PN} = "network-slave"
 INITSCRIPT_PARAMS_${PN} = "defaults 29 15"
 
 FILES_${PN} += "/usr/bin/network-slave"
-
-do_configure_append() {
-    # generate rpc stubs
-    mkdir -p ${S}/Rpc/Autogen
-
-    # Server objects
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_slave.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network.xml
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --server -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/network_nm.xml
-
-    # NetworkManager objects (stored in the network-manager specific directory)
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.xml -n NmManager
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.Device.xml -n NmDevice
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.Device.Wired.xml -n NmDeviceEthernet
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.Device.Wireless.xml -n NmDeviceWifi
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.Device.Modem.xml -n NmDeviceModem
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.AccessPoint.xml -n NmAccessPoint
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --client -o ${S}/Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_NMIDLDATADIR}/org.freedesktop.NetworkManager.Connection.Active.xml -n NmActiveConnection
-
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/dbus.xml
-}
 
 do_install_append() {
     install -m 0755 -d ${D}${sysconfdir}/network-daemon

--- a/recipes-openxt/xclibs/libxchdb_git.bb
+++ b/recipes-openxt/xclibs/libxchdb_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "helps accessing db daemon"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://../COPYING;md5=321bf41f280cf805086dd5a720b37785"
-DEPENDS += "libxch-rpc xenclient-rpcgen-native xenclient-idl hkg-mtl hkg-text hkg-json libxchutils"
+DEPENDS += "libxch-rpc xenclient-rpcgen-native xenclient-idl hkg-mtl hkg-text hkg-json libxchutils rpc-autogen"
 RDEPENDS_${PN} += "glibc-gconv-utf-32"
 
 require xclibs.inc
@@ -12,9 +12,3 @@ HPN = "xchdb"
 HPV = "0.1"
 
 require xclibs-haskell.inc
-inherit xc-rpcgen
-
-do_configure_append() {
-    mkdir -p Rpc/Autogen
-    xc-rpcgen --haskell --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} -c -o Rpc/Autogen --module-prefix=Rpc.Autogen ${STAGING_IDLDATADIR}/db.xml
-}


### PR DESCRIPTION
Provide generated Haskell bindings as a [cabal module](https://github.com/eric-ch/dbus-gen-bindings). The bindings were generated and versioned using [dbus-gen](https://github.com/eric-ch/dbus-gen/tree/haskell-bindings), then are provided by the rpc-autogen recipe.

This makes it easier to track changes across versions and avoid depending on generated sources in-tree for the haskell components.

The goal of this is to provide a reasonably easy to modify alternative to [rpcgen](https://github.com/OpenXT/idl/tree/master/rpcgen) that could still, with low efforts, target different languages.

To avoid changes in existing Haskell projects the module names have been preserved. Changes to the cabal configuration is still necessary though. The GHC 6 dependent projects being the main consumer of the generated bindings, these were targeted first. As, given the age of the runtime, they are the most likely to become a target for replacement.

In this current implementation, only haskell bindings are generated by dbus-gen, the other generated bindings (for OCaml, C and JavaScript) still rely on [rpcgen](https://github.com/OpenXT/idl/tree/master/rpcgen).

#### Dependencies:

- https://github.com/OpenXT/xclibs/pull/12
- https://github.com/OpenXT/manager/pull/184
- https://github.com/OpenXT/network/pull/21

#### External dependencies:

- rpc-autogen: https://github.com/eric-ch/dbus-gen-bindings
- dbus-gen: https://github.com/eric-ch/dbus-gen/tree/haskell-bindings