### PR TITLE
initscripts: fix dbus wait helpers

### DIFF
--- a/recipes-core/initscripts/initscripts-1.0/functions-dbus
+++ b/recipes-core/initscripts/initscripts-1.0/functions-dbus
@@ -13,11 +13,12 @@ dbus_name_has_owner () {
     dbus-send --system --type=method_call --print-reply \
         --dest=org.freedesktop.DBus /org/freedesktop/DBus \
         org.freedesktop.DBus.NameHasOwner \
-        string:"$name" >/dev/null 2>&1
+        string:"$name" | grep -q '^\s\+boolean\s\+true' >/dev/null 2>&1
 }
 
 # Usage: dbus_name_has_owner NAME [TIMEOUT]
-# Returns an error code if the service has not appeared on DBus when timeout expires, success otherwise.
+# Returns an error code if the service has not appeared on DBus when timeout in
+# seconds expires, success otherwise.
 dbus_wait_for_service () {
     local name="$1"
     local timeout="${2:-5}"
@@ -25,5 +26,6 @@ dbus_wait_for_service () {
     while ! dbus_name_has_owner "$1"; do
         [ "$timeout" -eq 0 ] && return 1
         timeout=$((timeout - 1))
+        sleep 1
     done
 }


### PR DESCRIPTION
Commit:
2ef30c8c initscripts: dbus wait for service providers
Did not handle its purpose correctly.

dbus-send will not return an error code regardless of the method_call result as long as the method was called successfully. Since the signature returns a boolean this is easy to grep.

The timeout is expected to be roughly in seconds, but the loop does not wait, so add that.