### PR TITLE
tpm-scripts: fix tpm_get_pcr grep format

### DIFF
--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -25,8 +25,9 @@ contains_only() {
     local s="$1"
     local c="$2"
 
-    # Remove all instances of c from s and check if the result is empty
-    [[ -z "${s//$c}" ]]
+    # Check if s is empty then remove all instances of c from s and check if
+    # the result is empty.
+    [[ -n "$s" ]] && [[ -z "${s//$c}" ]]
 }
 
 usage() {

--- a/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
+++ b/recipes-openxt/xenclient-tpm-scripts/xenclient-tpm-scripts/tpm-functions
@@ -762,7 +762,7 @@ tpm_get_pcr() {
     if is_tpm_2_0; then
         tpm_pcr_value_normalize "$(tpm2_pcrlist -L ${hashalg}:${pcr})"
     else
-        tpm_pcr_value_normalize "$(grep PCR-${pcr} "$(tpm_get_syspath)/device/pcrs")"
+        tpm_pcr_value_normalize "$(grep "$(printf "PCR-%02d" "$pcr")" "$(tpm_get_syspath)/device/pcrs")"
     fi
 }
 


### PR DESCRIPTION
For TPM1.2, /sys/class/tpm/tpm0/pcrs is [formatted with](https://elixir.bootlin.com/linux/v5.4.131/source/drivers/char/tpm/tpm-sysfs.c#L118): 'PCR-%02d: %02X %02X...'
The use of grep does not account for the 0 padding for PCRs below 10, which breaks forward seal on UEFI/TPM1.2 systems. The bug is mostly silent (apart from failing to unseal after upgrading/forward-sealing):
- tpm_get_pcr returns an empty string for PCR 8
- `! contains_only "$pcr8" "0"` is used to detect a UEFI measured   installation. `contains_only` will return true for   an empty-string given for the PCR value, for any character value.
- In turn, `seal-system` calls `calculate_drtm_pcr` for legacy installations, using `/boot/system/grub/grub.cfg` and setting SRTM to 0.

This leads to PCR18 and PCR19 not being predicted correctly, but predicted nonetheless while no error is apparently raised when performing the upgrade/forward-seal.
