### PR TITLE
installer: Generate root-owned control.tar.bz2

### DIFF
--- a/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
+++ b/recipes-openxt/xenclient-installer/xenclient-installer_git.bb
@@ -37,6 +37,7 @@ do_deploy() {
     install -m 0644 ${D}/*.ans ${DEPLOYDIR}/netboot/
 
     tar --exclude=./install \
+        --owner=root --group=root \
         -C ${D} -cjf ${DEPLOYDIR}/control.tar.bz2 .
 }
 addtask do_deploy after do_install before do_build


### PR DESCRIPTION
The build user & group id are leaking into the control.tar.bz2 tarball. Specify the owner and group as root to avoid this.

It doesn't have a practical impact in normal OpenXT use since the installer runs as root.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>