### PR TITLE
linux: txt.ko fix seq_file .next tpm_evtlog_next

### DIFF
--- a/recipes-kernel/linux/5.10/patches/xen-txt-add-xen-txt-eventlog-module.patch
+++ b/recipes-kernel/linux/5.10/patches/xen-txt-add-xen-txt-eventlog-module.patch
@@ -57,7 +57,7 @@ Subject: [PATCH] xen-txt: add xen txt eventlog module
  obj-$(CONFIG_XEN_PCIDEV_BACKEND)	+= xen-pciback/
 --- /dev/null
 +++ b/drivers/xen/txt.c
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,213 @@
 +/*
 + * Copyright (C) 2017 Apertus Solutions, LLC
 + *
@@ -111,12 +111,13 @@ Subject: [PATCH] xen-txt: add xen txt eventlog module
 +	size = (log->buffer + log->size) - addr;
 +	size = size > TPM_LOG_BLOCK_SIZE ? TPM_LOG_BLOCK_SIZE : size;
 +
++	(*pos)++;
++
 +	if ((size == 0) ||
 +	    ((addr + size) > (log->buffer + log->size)))
 +		return NULL;
 +
 +	addr += size;
-+	(*pos)++;
 +
 +	return addr;
 +}


### PR DESCRIPTION
With the 5.10 uprev, Linux is warning:

kernel:[  130.724434] seq_file: buggy .next function tpm_evtlog_next
[txt] did not update position index

commit 3bfa7e141b0b "fs/seq_file.c: seq_read(): add info message about
buggy .next functions" added the warning, but it points a real the
problem: "Some ->next functions do not increment *pos when they return
NULL...  Note that such ->next functions are buggy and should be fixed"

That's whats happening in txt.ko.  tpm_evtlog_next needs to update pos
before returning NULL, so move the advancement forward to handle all
cases.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>