### PR TITLE
Default to read-only blktap

### DIFF
--- a/recipes-extended/xen/blktap3.bb
+++ b/recipes-extended/xen/blktap3.bb
@@ -24,6 +24,7 @@ SRC_URI = "git://github.com/xapi-project/blktap.git;protocol=https \
     file://gcc9-compilation.patch \
     file://openssl-1.1.x.patch \
     file://0001-Set-libvhdio-libtool-version-info.patch \
+    file://0001-tap-ctl-Default-to-read-only-opening.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/xen/blktap3/0001-tap-ctl-Default-to-read-only-opening.patch
+++ b/recipes-extended/xen/blktap3/0001-tap-ctl-Default-to-read-only-opening.patch
@@ -1,0 +1,43 @@
+From 4c159040d59e176646fadd16b5d36c8fe35be92f Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Thu, 16 Feb 2023 12:06:44 -0500
+Subject: [PATCH] tap-ctl: Default to read-only opening
+
+OpenXT is changing to hash .vhds directly.  To do so, we need to only
+open .vhds as read-only as read-write can modify the metadata even if
+the contents do not change.
+
+Change the default to read-only, the former -R option.  Add a new -W
+option to use when read-write is desired.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ control/tap-ctl.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+--- a/control/tap-ctl.c
++++ b/control/tap-ctl.c
+@@ -307,11 +307,11 @@ tap_cli_create(int argc, char **argv)
+ 	devname   = NULL;
+ 	secondary = NULL;
+ 	prt_minor = -1;
+-	flags     = 0;
++	flags     = TAPDISK_MESSAGE_FLAG_RDONLY;
+ 	timeout   = 0;
+ 
+ 	optind = 0;
+-	while ((c = getopt(argc, argv, "a:c:RDd:e:r2:st:C:h")) != -1) {
++	while ((c = getopt(argc, argv, "a:c:RWDd:e:r2:st:C:h")) != -1) {
+ 		switch (c) {
+ 		case 'a':
+ 			args = optarg;
+@@ -326,6 +326,9 @@ tap_cli_create(int argc, char **argv)
+ 		case 'R':
+ 			flags |= TAPDISK_MESSAGE_FLAG_RDONLY;
+ 			break;
++		case 'W':
++			flags &= ~TAPDISK_MESSAGE_FLAG_RDONLY;
++			break;
+ 		case 'D':
+ 			flags |= TAPDISK_MESSAGE_FLAG_NO_O_DIRECT;
+ 			break;

--- a/recipes-extended/xen/files/0001-convert-block-tap-for-shared.patch
+++ b/recipes-extended/xen/files/0001-convert-block-tap-for-shared.patch
@@ -412,7 +412,7 @@ xenmgr to allow tapdisk to unlock encrypted VHDs.
      if ! tap-ctl check >& /dev/null ; then
  	fatal "Blocktap kernel module not available"
      fi
-@@ -81,23 +81,124 @@ find_device()
+@@ -81,23 +81,126 @@ find_device()
      done
  
      if [ -z "$pid" ] || [ -z "$minor" ]; then
@@ -511,6 +511,8 @@ xenmgr to allow tapdisk to unlock encrypted VHDs.
 +
 +    if [ "$mode" = "r" ]; then
 +        tap_opts="-R"
++    else
++        tap_opts="-W"
 +    fi
 +
 +    claim_lock "block"

--- a/recipes-openxt/vhd-scripts/vhd-scripts/vhd-copy
+++ b/recipes-openxt/vhd-scripts/vhd-scripts/vhd-copy
@@ -84,7 +84,7 @@ trap atexit EXIT
 
 size=$(vhd-util query -n $srcvhd -v)
 [ $? -eq 0 ] || error couldn\'t query size of src $srcvhd
-srctap=$(TAPDISK2_CRYPTO_KEYDIR="$srckeydir" TAPDISK3_CRYPTO_KEYDIR="$srckeydir" tap-ctl create -a "vhd:$srcvhd")
+srctap=$(TAPDISK2_CRYPTO_KEYDIR="$srckeydir" TAPDISK3_CRYPTO_KEYDIR="$srckeydir" tap-ctl create -R -a "vhd:$srcvhd")
 [ $? -eq 0 ] || error couldn\'t open src $srcvhd
 vhd-util create -n $destvhd -s $size
 [ $? -eq 0 ] || error couldn\'t create dest $destvhd
@@ -105,7 +105,7 @@ then
   [ "$destkey" ] || error couldn\'t find key for $destvhd in $destkeydir
 fi
 
-desttap=$(TAPDISK2_CRYPTO_KEYDIR="$destkeydir" TAPDISK3_CRYPTO_KEYDIR="$destkeydir" tap-ctl create -a "vhd:$destvhd")
+desttap=$(TAPDISK2_CRYPTO_KEYDIR="$destkeydir" TAPDISK3_CRYPTO_KEYDIR="$destkeydir" tap-ctl create -W -a "vhd:$destvhd")
 [ $? -eq 0 ] || error couldn\'t open dest $destvhd
 
 vhd-util read -n $srcvhd -e 0 -c $(($size*1024*2)) | while read s c

--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/create-ndvm
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/create-ndvm
@@ -71,7 +71,7 @@ xec -o "$VM" set icbinn-path "/config/certs/$NAME" ||
 VHD=$(xec create-vhd 256) ||
     die "failed to create swap VHD"
 
-DEV=$(tap-ctl create -a "vhd:$VHD") ||
+DEV=$(tap-ctl create -W -a "vhd:$VHD") ||
     die "failed to open swap VHD"
 
 mkswap "$DEV" > /dev/null ||

--- a/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/firstboot.sh
+++ b/recipes-openxt/xenclient-dom0-tweaks/xenclient-dom0-tweaks/firstboot.sh
@@ -157,17 +157,17 @@ if [ -r ${INSTALL_CONF}/uivm-gconf,aes-xts-plain,256.key ] ; then
     mv ${INSTALL_CONF}/uivm-gconf,aes-xts-plain,256.key ${KEY_FOLDER}
     restore -r ${KEY_FOLDER}
     # Setup the filesystem
-    UIVM_GCONF_DEV=`TAPDISK2_CRYPTO_KEYDIR=/config/platform-crypto-keys TAPDISK3_CRYPTO_KEYDIR=/config/platform-crypto-keys tap-ctl create -a "vhd:/storage/uivm/uivm-gconf.vhd"`
+    UIVM_GCONF_DEV=`TAPDISK2_CRYPTO_KEYDIR=/config/platform-crypto-keys TAPDISK3_CRYPTO_KEYDIR=/config/platform-crypto-keys tap-ctl create -W -a "vhd:/storage/uivm/uivm-gconf.vhd"`
     mkfs.ext3 -q "${UIVM_GCONF_DEV}"
     tune2fs -i 0 -c -1 -m 0 "${UIVM_GCONF_DEV}"
     tap-ctl destroy -d "${UIVM_GCONF_DEV}"
 fi
 
-NDVM_SWAP_DEV=`tap-ctl create -a "vhd:/storage/ndvm/ndvm-swap.vhd"`
+NDVM_SWAP_DEV=`tap-ctl create -W -a "vhd:/storage/ndvm/ndvm-swap.vhd"`
 mkswap "${NDVM_SWAP_DEV}"
 tap-ctl destroy -d "${NDVM_SWAP_DEV}"
 
-UIVM_SWAP_DEV=`tap-ctl create -a "vhd:/storage/uivm/uivm-swap.vhd"`
+UIVM_SWAP_DEV=`tap-ctl create -W -a "vhd:/storage/uivm/uivm-swap.vhd"`
 mkswap "${UIVM_SWAP_DEV}"
 tap-ctl destroy -d "${UIVM_SWAP_DEV}"
 


### PR DESCRIPTION
Change the default for `tap-ctl create` to read-only, the former -R option.  Add a new -W option to use when read-write is desired.

Now that tap-ctl defaults to read-only, we need to specify -W when opening writable .vhds.  For the read-only cases, explicity add -R to highlight the use.

OpenXT is changing to hash .vhds directly.  To do so, we need to only open .vhds as read-only as read-write can modify the metadata even if the contents do not change.  To avoid user error, default to read-only so explicit action is needed which will potentially modify the .vhd.