### PR TITLE
xenmgr: Remove depends on xenmgr-data

### DIFF
--- a/recipes-openxt/manager/xenmgr_git.bb
+++ b/recipes-openxt/manager/xenmgr_git.bb
@@ -21,7 +21,6 @@ DEPENDS = " \
     hkg-text \
     hkg-mtl \
     hkg-split \
-    xenmgr-data \
 "
 
 require manager.inc


### PR DESCRIPTION
xenmgr-data is the HTML+JS UI from toolstack-data.git.  xenmgr just
doesn't depend on it.  It's unclear why it was added in the first place.
Remove it from depends.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>