### PR TITLE
Update github SRC_URI to use https

### DIFF
--- a/recipes-core/jamvm/jamvm_git.bbappend
+++ b/recipes-core/jamvm/jamvm_git.bbappend
@@ -1,6 +1,6 @@
 PR .= ".5"
 
-SRC_URI = "git://github.com/xranby/jamvm;protocol=git \
+SRC_URI = "git://github.com/xranby/jamvm;protocol=https \
            file://jamvm-jni_h-noinst.patch \
            file://libffi.patch \
            file://jamvm-minmax-heap.patch \

--- a/recipes-devtools/bats-suite/bats-suite_git.bb
+++ b/recipes-devtools/bats-suite/bats-suite_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "OpenXT bats test scripts."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c93f84859222e5549645b5fee3d87947"
 
-SRC_URI = "git://github.com/OpenXT/bats-suite.git"
+SRC_URI = "git://github.com/OpenXT/bats-suite.git;protocol=https"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/bats/bats_git.bb
+++ b/recipes-devtools/bats/bats_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "The Bash Automated Testing System"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e0bceab9b5f17c5e35ab69da161b48c1"
 
-SRC_URI = "git://github.com/sstephenson/bats.git;protocol=git"
+SRC_URI = "git://github.com/sstephenson/bats.git;protocol=https"
 SRCREV = "03608115df2071fff4eaaff1605768c275e5f81f"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/xen/xen-xsm-policy_git.bb
+++ b/recipes-extended/xen/xen-xsm-policy_git.bb
@@ -7,7 +7,7 @@ XEN_REL ?= "4.12"
 PV = "${XEN_REL}+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/xsm-policy.git"
+SRC_URI = "git://github.com/OpenXT/xsm-policy.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/argo/argo.inc
+++ b/recipes-openxt/argo/argo.inc
@@ -1,4 +1,4 @@
 PV = "0+git${SRCPV}"
 
-SRC_URI = "git://github.com/OpenXT/linux-xen-argo.git"
+SRC_URI = "git://github.com/OpenXT/linux-xen-argo.git;protocol=https"
 SRCREV = "${AUTOREV}"

--- a/recipes-openxt/heimdallr/heimdallr_git.bb
+++ b/recipes-openxt/heimdallr/heimdallr_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "json-c pciutils"
 PV = "0+git${SRCPV}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/patches:"
-SRC_URI = "git://github.com/achartier/heimdallr.git;protocol=git \
+SRC_URI = "git://github.com/achartier/heimdallr.git;protocol=https \
            file://pci-quirks.json \
            file://fix-json-pkgconfig-name.patch \
            file://json-0.13-interface-change.patch \

--- a/recipes-openxt/idl/idl.inc
+++ b/recipes-openxt/idl/idl.inc
@@ -1,3 +1,3 @@
 PV = "0+git${SRCPV}"
-SRC_URI = "git://github.com/OpenXT/idl.git"
+SRC_URI = "git://github.com/OpenXT/idl.git;protocol=https"
 SRCREV = "${AUTOREV}"

--- a/recipes-openxt/libicbinn/icbinn.inc
+++ b/recipes-openxt/libicbinn/icbinn.inc
@@ -1,3 +1,3 @@
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/icbinn.git"
+SRC_URI = "git://github.com/OpenXT/icbinn.git;protocol=https"

--- a/recipes-openxt/libxcdbus/libxcdbus_git.bb
+++ b/recipes-openxt/libxcdbus/libxcdbus_git.bb
@@ -9,7 +9,7 @@ DEPENDS = " \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/libxcdbus.git"
+SRC_URI = "git://github.com/OpenXT/libxcdbus.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/libxenbackend/libxenbackend_git.bb
+++ b/recipes-openxt/libxenbackend/libxenbackend_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "xen-tools"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/libxenbackend.git"
+SRC_URI = "git://github.com/OpenXT/libxenbackend.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/manager/manager.inc
+++ b/recipes-openxt/manager/manager.inc
@@ -1,3 +1,3 @@
 PV = "0+git${SRCPV}"
-SRC_URI = "git://github.com/OpenXT/manager.git"
+SRC_URI = "git://github.com/OpenXT/manager.git;protocol=https"
 SRCREV = "${AUTOREV}"

--- a/recipes-openxt/network/network.inc
+++ b/recipes-openxt/network/network.inc
@@ -1,3 +1,3 @@
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/network.git"
+SRC_URI = "git://github.com/OpenXT/network.git;protocol=https"

--- a/recipes-openxt/openxt-ocaml-libs/openxt-ocaml-libs_git.bb
+++ b/recipes-openxt/openxt-ocaml-libs/openxt-ocaml-libs_git.bb
@@ -12,7 +12,7 @@ DEPENDS += " \
 
 PV = "0+git${SRCPV}"
 
-SRC_URI = "git://github.com/OpenXT/toolstack.git"
+SRC_URI = "git://github.com/OpenXT/toolstack.git;protocol=https"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-openxt/surfman/surfman.inc
+++ b/recipes-openxt/surfman/surfman.inc
@@ -1,4 +1,4 @@
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/surfman.git"
+SRC_URI = "git://github.com/OpenXT/surfman.git;protocol=https"

