### PR TITLE
linux: usbback: Remove stdarg.h include

### DIFF
--- a/recipes-kernel/linux/5.15/patches/usbback-base.patch
+++ b/recipes-kernel/linux/5.15/patches/usbback-base.patch
@@ -3549,7 +3549,7 @@ PATCHES
 +
 --- /dev/null
 +++ b/drivers/usb/xen-usbback/xenbus.c
-@@ -0,0 +1,583 @@
+@@ -0,0 +1,582 @@
 +/*  Xenbus code for usbif backend
 +    Copyright (C) 2005 Rusty Russell <rusty@rustcorp.com.au>
 +    Copyright (C) 2005 XenSource Ltd
@@ -3570,7 +3570,6 @@ PATCHES
 +    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 +*/
 +
-+#include <stdarg.h>
 +#include <linux/module.h>
 +#include <linux/kthread.h>
 +#include "common.h"


### PR DESCRIPTION
We have warnings like this for va_start, va_arg and va_copy:
include/linux/stdarg.h:6: warning: "va_start" redefined
    6 | #define va_start(v, l) __builtin_va_start(v, l)

gcc/x86_64-oe-linux/9.3.0/include/stdarg.h:47: note: this is the location of the previous definition
   47 | #define va_start(v,l) __builtin_va_start(v,l)

usbback should not be including the compiler's stdarg, since it should
be using Linux's definitions.  Drop the compiler inclusion.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>