### PR TITLE
rsyslog-conf-dom0: Drop uivm Memory pressure relief

### DIFF
--- a/recipes-extended/rsyslog/rsyslog-conf-dom0/rsyslog.conf
+++ b/recipes-extended/rsyslog/rsyslog-conf-dom0/rsyslog.conf
@@ -29,6 +29,9 @@ $Umask 0022
 ###############
 $outchannel log_rotation,/var/log/messages,20971520,/usr/sbin/logrotate-wrapper
 
+# uivm log spam.  Need to drop before vm_format logs it.
+:msg, contains, "Memory pressure relief" stop
+
 # Use custom format for VM messages
 :programname, isequal, "xenconsoled" :omfile:$log_rotation;vm_format
 :programname, isequal, "xenconsoled" ~


### PR DESCRIPTION
These messages are not actionable and just spammy from WebKit.  Drop them.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>