### PR TITLE
vim-tiny: Remove graphical (x11/gtk3) mode

### DIFF
--- a/recipes-support/vim/vim-tiny_8.2.bbappend
+++ b/recipes-support/vim/vim-tiny_8.2.bbappend
@@ -1,0 +1,2 @@
+# Don't build graphical support to avoid X11/GTK3 depends
+PACKAGECONFIG_remove = "gtkgui x11"


### PR DESCRIPTION
vim-tiny's PACKAGECONFIG defaults to enabling graphical support when
DISTRO_FEATURES contains x11, which openxt-main contains.  This pulls in
x11 and gtk3.  gtk3 especially brings in lots of dependencies like mesa
and drm.  Graphical mode is unnecessary as our VMs don't have guis aside
from uivm, and even there vim isn't exposed for graphical use.

As an example, this reduces the size of syncvm-image rootfs from 155MB
to 99MB (52MB -> 34MB for the .ext3.vhd.gz).

It drops dom0 rootfs 487MB -> 459MB (186MB -> 178MB .ext3.gz) as dom0
still keeps some of the drm libraries for vGlass.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>