### PR TITLE
Remove multilib

### DIFF
--- a/classes/multilib-allarch.bbclass
+++ b/classes/multilib-allarch.bbclass
@@ -1,6 +1,0 @@
-# Since we have multilib enabled for xen, regular allarch doesn't take affect
-# and the packages use the default tune.  Setting PACKAGE_ARCH forces allarch
-# like we want.
-PACKAGE_ARCH = "all"
-
-inherit allarch

--- a/conf/distro/openxt-main.conf
+++ b/conf/distro/openxt-main.conf
@@ -100,24 +100,3 @@ STUBDOMAIN_KERNEL ?= "bzImage"
 
 # Set our root home
 ROOT_HOME = "/root"
-
-# multilib is required for building Xen's hvmloader, which needs
-# materials from a 32-bit libc
-require conf/multilib.conf
-MULTILIBS = "multilib:lib32"
-DEFAULTTUNE_virtclass-multilib-lib32 = "x86"
-
-# multilib directory settings : 64-bit in /lib, 32-bit in /lib32
-# as required by the OpenXT haskell toolchain
-BASE_LIB_tune-core2-32 = "lib32"
-BASE_LIB_tune-core2-32 = "lib32"
-BASE_LIB_tune-i586 = "lib32"
-BASE_LIB_tune-i686 = "lib32"
-BASE_LIB_tune-x86 = "lib32"
-
-BASE_LIB_tune-x86-64 = "lib"
-BASE_LIB_tune-x86-64 = "lib"
-BASE_LIB_tune-core2-64 = "lib"
-
-BASE_LIB_tune-core2-64-x32 = "libx32"
-BASE_LIB_tune-x86-64-x32 = "libx32"

--- a/recipes-connectivity/networkmanager-certs/networkmanager-certs.bb
+++ b/recipes-connectivity/networkmanager-certs/networkmanager-certs.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     file://populate-certs.sh \
 "
 
