### PR TITLE
Blktap2 fixes

### DIFF
--- a/recipes-kernel/linux/5.15/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.15/patches/blktap2.patch
@@ -1089,12 +1089,12 @@ PATCHES
 +blktap_device_fail_queue(struct blktap *tap)
 +{
 +	struct blktap_device *tapdev = &tap->device;
-+	struct request_queue *q = tapdev->gd->queue;
 +
 +	mutex_lock(&tapdev->lock);
-+	// Moved inside lock like it was in 4.14
-+	blk_queue_flag_clear(QUEUE_FLAG_STOPPED, q);
-+	blk_mq_free_tag_set(&tapdev->tag_set);
++
++	blk_mq_stop_hw_queues(tapdev->gd->queue);
++	blk_mark_disk_dead(tapdev->gd);
++	set_capacity(tapdev->gd, 0);
 +
 +	mutex_unlock(&tapdev->lock);
 +}

--- a/recipes-kernel/linux/5.15/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.15/patches/blktap2.patch
@@ -1741,7 +1741,7 @@ PATCHES
 +}
 --- /dev/null
 +++ b/drivers/block/blktap/ring.c
-@@ -0,0 +1,825 @@
+@@ -0,0 +1,823 @@
 +
 +#include <linux/device.h>
 +#include <linux/signal.h>
@@ -1751,8 +1751,6 @@ PATCHES
 +#include <linux/export.h>
 +
 +#include "blktap.h"
-+
-+#define BLKTAP_DESTROY_RETRY_PERIOD (HZ/10) /*100 msec*/
 +
 +int blktap_ring_major;
 +static struct cdev blktap_ring_cdev;
@@ -2097,7 +2095,7 @@ PATCHES
 +		mutex_lock(&tapdev->lock);
 +		if (test_bit(BLKTAP_DEVICE, &tap->dev_inuse)) {
 +			schedule_delayed_work(&tap->destroy_work,
-+					      BLKTAP_DESTROY_RETRY_PERIOD);
++					      msecs_to_jiffies(5000));
 +		}
 +		mutex_unlock(&tapdev->lock);
 +	}

--- a/recipes-kernel/linux/5.15/patches/blktap2.patch
+++ b/recipes-kernel/linux/5.15/patches/blktap2.patch
@@ -75,7 +75,7 @@ PATCHES
 +blktap-objs := control.o ring.o device.o request.o sysfs.o
 --- /dev/null
 +++ b/drivers/block/blktap/blktap.h
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,184 @@
 +#ifndef _BLKTAP_H_
 +#define _BLKTAP_H_
 +
@@ -120,7 +120,6 @@ PATCHES
 +struct blktap_device {
 +	struct mutex                   lock;
 +	struct gendisk                *gd;
-+	struct request_queue          *rq;
 +	struct blk_mq_tag_set          tag_set;
 +};
 +
@@ -626,7 +625,7 @@ PATCHES
 +MODULE_LICENSE("Dual BSD/GPL");
 --- /dev/null
 +++ b/drivers/block/blktap/device.c
-@@ -0,0 +1,684 @@
+@@ -0,0 +1,683 @@
 +#include <linux/fs.h>
 +#include <linux/blkdev.h>
 +#include <linux/blk-mq.h>
@@ -1058,7 +1057,7 @@ PATCHES
 +		goto out;
 +	}
 +
-+	blk_mq_stop_hw_queues(tapdev->rq);
++	blk_mq_stop_hw_queues(gd->queue);
 +
 +	del_gendisk(gd);
 +	gd->private_data = NULL;
@@ -1234,7 +1233,6 @@ PATCHES
 +	gd->private_data = tapdev;
 +
 +	gd->queue->queuedata = tap;
-+	tapdev->rq = gd->queue;
 +	tapdev->gd = gd;
 +
 +	blktap_device_configure(tap, info);


### PR DESCRIPTION
https://github.com/OpenXT/xenclient-oe/commit/072a39ded084eea085ae3658312828af715ac3c9 didn't full solve the crash it was trying to.  Turns out you can repro by SIGKILL-ing a tapdisk process.  The destroy work calls cleanup_queue() -> blk_cleanup_queues(), and it crashes when blk_cleanup_queues() runs a second time.  

(blktap_device_destroy seems wonky.  It leaves the device open if there are still any openers, or if it is locked.  Locked implying that it is the final opener.  This means closing the final opener doesn't close the device and relies on destroy_work or an IOCTL to remove.  I feel like this should be done better, but I'm not sure.  Maybe destroy_work should just go away and leave cleanup tied to ioctl?)

There are also two small cleanups to remove a duplicate queue pointer and correct the units for the destroy_work timeout.