### PR TITLE
xen: Fixup libxl-openxt-helpers.patch

### DIFF
--- a/recipes-extended/xen/files/libxl-openxt-helpers.patch
+++ b/recipes-extended/xen/files/libxl-openxt-helpers.patch
@@ -52,15 +52,16 @@ PATCHES
  static const char *libxl_tapif_script(libxl__gc *gc)
  {
  #if defined(__linux__) || defined(__FreeBSD__)
-@@ -1514,6 +1517,7 @@ static int libxl__build_device_model_arg
-         }
-         if (b_info->u.hvm.soundhw) {
-             flexarray_vappend(dm_args, "-soundhw", b_info->u.hvm.soundhw, NULL);
+@@ -1531,6 +1534,8 @@ static int libxl__build_device_model_arg
+                 flexarray_append_pair(dm_args, "-device",
+                                       (char*)libxl__qemu_soundhw_to_string(soundhw));
+             }
++
 +            need_audio_helper = true;
          }
          if (!libxl__acpi_defbool_val(b_info)) {
              flexarray_append(dm_args, "-no-acpi");
-@@ -2258,6 +2262,42 @@ char *libxl__stub_dm_name(libxl__gc *gc,
+@@ -2275,6 +2280,42 @@ char *libxl__stub_dm_name(libxl__gc *gc,
      return GCSPRINTF("%s-dm", guest_name);
  }
  
@@ -103,7 +104,7 @@ PATCHES
  void libxl__spawn_stub_dm(libxl__egc *egc, libxl__stub_dm_spawn_state *sdss)
  {
      STATE_AO_GC(sdss->dm.spawn.ao);
-@@ -2382,6 +2422,17 @@ void libxl__spawn_stub_dm(libxl__egc *eg
+@@ -2399,6 +2440,17 @@ void libxl__spawn_stub_dm(libxl__egc *eg
          goto out;
      }
  


### PR DESCRIPTION
"tools/libxl: Replace deprecated -soundhw on QEMU command line" was backported to stable-4.16 in commit	e85e2a3c17b6.  This change to soundhw code has quilt applying libxl-openxt-helpers.patch with a huge offset.  From do_patch:

Applying patch libxl-openxt-helpers.patch
patching file tools/libs/light/libxl_dm.c
Hunk #2 succeeded at 841 with fuzz 2 (offset -677 lines).
Hunk #3 succeeded at 2280 (offset 17 lines).
Hunk #4 succeeded at 2440 (offset 17 lines).
patching file tools/libs/light/libxl_domain.c
patching file tools/libs/light/libxl_internal.h

The -677 offset is patching libxl__build_device_model_args_old() instead of libxl__build_device_model_args_new().  linux stubdoms use libxl__build_device_model_args_new(), so audio-helper won't get flagged for starting.

Fixup the patch to apply to libxl__build_device_model_args_new().

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>