### PR TITLE
xenmgr: regression on cmdline argument autostart

### DIFF
--- a/recipes-openxt/manager/xenmgr/xenmgr.initscript
+++ b/recipes-openxt/manager/xenmgr/xenmgr.initscript
@@ -29,7 +29,7 @@
 DESC="XenMgr"
 EXEC="/usr/bin/xenmgr"
 PIDFILE="/var/run/xenmgr.pid"
-OPTS=("--writepid=$PIDFILE" "--no-daemonize")
+OPTS=("--writepid=$PIDFILE" "--no-daemonize" "--no-autostart")
 
 . /etc/init.d/functions-selinux
 . /etc/init.d/functions-dbus
@@ -41,9 +41,9 @@ cmdline_options() {
     read -r -a cmdline_opts < /proc/cmdline
     for i in "${cmdline_opts[@]}"; do
         case "$i" in
-            no-autostart)
-                OPTS+=("--no-autostart")
-                echo "$DESC not starting VMs automatically."
+            autostart)
+                OPTS=("${OPTS[@]//--no-autostart/}")
+                echo "$DESC will start VMs automatically."
                 ;;
             rm_uivm_suspend_img)
                 rm -f /storage/uivm/uivm-suspend-image


### PR DESCRIPTION
Xenmgr can be configured to not autostart VMs at startup, this used to be handled by the initscript by checking "autostart" on the kernel cmdline.
Commit: ae940b14 xenmgr: cleanup initscript introduced a regression on a knee-jerk change from "autostart" to "no-autostart" being checked on the command line, yet the configuration files used at bootstrap were not changed.

This is in any case a regression that would affect any customised openxt.cfg or grub.cfg, making it not worth it.

Restore the original behavior: normal operation boot entries add "autostart" to the kernel cmdline, "no-autostart" is the default.

Regression introduced by: https://github.com/OpenXT/xenclient-oe/pull/1410 (https://github.com/OpenXT/xenclient-oe/pull/1410#discussion_r670423609)