### PR TITLE
[mle] Write PCRS_GOOD on successful unlock

### DIFF
--- a/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
+++ b/recipes-openxt/xenclient-root-ro/xenclient-root-ro/init.root-ro
@@ -311,6 +311,7 @@ unlock_config()
                 mount /dev/mapper/config /config
                 mkdir -p $(dirname ${measured_flag})
                 touch ${measured_flag}
+                tpm_list_pcrs > "${PCRS_GOOD}"
                 return 0
             }
             maybe_break "measure-fail"


### PR DESCRIPTION
  Over time after upgrades and forward seal operations, PCRS_GOOD
  can become outdated. When you do encounter a measurement failure,
  it doesn't always provide an admin/developer accurate PCR values
  for debugging what PCR measurement failed.

  This commit writes the latest known-good PCR values on each successful
  unlock of the encrypted partition when booting.

Signed-off-by: Chris Rogers <crogers122@gmail.com>