### PR TITLE
xen: Run qemu with -no-shutdown to avoid timeout

### DIFF
--- a/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
+++ b/recipes-extended/xen/files/libxl-openxt-qemu-args.patch
@@ -36,11 +36,12 @@ PATCHES
 ################################################################################
 --- a/tools/libxl/libxl_dm.c
 +++ b/tools/libxl/libxl_dm.c
-@@ -1168,17 +1168,15 @@ static int libxl__build_device_model_arg
+@@ -1168,17 +1168,16 @@ static int libxl__build_device_model_arg
                        "-xen-domid",
                        GCSPRINTF("%d", guest_domid), NULL);
  
 -    /* There is currently no way to access the QMP socket in the stubdom */
++    flexarray_append(dm_args, "-no-shutdown");
      if (!is_stubdom) {
 -        flexarray_append(dm_args, "-chardev");
 +        flexarray_append(dm_args, "-qmp");
@@ -60,7 +61,7 @@ PATCHES
      }
  
      for (i = 0; i < guest_config->num_channels; i++) {
-@@ -1220,7 +1218,7 @@ static int libxl__build_device_model_arg
+@@ -1220,7 +1219,7 @@ static int libxl__build_device_model_arg
      }
  
      if (c_info->name) {
@@ -69,7 +70,7 @@ PATCHES
      }
  
      if (vnc && !is_stubdom) {
-@@ -1262,17 +1260,7 @@ static int libxl__build_device_model_arg
+@@ -1262,17 +1261,7 @@ static int libxl__build_device_model_arg
          }
  
          flexarray_append(dm_args, vncarg);
@@ -88,7 +89,7 @@ PATCHES
  
      if (sdl && !is_stubdom) {
          flexarray_append(dm_args, "-sdl");
-@@ -1455,6 +1443,9 @@ static int libxl__build_device_model_arg
+@@ -1455,6 +1444,9 @@ static int libxl__build_device_model_arg
          }
          if (!libxl__acpi_defbool_val(b_info)) {
              flexarray_append(dm_args, "-no-acpi");
@@ -98,7 +99,7 @@ PATCHES
          }
          if (b_info->max_vcpus > 1) {
              flexarray_append(dm_args, "-smp");
-@@ -1480,7 +1471,7 @@ static int libxl__build_device_model_arg
+@@ -1480,7 +1472,7 @@ static int libxl__build_device_model_arg
                                                  LIBXL_NIC_TYPE_VIF_IOEMU);
                  flexarray_append(dm_args, "-device");
                  flexarray_append(dm_args,
@@ -107,7 +108,7 @@ PATCHES
                               nics[i].model, nics[i].devid,
                               nics[i].devid, smac));
                  flexarray_append(dm_args, "-netdev");
-@@ -1631,11 +1622,9 @@ static int libxl__build_device_model_arg
+@@ -1631,11 +1623,9 @@ static int libxl__build_device_model_arg
  #undef APPEND_COLO_SOCK_CLIENT
              }
          }


### PR DESCRIPTION
libxl-RFC-5of7-Handle-Linux-stubdomain-specific-QEMUoptions.patch moved
-no-shutdown as "There is currently no way to access the QMP socket in
the stubdom".

libxl-openxt-qemu-args.patch introduces a way to access QMP, but it did
not re-add -no-shutdown.

Without -no-shutdown, QEMU exits when the VM stops.  libxl expects QEMU
to still be running to issues "stop" and "quit" commands.  When QEMU is
gone, we get 10 seconds (2 x 5) of delay while libxl waits for the
timeouts. By re-adding "-no-shutdown" we avoid this shutdown delay.

On other issue with QEMU exiting is that it closes up its vGlass
connection which results in a slew of "xen:grant_table: WARNING: g.e.
0x1200 still in use!" since those grants are still mapped by vGlass in
dom0.  By having QEMU wait for an explicit quit, vGlass starts unmapping
the grants before QEMU.  There are still some "still in use" messages,
but it's ~12 instead of thousands.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>