### PR TITLE
[tboot] Add RPROVIDES to tboot

### DIFF
--- a/recipes-security/tboot/tboot.inc
+++ b/recipes-security/tboot/tboot.inc
@@ -77,3 +77,32 @@ FILES_${PN}-pcr-calc = " \
     ${sbindir}/pcr-calc \
     ${sbindir}/acmmatch \
 "
+
+RPROVIDES_${PN}-lcptools += " \
+    lcp_readpol \
+    lcp_writepol \
+    tb_polgen \
+    tpmnv_defindex \
+    tpmnv_getcap \
+    tpmnv_lock \
+    tpmnv_relindex \
+"
+
+RPROVIDES_${PN}-lcptools-v2 += " \
+    lcp2_mlehash \
+    lcp2_crtpol \
+    lcp2_crtpollist \
+    lcp2_crtpolelt \
+"
+
+RPROVIDES_${PN}-utils += " \
+    txt-stat \
+    parse_err \
+    acminfo \
+"
+
+RPROVIDES_${PN}-pcr-calc += " \
+    module_hash \
+    pcr-calc \
+    acmmatch \
+"


### PR DESCRIPTION
This does not fix any problems or issues. It just adds RPROVIDES for each
 of the tboot packages. This helps anyone using opkg find which package
 provides which binary.

For example, running ```opkg whatprovides acmmatch``` currently doesn't
 return any useful information. With this change, it should.

Signed-off-by: Tyler McGavran <mcgavrant@ainfosec.com>