### PR TITLE
refpolicy: Fix /run/ifstate labeling

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.init.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.system.init.diff
@@ -133,7 +133,7 @@
 +files_create_pid_dirs(initrc_t)
 +files_manage_all_locks(initrc_t)
 +files_manage_var_dirs(initrc_t)
-+files_create_etc_runtime(initrc_t, "ifstate")
++files_create_etc_runtime(initrc_t, "ifstate.new")
 +
 +optional_policy(`
 +	hal_setattr_cache_dirs(initrc_t)


### PR DESCRIPTION
/run/ifstate is no longer labeled properly after the dunfell uprev.
Busybox changed from directly modifying /run/ifstate, to creating
/run/ifstate.new and then renaming.

Update for the new filename to get the desired etc_runtime_t label.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>