### PR TITLE
tboot: Fix acmmatch segfault on microcode

### DIFF
--- a/recipes-security/tboot/tboot-1.9.12/0006-pcr-calc-Add-pcr-calculator-tool.patch
+++ b/recipes-security/tboot/tboot-1.9.12/0006-pcr-calc-Add-pcr-calculator-tool.patch
@@ -360,7 +360,7 @@ index 0000000..f740f2a
 +	p = mmap(NULL, acm->size, PROT_READ, MAP_PRIVATE, fd, 0);
 +	if (p == MAP_FAILED) {
 +		printd("mmap failed: %s", strerror(errno));
-+		goto fail_map;
++		goto fail_sanity;
 +	}
 +	close(fd);
 +
@@ -400,7 +400,7 @@ index 0000000..f740f2a
 +	return acm;
 +
 +fail_map:
-+	munmap(acm->header, acm->size);
++	munmap(p, acm->size);
 +fail_sanity:
 +	free(acm);
 +fail_alloc:


### PR DESCRIPTION
acmmatch is segfaulting on microcode_intel.bin and its date symlink.
They are not acms, but sanity check error handling has problems.

If get_acm_header() fails, acm->header is NULL when we jump to fail_map.
Change munmap() to use p, which is the valid pointer from mmap().  This
is the part that avoids the segfault.

Also if mmap() fails, go to fail_sanity.  There is nothing to munmap in
that case.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>