--- a/recipes-openxt/sync-client/sync-client_git.bb
+++ b/recipes-openxt/sync-client/sync-client_git.bb
@@ -28,7 +28,7 @@ RDEPENDS_sync-cmd += " \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/sync-client.git \
+SRC_URI = "git://github.com/OpenXT/sync-client.git;protocol=https \
            file://sync-client-daemon.initscript"
 
 INITSCRIPT_NAME = "sync-client-daemon"

--- a/recipes-openxt/sync-wui/sync-wui_git.bb
+++ b/recipes-openxt/sync-wui/sync-wui_git.bb
@@ -12,7 +12,7 @@ XENCLIENT_RELEASE ?= "unknown"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/sync-wui.git"
+SRC_URI = "git://github.com/OpenXT/sync-wui.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-openxt/uid/uid_git.bb
+++ b/recipes-openxt/uid/uid_git.bb
@@ -11,7 +11,7 @@ DEPENDS = " \
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/uid.git"
+SRC_URI = "git://github.com/OpenXT/uid.git;protocol=https"
 
 SRC_URI += " \
     file://uid_dbus.conf \

--- a/recipes-openxt/vusb/vusb-daemon_git.bb
+++ b/recipes-openxt/vusb/vusb-daemon_git.bb
@@ -7,7 +7,7 @@ RDEPENDS_${PN} += "libxcxenstore"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/vusb-daemon.git \
+SRC_URI = "git://github.com/OpenXT/vusb-daemon.git;protocol=https \
            file://xenclient-vusb.initscript \
            "
 

--- a/recipes-openxt/xclibs/xclibs.inc
+++ b/recipes-openxt/xclibs/xclibs.inc
@@ -1,3 +1,3 @@
 PV = "0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/xclibs.git"
+SRC_URI = "git://github.com/OpenXT/xclibs.git;protocol=https"

--- a/recipes-openxt/xctools/xctools.inc
+++ b/recipes-openxt/xctools/xctools.inc
@@ -1,4 +1,4 @@
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/xctools.git"
+SRC_URI = "git://github.com/OpenXT/xctools.git;protocol=https"

--- a/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
@@ -6,7 +6,7 @@ PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://github.com/OpenXT/installer.git \
+    git://github.com/OpenXT/installer.git;protocol=https \
     file://network.ans \
     file://network_download_win.ans \
     file://network_manual.ans \

--- a/recipes-openxt/xenmgr-data/xenmgr-data_git.bb
+++ b/recipes-openxt/xenmgr-data/xenmgr-data_git.bb
@@ -20,7 +20,7 @@ DEPENDS = "dojosdk-native"
 PV = "0+git${SRCPV}"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/OpenXT/toolstack-data.git"
+SRC_URI = "git://github.com/OpenXT/toolstack-data.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-security/libseccomp/libseccomp_2.4.3.bb
+++ b/recipes-security/libseccomp/libseccomp_2.4.3.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;beginline=0;endline=1;md5=8eac08d22113880357c
 
 SRCREV = "1dde9d94e0848e12da20602ca38032b91d521427"
 
-SRC_URI = "git://github.com/seccomp/libseccomp.git;branch=release-2.4 \
+SRC_URI = "git://github.com/seccomp/libseccomp.git;branch=release-2.4;protocol=https \
            file://run-ptest \
 "
 

--- a/recipes-security/tss2/tpm2-tools_3.1.3.bb
+++ b/recipes-security/tss2/tpm2-tools_3.1.3.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=91b7c548d73ea16537799e8060cea819"
 DEPENDS = "tpm2-tss openssl curl autoconf-archive pkgconfig libgcrypt"
 
 SRCREV = "74ba065e5914bc5d713ca3709d62a5751b097369"
-SRC_URI = "git://github.com/01org/tpm2-tools.git;protocol=git;branch=3.X \
+SRC_URI = "git://github.com/01org/tpm2-tools.git;protocol=https;branch=3.X \
     file://tpm2-tools-lib-support.patch \
     file://tpm2-sealing-support.patch \
     file://tpm2-unsealing-support.patch \

--- a/recipes-security/tss2/tpm2-tss_2.0.0.bb
+++ b/recipes-security/tss2/tpm2-tss_2.0.0.bb
@@ -11,7 +11,7 @@ SRCREV = "ced20c209397f58d81da79810f49976ba2d36566"
 
 SRC_URI = " \
     file://0001-build-update-for-ax_code_coverage.m4-version-2019.01.patch \
-    git://github.com/01org/tpm2-tss.git;protocol=git;branch=master \
+    git://github.com/01org/tpm2-tss.git;protocol=https;branch=master \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-support/pesign/pesign_git.bb
+++ b/recipes-support/pesign/pesign_git.bb
@@ -19,7 +19,7 @@ PV = "git${SRCPV}"
 
 SRCREV = "be25a1be3d1b71bd747065f2b03c5a97e7a4ba20"
 
-SRC_URI = "git://github.com/rhboot/pesign;branch=main \
+SRC_URI = "git://github.com/rhboot/pesign;branch=main;protocol=https \
     file://0001-Disable-warning.patch \
     file://0002-Init-error.patch \
     file://0003-cast-macro.patch \


### PR DESCRIPTION
Github git protocol fetches are failing with:
> The unauthenticated git protocol on port 9418 is no longer supported.
> Please see
> https://github.blog/2021-09-01-improving-git-protocol-security-github/
> for more information.

Follow oe-core's lead and switch to explicitly specifying protocol=https
for fetching.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>