### PR TITLE
blktap2: cancel_delayed_work

### DIFF
--- a/recipes-kernel/linux/5.10/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.10/patches/blktap2.patch
@@ -625,7 +625,7 @@ PATCHES
 +MODULE_LICENSE("Dual BSD/GPL");
 --- /dev/null
 +++ b/drivers/block/blktap/device.c
-@@ -0,0 +1,710 @@
+@@ -0,0 +1,715 @@
 +#include <linux/fs.h>
 +#include <linux/blkdev.h>
 +#include <linux/blk-mq.h>
@@ -1062,7 +1062,12 @@ PATCHES
 +	put_disk(gd);
 +	tapdev->gd = NULL;
 +
++	mutex_lock(&tapdev->lock);
++	/* Prevent a race with schedule_delayed_work from another thread. */
 +	clear_bit(BLKTAP_DEVICE, &tap->dev_inuse);
++
++	cancel_delayed_work(&tap->destroy_work);
++	mutex_unlock(&tapdev->lock);
 +
 +	if (test_bit(BLKTAP_SHUTDOWN_REQUESTED, &tap->dev_inuse))
 +		blktap_control_destroy_tap(tap);
@@ -1768,7 +1773,7 @@ PATCHES
 +}
 --- /dev/null
 +++ b/drivers/block/blktap/ring.c
-@@ -0,0 +1,819 @@
+@@ -0,0 +1,825 @@
 +
 +#include <linux/device.h>
 +#include <linux/signal.h>
@@ -2118,9 +2123,15 @@ PATCHES
 +static void
 +blktap_destroy_work_common(struct blktap *tap)
 +{
++	struct blktap_device *tapdev = &tap->device;
++
 +	if (blktap_device_try_destroy(tap)) {
-+		schedule_delayed_work(&tap->destroy_work,
-+				      BLKTAP_DESTROY_RETRY_PERIOD);
++		mutex_lock(&tapdev->lock);
++		if (test_bit(BLKTAP_DEVICE, &tap->dev_inuse)) {
++			schedule_delayed_work(&tap->destroy_work,
++					      BLKTAP_DESTROY_RETRY_PERIOD);
++		}
++		mutex_unlock(&tapdev->lock);
 +	}
 +}
 +

--- a/recipes-kernel/linux/5.10/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.10/patches/blktap2.patch
@@ -1768,7 +1768,7 @@ PATCHES
 +}
 --- /dev/null
 +++ b/drivers/block/blktap/ring.c
-@@ -0,0 +1,814 @@
+@@ -0,0 +1,819 @@
 +
 +#include <linux/device.h>
 +#include <linux/signal.h>
@@ -2115,6 +2115,36 @@ PATCHES
 +	ring->ring.req_prod_pvt++;
 +}
 +
++static void
++blktap_destroy_work_common(struct blktap *tap)
++{
++	if (blktap_device_try_destroy(tap)) {
++		schedule_delayed_work(&tap->destroy_work,
++				      BLKTAP_DESTROY_RETRY_PERIOD);
++	}
++}
++
++static void
++blktap_destroy_work(struct work_struct *work)
++{
++	struct blktap *tap
++		= container_of(work, struct blktap, destroy_work.work);
++
++	blktap_destroy_work_common(tap);
++}
++
++static int
++blktap_ring_release(struct inode *inode, struct file *filp)
++{
++	struct blktap *tap = filp->private_data;
++
++	tap->ring.task = NULL;
++
++	blktap_destroy_work_common(tap);
++
++	return 0;
++}
++
 +static int
 +blktap_ring_open(struct inode *inode, struct file *filp)
 +{
@@ -2137,32 +2167,7 @@ PATCHES
 +
 +	filp->private_data = tap;
 +	tap->ring.task = current;
-+
-+	return 0;
-+}
-+
-+static void
-+blktap_destroy_work(struct work_struct *work)
-+{
-+        struct blktap *tap
-+                = container_of(work, struct blktap, destroy_work.work);
-+
-+	if (blktap_device_try_destroy(tap)) {
-+		schedule_delayed_work(&tap->destroy_work, BLKTAP_DESTROY_RETRY_PERIOD);
-+	}
-+}
-+
-+static int
-+blktap_ring_release(struct inode *inode, struct file *filp)
-+{
-+	struct blktap *tap = filp->private_data;
-+
-+	tap->ring.task = NULL;
-+
-+	if (blktap_device_try_destroy(tap)) {
-+		INIT_DELAYED_WORK(&tap->destroy_work, blktap_destroy_work);
-+		schedule_delayed_work(&tap->destroy_work, BLKTAP_DESTROY_RETRY_PERIOD);
-+	}
++	INIT_DELAYED_WORK(&tap->destroy_work, blktap_destroy_work);
 +
 +	return 0;
 +}


### PR DESCRIPTION
I saw a dom0 kernel backtrace in console mode, I think while shutting down.  I put some hand copied info from that BUG into the commit message here: https://github.com/OpenXT/xenclient-oe/commit/c122ed5ddcab7ea2ef0b7800e67d16c5f13a5e15

I'm not sure what caused it, but the call stack seems to indicated that an already un-linked delayed_work struct might have been called a second time.  Since I didn't find any existing cancel_delayed_work call, this PR reorganizes code and adds one.

It was developed against 5.4, so it "Can't automatically merge" at this time.  At this time, I want to see if there is any feedback.  I'll put it in 5.10 locally for a little bit of testing.
