### PR TITLE
rpc-proxy: Fixup rules for syncvm

### DIFF
--- a/recipes-openxt/manager/rpc-proxy/rpc-proxy.rules
+++ b/recipes-openxt/manager/rpc-proxy/rpc-proxy.rules
@@ -6,6 +6,7 @@ allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db memb
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member read_binary if-boolean domstore-read-access true
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member list if-boolean domstore-read-access true
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member exists if-boolean domstore-read-access true
+allow destination org.freedesktop.DBus interface org.freedesktop.DBus member Hello if-boolean domstore-read-access true
 
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member write if-boolean domstore-write-access true
 allow destination com.citrix.xenclient.db interface com.citrix.xenclient.db member rm if-boolean domstore-write-access true
@@ -36,6 +37,7 @@ allow dom-type syncvm destination com.citrix.xenclient.xenmgr interface org.free
 allow dom-type syncvm interface com.citrix.xenclient.xenmgr.host member generic_message
 allow dom-type syncvm destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.vmdisk member umount
 allow dom-type syncvm destination com.citrix.xenclient.xenmgr interface com.citrix.xenclient.vmdisk member delete
+allow dom-type syncvm destination org.freedesktop.DBus interface org.freedesktop.DBus member GetNameOwner
 
 # allow all kinds of outgoing messages from dom0 to elsewhere
 allow out-any


### PR DESCRIPTION
syncvm (and any users of domstore) need to be able to call
org.freedesktop.DBus.Hello.  Without it, the db-*-dom0 calls get blocked
by rpc-proxy.  Allow that when domstore-read access is given so things
just work.

syncvm's sync-client also calls org.freedesktop.DBus.GetOwnerName in
Domstore.__init__()
db_obj = bus.get_object(DOMSTORE_SERVICE, DOMSTORE_OBJECT)
allow that as well.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>