### PR TITLE
RFC: Display PCRs when unseal fails

### DIFF
--- a/recipes-core/images/xenclient-dom0-image.bb
+++ b/recipes-core/images/xenclient-dom0-image.bb
@@ -118,3 +118,9 @@ rw_config_partition() {
 }
 ROOTFS_POSTPROCESS_COMMAND += "rw_config_partition; "
 ROOTFS_POSTPROCESS_COMMAND += "start_tty_on_hvc0;"
+
+# Toggle flag to show PCRs during measured launch failure
+debug_pcrs() {
+	sed -i '/^DEBUG_DUMP_PCRS=/s/0/1/' "${IMAGE_ROOTFS}/sbin/init.root-ro"
+}
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "debug-tweaks", "debug_pcrs; ", "",d)}'

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -78,6 +78,7 @@ tpm_ver="$(get_tpm_version)"
 operation="seal"
 config_key="/config/keys/config.key"
 sealed_key="/boot/system/tpm/config.tss"
+forward_seal_list=/boot/system/tpm/forward_pcr.lst
 config_pcrs="/config/config.pcrs"
 good_pcrs="/config/good.pcrs"
 bad_pcrs="/boot/system/tpm/bad.pcrs"
@@ -231,11 +232,17 @@ forward)
         pcr_forward[19]=":${pcr19}"
     fi
 
-    rm -f /boot/system/tpm/forward_pcr.lst
-    for p in ${pcr_selection}; do
-        pcr_params="${pcr_params} -p ${p}${pcr_forward[${p}]}"
-        if [ -n "${pcr_forward[${p}]}" ]; then
-            echo "${p}${pcr_forward[${p}]}" >> /boot/system/tpm/forward_pcr.lst
+    rm -f $forward_seal_list
+    for p in $( seq 0 23 ) ; do
+        if pcr_in_selection "$p" ; then
+            pcr_params="${pcr_params} -p ${p}${pcr_forward[${p}]}"
+            if [ -n "${pcr_forward[${p}]}" ]; then
+                echo "forward ${p}${pcr_forward[${p}]}" >> $forward_seal_list
+            else
+                echo "current $p:$( tpm_get_pcr "$p")" >> $forward_seal_list
+            fi
+        else
+            echo "skipped $p:$( tpm_get_pcr "$p")" >> $forward_seal_list
         fi
     done
 

--- a/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
+++ b/recipes-openxt/openxt-measuredlaunch/openxt-measuredlaunch/seal-system
@@ -59,6 +59,7 @@ EOF
 # list of PCRs defined in ${config_pcrs}.
 pcr_in_selection() {
     local pcr="$1"
+    local p
 
     for p in ${pcr_selection}; do
         if [ "${p}" -eq "${pcr}" ]; then

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -162,8 +162,13 @@ txt_failure()
     exit 1
 }
 
-unseal_failure()
-{
+# Hard code disable.  debug-tweaks image feature will switch on
+DEBUG_DUMP_PCRS=0
+debug_pcrs() {
+    if [ "$DEBUG_DUMP_PCRS" != "1" ] ; then
+        return
+    fi
+
     # /tmp isn't available yet
     mkdir /dev/pcrs
     # forward_pcr.lst format:
@@ -200,6 +205,15 @@ unseal_failure()
 
     rm -rf /dev/pcrs
 
+echo "
+    You can't trust me - I may be compromised - but here is a diff
+    of the PCRs:
+$pcr_diff
+"
+}
+
+unseal_failure()
+{
     dialog --colors --backtitle "${BACK_TITLE}" --defaultno \
         --yes-label "Continue" --no-label "Shutdown" --yesno "
           \ZbSECURITY WARNING: Measured Launch Unseal FAILED\ZB
@@ -207,11 +221,7 @@ unseal_failure()
     The failure is due to a mismatch between sealed and current
     PCR values. Primarily this is the result of either an upgrade
     or the tampering of the system.
-
-    You can't trust me - I may be compromised - but here is a diff
-    of the PCRs:
-$pcr_diff
-
+$(debug_pcrs)
     If a system change is expected, then you may enter the
     recovery passphrase to continue launching the system." 0 0
 

--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -164,6 +164,42 @@ txt_failure()
 
 unseal_failure()
 {
+    # /tmp isn't available yet
+    mkdir /dev/pcrs
+    # forward_pcr.lst format:
+    # (foward|current|skipped) $p:$hash
+    # We only care about forward and current - not skipped - grab $p:$hash
+    awk '/forward |current /{ print $2 }' \
+        /boot/system/tpm/forward_pcr.lst > /dev/pcrs/expected
+    # Get used pcrs
+    pcrs=$( cut -d: -f1 < /dev/pcrs/expected )
+
+    i=0
+    do_diff=1
+
+    for p in $pcrs ; do
+        i=$(( i + 1 ))
+        if [ "$i" -ge 24 ]; then
+            do_diff=0
+            pcr_diff="Diff skipped - too many lines in forward_pcr.lst"
+            break
+        fi
+        # Only accept valid PCRs
+        if [ "$p" -ge 0 ] && [ "$p" -le 23 ] ; then
+            echo "$p:$( tpm_get_pcr "$p" )" >> /dev/pcrs/current
+        else
+            do_diff=0
+            pcr_diff="Diff skipped - unexpected data in forward_pcr.lst"
+            break
+        fi
+    done
+
+    if [ "$do_diff" = "1" ] ; then
+        pcr_diff="$( diff -u /dev/pcrs/expected /dev/pcrs/current )"
+    fi
+
+    rm -rf /dev/pcrs
+
     dialog --colors --backtitle "${BACK_TITLE}" --defaultno \
         --yes-label "Continue" --no-label "Shutdown" --yesno "
           \ZbSECURITY WARNING: Measured Launch Unseal FAILED\ZB
@@ -171,6 +207,10 @@ unseal_failure()
     The failure is due to a mismatch between sealed and current
     PCR values. Primarily this is the result of either an upgrade
     or the tampering of the system.
+
+    You can't trust me - I may be compromised - but here is a diff
+    of the PCRs:
+$pcr_diff
 
     If a system change is expected, then you may enter the
     recovery passphrase to continue launching the system." 0 0


### PR DESCRIPTION
This may be a bad idea.

When unseal fails for a PCR mismatch, it takes some work to figure out what failed.  And you can only do that after either unlocking or booting from alternate media.  We don't store the non-calculated (current) PCRs at sealing time, so we can't know how they compare.

This has the machine print the mis-matched PCRs... but you can't trust the output since it may be compromised!  In that light, this could be a bad idea in production.  For development, it is handy to see what is unexpected for a failed unseal.

The output looks like:
![PXL_20220322_120859327a](https://user-images.githubusercontent.com/1879231/159481179-f2f66775-44d3-462b-b2e0-d1b304bc7952.jpg)

Ideally we have a TPM Quote displayed as a QR code so we can verify the current PCRs...

Even if the unseal message isn't changed, I think the recording of all PCRs is worthwhile.  Another option is to add a third option to `<Continue>` and `<Shutdown>` and only display the diff when `<Untrustworthy Info>` is selected.

Thoughts?