### PR TITLE
tboot: pcr-calc: Error without evtlog

### DIFF
--- a/recipes-security/tboot/tboot-1.9.12/0006-pcr-calc-Add-pcr-calculator-tool.patch
+++ b/recipes-security/tboot/tboot-1.9.12/0006-pcr-calc-Add-pcr-calculator-tool.patch
@@ -2461,7 +2461,7 @@ new file mode 100644
 index 0000000..f3dbb90
 --- /dev/null
 +++ b/pcr-calc/pcr-calc.c
-@@ -0,0 +1,446 @@
+@@ -0,0 +1,447 @@
 +/*
 + *
 + * Copyright (c) 2017 Daniel P. Smith
@@ -2826,6 +2826,7 @@ index 0000000..f3dbb90
 +				flags |= FLAG_EVTLOG_OLD;
 +			} else {
 +				error_msg("failed to find TPM 2.0 event log.\n");
++				ret = 1;
 +				goto out;
 +			}
 +		}


### PR DESCRIPTION
It is an error to be unable to find the tpm 2.0 sysfs event log, so
return failure.  Without this, seal-system keeps running with empty pcr
17, 18 & 19, which are invalid forward seal values.

The sysfs event log can be missing when the txt_op hypercall number
mismatches between Xen and Linux.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>