### PR TITLE
varstored: Create fresh {KEK,db}.list

### DIFF
--- a/recipes-core/varstored/varstored_git.bb
+++ b/recipes-core/varstored/varstored_git.bb
@@ -67,8 +67,8 @@ do_compile_append() {
     openssl x509 -inform DER -in ${WORKDIR}/MicWinProPCA2011_2011-10-19.crt -outform PEM -out ${S}/MicWinProPCA2011_2011-10-19.pem -text
     openssl x509 -inform DER -in ${WORKDIR}/MicCorKEKCA2011_2011-06-24.crt -outform PEM -out ${S}/MicCorKEKCA2011_2011-06-24.pem
 
-    echo ${S}/MicCorKEKCA2011_2011-06-24.pem >> ${S}/KEK.list
-    echo ${S}/MicWinProPCA2011_2011-10-19.pem >> ${S}/db.list
+    echo ${S}/MicCorKEKCA2011_2011-06-24.pem > ${S}/KEK.list
+    echo ${S}/MicWinProPCA2011_2011-10-19.pem > ${S}/db.list
     echo ${S}/MicCorUEFCA2011_2011-06-27.pem >> ${S}/db.list
 
     oe_runmake auth


### PR DESCRIPTION
The append redirects may get called repeatedly if re-builds are
triggered without cleaning.  This will created larger and larger db.auth
files.  At runtime, varstored will fail to load them with:
"Auth file '/usr/share/varstored/db.auth' is too large: 57829"

The guest sits spinning in OVMF, and the display doesn't initialize,
showing "Guest has not initialized the display (yet)."

Clear the files first with '>' before appending more.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>