### PR TITLE
tboot fixes

### DIFF
--- a/recipes-security/tboot/tboot-1.9.12/0010-Add-support-for-launching-64-bit-PE-kernels.patch
+++ b/recipes-security/tboot/tboot-1.9.12/0010-Add-support-for-launching-64-bit-PE-kernels.patch
@@ -418,7 +418,7 @@ new file mode 100644
 index 0000000..bafb574
 --- /dev/null
 +++ b/tboot/common/pe.c
-@@ -0,0 +1,221 @@
+@@ -0,0 +1,227 @@
 +/*
 + * pe.c: support functions for manipulating PE binaries
 + */
@@ -606,12 +606,18 @@ index 0000000..bafb574
 +
 +    uint32_t limit = get_lowest_mod_start(lctx);
 +
-+    efi_memmap_get_highest_sized_ram(image_max + (1 << 21), (u32)limit,
-+                          &ram_base, &ram_size);
-+
-+    if ( ram_size < image_max ) {
-+        printk(TBOOT_ERR"Not enough memory to load kernel.\n");
-+        return false;
++    /*  NOTE: the memory maps have been modified already to reserve critical
++        memory regions (tboot memory, etc ...). get_highest_sized_ram
++        will return a range that excludes critical memory regions. */
++    if (!efi_memmap_get_highest_sized_ram(image_max + (1 << 21), (u32)limit,
++                                          &ram_base, &ram_size)) {
++        if (!e820_get_highest_sized_ram(image_max + (1 << 21), (u32)limit,
++                                        &ram_base, &ram_size)) {
++            printk(TBOOT_INFO"ERROR No memory area found for image"
++                             "relocation!\n");
++            printk(TBOOT_INFO"required 0x%X\n", image_max + (1 << 21));
++            return false;
++        }
 +    }
 +
 +    if ( ram_base + ram_size > (u32)image )

--- a/recipes-security/tboot/tboot-1.9.12/0010-Add-support-for-launching-64-bit-PE-kernels.patch
+++ b/recipes-security/tboot/tboot-1.9.12/0010-Add-support-for-launching-64-bit-PE-kernels.patch
@@ -188,7 +188,7 @@ new file mode 100644
 index 0000000..39b8422
 --- /dev/null
 +++ b/tboot/common/paging_64.c
-@@ -0,0 +1,224 @@
+@@ -0,0 +1,225 @@
 +/*
 + * paging_64.c: Enable 64-bit paging and jump to PE entry points
 + */
@@ -348,7 +348,8 @@ index 0000000..39b8422
 +     "lgdtl %[gdt]\n"
 +
 +    // Enable PAE
-+     "mov %[cr4], %%eax\n"
++     "mov %%cr4, %%eax\n"
++     "or  %[cr4_pae], %%eax\n"
 +     "mov %%eax, %%cr4\n"
 +
 +    // Load our page tables
@@ -397,7 +398,7 @@ index 0000000..39b8422
 +     [lme] "i" (1 << _EFER_LME),
 +     [cr0_nopg] "i" (CR0_PE | CR0_MP | CR0_NE),
 +     [cr0] "i" (CR0_PE | CR0_MP | CR0_NE | CR0_PG),
-+     [cr4] "i" (CR4_DE | CR4_PAE | CR4_MCE | CR4_FXSR | CR4_XMM | CR4_SMXE),
++     [cr4_pae] "i" (CR4_PAE),
 +     [ds64] "i" (__BOOT_DS64),
 +     [cs64] "i" (__BOOT_CS64),
 +     "S" (&pe_data)


### PR DESCRIPTION
I made these two changes while working on the Xen 4.14 & 4.16 uprevs.  I got OpenXT's UEFI -> xen -> tboot -> xen running in QEMU so I could debug it.

[tboot/pe: Fix PE load address calculation](https://github.com/OpenXT/xenclient-oe/commit/9bcd088fdb35205c12c8fd190a682f139b090362) is a bug fix.  `efi_memmap_get_highest_sized_ram()`'s return value isn't checked,so the uninitialized ram_size is used.

[tboot/PE: Or-in PAE flag to cr4](https://github.com/OpenXT/xenclient-oe/commit/872e442d5d685be5f22df14df52e9e633495ab09) fixes running tboot under QEMU.  My QEMU instance didn't emulate enough of CR4 that it faulted when trying to set all the values.  In particular, QEMU doesn't support TXT(SMX), so that can't be set in cr4.  This change makes it a little more proper to just or-in the desired cr4 PAE flag instead of using the hard coded set.

vGlass (and maybe disman) don't run because SSE3 is missing where I was testing.  Specifying a sufficient cpu like `qemu-system-x86_64 -cpu Skylake-Client-v4,+ssse3` lets them run.

OpenXT hardcodes NDVM as HVM and UIVM as PVH, so neither can run by default under QEMU/KVM.  If they are changed to PV, they will start and you can have the OpenXT gui in QEMU.  Nested virt could work, but I did not investigate.  I logged in via the serial console, used db-write to change virt-type and started them manually.