### PR TITLE
refpolicy fixes

### DIFF
--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/blktap-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/blktap-interfaces.diff
@@ -33,11 +33,12 @@
  kernel_write_xen_state(xend_t)
 --- a/policy/modules/roles/sysadm.te
 +++ b/policy/modules/roles/sysadm.te
-@@ -1112,6 +1112,10 @@ optional_policy(`
+@@ -1112,6 +1112,11 @@ optional_policy(`
  ')
  
  optional_policy(`
 +	tapctl_run(sysadm_t, sysadm_r)
++	dev_list_xen(sysadm_t)
 +')
 +
 +optional_policy(`

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.admin.alsa.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.admin.alsa.diff
@@ -56,4 +56,4 @@
 +xc_config_dir_getattr(alsa_t)
 +xc_config_dir_search(alsa_t)
 +xc_config_filetrans(alsa_t, alsa_etc_rw_t, { dir file })
-+
++allow alsa_t alsa_etc_rw_t:file manage_file_perms;

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.kernel.devices.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.kernel.devices.diff
@@ -111,7 +111,7 @@
  ')
  
  ########################################
-@@ -5233,3 +5284,171 @@ interface(`dev_unconfined',`
+@@ -5233,3 +5284,189 @@ interface(`dev_unconfined',`
  
  	typeattribute $1 devices_unconfined_type;
  ')
@@ -209,6 +209,24 @@
 +       ')
 +
 +       read_lnk_files_pattern($1, device_t, xen_device_t)
++')
++
++########################################
++## <summary>
++##     List Xen devices - specifically /dev/xen/blktap-2/*
++## </summary>
++## <param name="domain">
++##     <summary>
++##     Domain allowed access.
++##     </summary>
++## </param>
++#
++interface(`dev_list_xen',`
++       gen_require(`
++               type device_t, xen_device_t;
++       ')
++
++       list_dirs_pattern($1, device_t, xen_device_t)
 +')
 +
 +########################################

--- a/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.kernel.storage.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs-2.%/patches/policy.modules.kernel.storage.diff
@@ -10,7 +10,7 @@
 +/dev/xen/blktap-2/.*		gen_context(system_u:object_r:blktap_device_t,s0)
 --- a/policy/modules/kernel/storage.if
 +++ b/policy/modules/kernel/storage.if
-@@ -813,3 +813,105 @@ interface(`storage_unconfined',`
+@@ -813,3 +813,106 @@ interface(`storage_unconfined',`
  
  	typeattribute $1 storage_unconfined_type;
  ')
@@ -50,6 +50,7 @@
 +	rw_chr_files_pattern($1, blktap_device_t, blktap_device_t)
 +	rw_blk_files_pattern($1, blktap_device_t, blktap_device_t)
 +	allow $1 blktap_device_t:chr_file map;
++	dev_search_xen($1)
 +')
 +########################################
 +## <summary>


### PR DESCRIPTION
Two fixes:

The first restores sysadm's ability to list /dev/xen/blktap-2.  A side effect of this is that sysadm can read/write the /dev/xen/blktap-2/tapdev* nodes.  This was not allowed in stable-9 because those nodes were labeled xen_device_t.  sysadm can already mount the tapdevs, so I think this is okay.  Since OpenXT was open sourced, there's existed: storage_rw_blktap(sysadm_t), so I think this was intended.  sysadm_t can modify the .vhds directly anyway.

The second fixes some avc denials with writing /config/asound{,.new} on shutdown.