### PR TITLE
ndvm: Use RDEPEND with network-slave

### DIFF
--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -51,11 +51,8 @@ IMAGE_INSTALL = " \
     libargo-bin \
     dbus \
     xenclient-dbusbouncer \
-    networkmanager \
     linux-firmware-iwlwifi \
     linux-firmware-bnx2 \
-    bridge-utils \
-    iptables \
     xenclient-ndvm-tweaks \
     rsyslog \
     argo-module \
@@ -63,7 +60,6 @@ IMAGE_INSTALL = " \
     xen-tools-xenstore \
     wget \
     ethtool \
-    carrier-detect \
     xenclient-nws \
     modemmanager \
     ppp \

--- a/recipes-openxt/network/xenclient-nws_git.bb
+++ b/recipes-openxt/network/xenclient-nws_git.bb
@@ -2,7 +2,6 @@ DESCRIPTION = "XenClient Network Slave"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM="file://../COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 DEPENDS = " \
-    carrier-detect \
     libxchutils \
     hkg-hsyslog \
     libxch-rpc \
@@ -15,8 +14,12 @@ DEPENDS = " \
     hkg-network \
 "
 RDEPENDS_${PN} += " \
+    bridge-utils \
+    carrier-detect \
     glibc-gconv-utf-32 \
     iproute2 \
+    iptables \
+    networkmanager \
 "
 
 require network.inc


### PR DESCRIPTION
network-slave execs brctl, carrier-detect, iptables, and NetworkManager,
so it has direct runtime dependencies on them.  Add them to RDEPENDS.

With that, carrier-detect is not a build depends, so drop it from
DEPENDS.

Since they are set as RDEPENDS, drop the runtime deps from the ndvm
image recipe.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>