### PR TITLE
image-qa-module-sigs: Remove bashism

### DIFF
--- a/classes/image-qa-module-sigs.bbclass
+++ b/classes/image-qa-module-sigs.bbclass
@@ -86,13 +86,12 @@ check_module() {
 	"$scriptdir/extract-module-sig.pl" -0 "$mod" > "$data" 2>/dev/null
 
 	# needed to get smime failure and not sed's exit status
-	set -o pipefail
 	# Verify
-	openssl smime -verify -binary -inform DER -in "$sigdata" \
+	output=$( openssl smime -verify -binary -inform DER -in "$sigdata" \
 		-content "$data" -certfile "$keyring" -nointern -noverify \
-		-out /dev/null 2>&1 >/dev/null | \
-			sed -n '/Verification successful/!p'
+		-out /dev/null 2>&1 >/dev/null )
 	ret=$?
+	echo "$output" | sed -n '/Verification successful/!p'
 
 	rm "$data"
 	rm "$sigdata"


### PR DESCRIPTION
set -o pipefail is a bashism and fails when the system shell is dash.

Replace the pipefail with a 2-step implementation to catch the openssl
smime verify exit code, and then process the output.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>