-inherit multilib-allarch update-rc.d
+inherit allarch update-rc.d
 
 do_install () {
     install -d ${D}/usr/bin

--- a/recipes-core/initrdscripts/initramfs-stubdomain_1.0.bb
+++ b/recipes-core/initrdscripts/initramfs-stubdomain_1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://init.sh \
 "
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -m 0755 ${WORKDIR}/init.sh ${D}/init

--- a/recipes-core/udev/udev-extraconf-dom0_1.0.bb
+++ b/recipes-core/udev/udev-extraconf-dom0_1.0.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
     file://50-usb-powersave.rules \
 "
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -d ${D}${sysconfdir}/udev/rules.d

--- a/recipes-devtools/bats-suite/bats-suite_git.bb
+++ b/recipes-devtools/bats-suite/bats-suite_git.bb
@@ -7,7 +7,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install () {
     if [ -e "${S}/dom0" ]; then

--- a/recipes-devtools/bats/bats_git.bb
+++ b/recipes-devtools/bats/bats_git.bb
@@ -7,7 +7,7 @@ SRCREV = "03608115df2071fff4eaaff1605768c275e5f81f"
 
 S = "${WORKDIR}/git"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install () {
     ${S}/install.sh ${D}/${exec_prefix}

--- a/recipes-extended/rsyslog/rsyslog-conf-dom0.bb
+++ b/recipes-extended/rsyslog/rsyslog-conf-dom0.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "db tools"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM="file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-inherit multilib-allarch
+inherit allarch
 
 SRC_URI = "file://rsyslog.conf"
 

--- a/recipes-extended/xen/files/0001-tools-firmware-Build-firmware-as-ffreestanding.patch
+++ b/recipes-extended/xen/files/0001-tools-firmware-Build-firmware-as-ffreestanding.patch
@@ -1,0 +1,68 @@
+From 0eae016b6e3dce69e3fb86aca5c4f221591a2f12 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 25 Feb 2021 19:15:08 +0000
+Subject: [PATCH] tools/firmware: Build firmware as -ffreestanding
+
+firmware should always have been -ffreestanding, as it doesn't execute in the
+host environment.  -ffreestanding implies -fno-builtin, so replace the option.
+
+inttypes.h isn't a freestanding header, but the 32bitbios_support.c only wants
+the stdint.h types so switch to the more appropriate include.
+
+This removes the build time dependency on a 32bit libc just to compile the
+hvmloader and friends.
+
+Update README and the TravisCI configuration.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Ian Jackson <iwj@xenproject.org>
+Release-Acked-by: Ian Jackson <iwj@xenproject.org>
+---
+ .travis.yml                                  | 1 -
+ README                                       | 3 ---
+ tools/firmware/Rules.mk                      | 2 +-
+ tools/firmware/hvmloader/32bitbios_support.c | 2 +-
+ 4 files changed, 2 insertions(+), 6 deletions(-)
+
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -58,7 +58,6 @@ addons:
+             - acpica-tools
+             - bin86
+             - bcc
+-            - libc6-dev-i386
+             - libnl-3-dev
+             - ocaml-nox
+             - libfindlib-ocaml-dev
+--- a/README
++++ b/README
+@@ -62,9 +62,6 @@ provided by your OS distributor:
+     * GNU bison and GNU flex
+     * GNU gettext
+     * ACPI ASL compiler (iasl)
+-    * Libc multiarch package (e.g. libc6-dev-i386 / glibc-devel.i686).
+-      Required when building on a 64-bit platform to build
+-      32-bit components which are enabled on a default build.
+ 
+ In addition to the above there are a number of optional build
+ prerequisites. Omitting these will cause the related features to be
+--- a/tools/firmware/Rules.mk
++++ b/tools/firmware/Rules.mk
+@@ -16,4 +16,4 @@ CFLAGS += -Werror
+ $(call cc-options-add,CFLAGS,CC,$(EMBEDDED_EXTRA_CFLAGS))
+ 
+ # Extra CFLAGS suitable for an embedded type of environment.
+-CFLAGS += -fno-builtin -msoft-float
++CFLAGS += -ffreestanding -msoft-float
+--- a/tools/firmware/hvmloader/32bitbios_support.c
++++ b/tools/firmware/hvmloader/32bitbios_support.c
+@@ -20,7 +20,7 @@
+  * this program; If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+-#include <inttypes.h>
++#include <stdint.h>
+ #include <elf.h>
+ #ifdef __sun__
+ #include <sys/machelf.h>

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -14,6 +14,7 @@ SRC_URI_append = " \
     file://xen-tools-pygrub-change-tabs-into-spaces.patch \
     file://xen-tools-pygrub-py3.patch \
     file://xen-tools-pygrub-fsimage-drop-unused-struct.patch \
+    file://0001-tools-firmware-Build-firmware-as-ffreestanding.patch \
     file://kconfig-grant-table.patch \
     file://kconfig-grant-table-v2-interface.patch \
     file://kconfig-grant-table-exotic.patch \
@@ -118,6 +119,13 @@ SRC_URI_append = " \
     file://ocamlfind-static.patch \
     file://ocaml-makefiles-sysroot.patch \
 "
+
+# Unset variables inherited from meta-virt dunfell to avoid multilib
+# dependency.  0001-tools-firmware-Build-firmware-as-ffreestanding.patch makes
+# it unnecessary (from Xen 4.15).  These can be removed in OE hardknott or
+# later.
+GLIBC32_x86-64 = ""
+ADD_SYSROOT32_CFLAGS_x86-64 = ""
 
 PACKAGECONFIG =+ "xsm"
 PACKAGECONFIG =+ "hvm"

--- a/recipes-kernel/linux-firmware/linux-firmware_git.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bb
@@ -136,7 +136,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware
 
 S = "${WORKDIR}/git"
 
-inherit multilib-allarch update-alternatives
+inherit allarch update-alternatives
 
 # OE started complaining about the architecture of the binaries for some reason
 INSANE_SKIP = "arch"

--- a/recipes-openxt/argo/argo-module-headers_git.bb
+++ b/recipes-openxt/argo/argo-module-headers_git.bb
@@ -8,7 +8,7 @@ require argo.inc
 
 S = "${WORKDIR}/git/argo-linux"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     oe_runmake INSTALL_HDR_PATH=${D}${prefix} headers_install

--- a/recipes-openxt/idl/xenclient-idl_git.bb
+++ b/recipes-openxt/idl/xenclient-idl_git.bb
@@ -6,7 +6,7 @@ require idl.inc
 
 S = "${WORKDIR}/git"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -m 0755 -d ${D}${idldatadir}

--- a/recipes-openxt/xen-legacy-block-scripts/xen-legacy-block-scripts_1.0.bb
+++ b/recipes-openxt/xen-legacy-block-scripts/xen-legacy-block-scripts_1.0.bb
@@ -10,7 +10,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xen-tap-scripts/xen-tap-scripts_1.0.bb
+++ b/recipes-openxt/xen-tap-scripts/xen-tap-scripts_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xen-vif-scripts/xen-vif-scripts-dom0_1.0.bb
+++ b/recipes-openxt/xen-vif-scripts/xen-vif-scripts-dom0_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm_1.0.bb
+++ b/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev

--- a/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
-inherit multilib-allarch deploy
+inherit allarch deploy
 
 do_install () {
     ${S}/install part1 ${D}/install

--- a/recipes-openxt/xenclient-repo-certs/xenclient-repo-certs_1.0.bb
+++ b/recipes-openxt/xenclient-repo-certs/xenclient-repo-certs_1.0.bb
@@ -9,7 +9,7 @@ SRC_URI = "file://${REPO_PROD_CACERT} \
 FILES_${PN} = "${datadir}/xenclient/repo-certs \
                ${bindir}/verify-repo-metadata"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     CERTDIR_PROD=${D}${datadir}/xenclient/repo-certs/prod

--- a/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig_0.0.2.bb
+++ b/recipes-openxt/xenclient-uivm-xsessionconfig/xenclient-uivm-xsessionconfig_0.0.2.bb
@@ -31,7 +31,7 @@ SRC_URI = " \
     file://keyboard \
 "
 
-inherit multilib-allarch
+inherit allarch
 
 do_install () {
     install -d ${D}/root/.config/xfce4

--- a/recipes-security/selinux/selinux-load_1.0.bb
+++ b/recipes-security/selinux/selinux-load_1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-inherit multilib-allarch
+inherit allarch
 
 do_install() {
     install -d ${D}/sbin


### PR DESCRIPTION
Backport the xen hvmloader freestanding patch and remove the need to build multilib.  It's a lot of extra building for one component, so it's nice to skip it.  Then revert the distro and multilib-allarch changes to clean up further.