### PR TITLE
Add monit to monitor vglass

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,12 +1,7 @@
 # We have a conf and classes directory, append to BBPATH
 BBPATH .= ":${LAYERDIR}"
 
-# meta-selinux appends populate-volatiles.sh with commands that will not work
-# under a read-only rootfs:
-# - liberaly restorecon /var/lib
-# - sed checkroot.sh
 BBMASK = " \
-    meta-selinux/recipes-core/initscripts/ \
     meta-virtualization/recipes-extended/images/xen-guest-image-minimal.bb \
     meta-virtualization/recipes-devtools/go/go-build_git.bb \
     meta-virtualization/recipes-core/runx/runx_git.bb \

--- a/recipes-extended/monit/monit/dom0-cfg
+++ b/recipes-extended/monit/monit/dom0-cfg
@@ -1,0 +1,10 @@
+# Override the defaults in monitrc
+set daemon  2              # check services at 2 seconds intervals
+    with start delay 12    # Avoid racing with vglass start up
+
+# Move to volatile space
+set idfile /var/lib/monit/id
+set statefile /var/lib/monit/state
+set eventqueue
+    basedir /var/lib/monit/events
+    slots 100

--- a/recipes-extended/monit/monit/volatiles
+++ b/recipes-extended/monit/monit/volatiles
@@ -1,0 +1,2 @@
+l root root 0755 /var/lib/monit /var/volatile/monit
+d root root 0755 /var/lib/monit none

--- a/recipes-extended/monit/monit_%.bbappend
+++ b/recipes-extended/monit/monit_%.bbappend
@@ -1,0 +1,3 @@
+# In dom0, monit controls vglass, so we only want monit to run in
+# runlevel 5, which matches vglass, disman & ivcdaemon.
+INITSCRIPT_PARAMS_${PN}_xenclient-dom0 = "start 99 5 . stop 01 0 1 2 3 4 6 ."

--- a/recipes-extended/monit/monit_%.bbappend
+++ b/recipes-extended/monit/monit_%.bbappend
@@ -8,8 +8,17 @@ SRC_URI += " \
     file://volatiles \
 "
 
+SRC_URI_append_xenclient-dom0 = " \
+    file://dom0-cfg \
+"
+
 do_install_append() {
     install -d -m 700 ${D}${sysconfdir}/default/volatiles
     install -m 600 ${WORKDIR}/volatiles \
         ${D}${sysconfdir}/default/volatiles/50_monit
+}
+
+do_install_append_xenclient-dom0() {
+    install -d -m 700 ${D}${sysconfdir}/monit.d/
+    install -m 600 ${WORKDIR}/dom0-cfg ${D}${sysconfdir}/monit.d/
 }

--- a/recipes-extended/monit/monit_%.bbappend
+++ b/recipes-extended/monit/monit_%.bbappend
@@ -1,3 +1,15 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 # In dom0, monit controls vglass, so we only want monit to run in
 # runlevel 5, which matches vglass, disman & ivcdaemon.
 INITSCRIPT_PARAMS_${PN}_xenclient-dom0 = "start 99 5 . stop 01 0 1 2 3 4 6 ."
+
+SRC_URI += " \
+    file://volatiles \
+"
+
+do_install_append() {
+    install -d -m 700 ${D}${sysconfdir}/default/volatiles
+    install -m 600 ${WORKDIR}/volatiles \
+        ${D}${sysconfdir}/default/volatiles/50_monit
+}

--- a/recipes-security/refpolicy/refpolicy-mcs/patches/monit-volatiles.patch
+++ b/recipes-security/refpolicy/refpolicy-mcs/patches/monit-volatiles.patch
@@ -1,0 +1,37 @@
+Monit openxt fixes
+
+/var/lib/monit is a volatiles symlink to /var/volatile/monit, so label it and
+allow the symlink to be read.
+
+monit will start/stop vglass, disman and ivcdaemon, so allow monit to start
+init scripts.
+
+--- a/policy/modules/services/monit.fc
++++ b/policy/modules/services/monit.fc
+@@ -10,5 +10,6 @@
+ /usr/lib/systemd/system/monit.*	--	gen_context(system_u:object_r:monit_unit_t,s0)
+ 
+ /var/lib/monit(/.*)?			gen_context(system_u:object_r:monit_var_lib_t,s0)
++/var/volatile/monit(/.*)?			gen_context(system_u:object_r:monit_var_lib_t,s0)
+ 
+ /var/log/monit\.log.*		--	gen_context(system_u:object_r:monit_log_t,s0)
+--- a/policy/modules/services/monit.te
++++ b/policy/modules/services/monit.te
+@@ -104,6 +104,7 @@ files_pid_filetrans(monit_t, monit_runti
+ 
+ allow monit_t monit_var_lib_t:dir manage_dir_perms;
+ allow monit_t monit_var_lib_t:file manage_file_perms;
++allow monit_t monit_var_lib_t:lnk_file read_lnk_file_perms;
+ 
+ # entropy
+ kernel_read_kernel_sysctls(monit_t)
+@@ -141,6 +142,9 @@ tunable_policy(`monit_startstop_services
+ 	init_stop_all_units(monit_t)
+ ')
+ 
++# Need to support classic sysvinit scripts
++init_domtrans_script(monit_t)
++
+ optional_policy(`
+ 	dbus_system_bus_client(monit_t)
+ ')

--- a/recipes-security/refpolicy/refpolicy-mcs/policy/modules-upstream.conf
+++ b/recipes-security/refpolicy/refpolicy-mcs/policy/modules-upstream.conf
@@ -1906,7 +1906,7 @@ mongodb = off
 #
 # Monit - utility for monitoring services on a Unix system.
 # 
-monit = off
+monit = module
 
 # Layer: services
 # Module: monop

--- a/recipes-security/refpolicy/refpolicy-mcs_git.bbappend
+++ b/recipes-security/refpolicy/refpolicy-mcs_git.bbappend
@@ -160,6 +160,7 @@ SRC_URI += " \
     file://patches/add-missing-dbusd-permissions.patch \
     file://patches/xl-sysadm-interfaces.patch \
     file://patches/policy.modules.admin.bootloader.diff \
+    file://patches/monit-volatiles.patch \
 "
 
 DEPENDS_append += " \


### PR DESCRIPTION
This adds monit to dom0.  It will monitor vglass, disman & ivcdaemon and restart them as necessary.

We want to run more frequently than the default monit interval of 30 seconds, so we use every 2 seconds.  There is also a 12 second delay at startup to give things a change to start.  I did this via dom0-cfg to avoid overriding monitrc which would require keeping in sync... Maybe this was a bad choice and monitrc should just be overridden.

refpolicy needs tweaks to work with volatiles and actually start the daemons.

Goes with https://gitlab.com/vglass/meta-vglass/-/merge_requests/20