### PR TITLE
Add grub-xen-pvh & grub-xen-pv64

### DIFF
--- a/recipes-bsp/grub/files/grub-xen.cfg
+++ b/recipes-bsp/grub/files/grub-xen.cfg
@@ -1,0 +1,30 @@
+insmod part_msdos
+insmod part_gpt
+insmod search
+insmod configfile
+insmod legacycfg
+if search -s root -f /boot/grub2/grub.cfg ; then
+  echo "Reading ${root}/boot/grub2/grub.cfg"
+  configfile /boot/grub2/grub.cfg
+elif search -s root -f /boot/grub/menu.lst ; then
+  legacy_configfile /boot/grub/menu.lst
+elif search -s root -f /grub2/grub.cfg ; then
+  echo "Reading ${root}/grub2/grub.cfg"
+  configfile /grub2/grub.cfg
+elif search -s root -f /grub/menu.lst ; then
+  legacy_configfile /grub/menu.lst
+elif search -s root -f /boot/bzImage ; then
+  echo loading /boot/bzImage
+  linux /boot/bzImage ro console=hvc0 root=/dev/xvda1
+  if search -s root -f /boot/initrd ; then
+    initrd /boot/initrd
+  fi
+  boot
+elif search -s root -f /bzImage ; then
+  echo loading /bzImage
+  linux /bzImage ro console=hvc0 root=/dev/xvda1
+  if search -s root -f /initrd ; then
+    initrd /initrd
+  fi
+  boot
+fi

--- a/recipes-bsp/grub/grub-xen-conf.bb
+++ b/recipes-bsp/grub/grub-xen-conf.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Basic grub.cfg for PVH/PV domains"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6 \
+"
+
+APPEND ??= "root=/dev/xvda1 ro console=hvc0"
+# Make sure the package is machine specific since it uses APPEND
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d "${D}/boot/grub2"
+
+    echo "default=boot" > "${D}/boot/grub2/grub.cfg"
+    echo "timeout=0" >> "${D}/boot/grub2/grub.cfg"
+    echo "menuentry 'boot' {" >> "${D}/boot/grub2/grub.cfg"
+    echo "linux /boot/${KERNEL_IMAGETYPE} ${APPEND}" >> "${D}/boot/grub2/grub.cfg"
+    echo "}" >> "${D}/boot/grub2/grub.cfg"
+}
+
+FILES_${PN} = "/boot"

--- a/recipes-bsp/grub/grub-xen-pv64_2.04.bb
+++ b/recipes-bsp/grub/grub-xen-pv64_2.04.bb
@@ -1,0 +1,4 @@
+require grub-xen.inc
+GRUBPLATFORM = "xen"
+GRUB_TARGET = "x86_64"
+GRUBEXT = "${GRUBPLATFORM}-pv64"

--- a/recipes-bsp/grub/grub-xen-pvh_2.04.bb
+++ b/recipes-bsp/grub/grub-xen-pvh_2.04.bb
@@ -1,0 +1,4 @@
+require grub-xen.inc
+GRUBPLATFORM = "xen_pvh"
+GRUB_TARGET = "i386"
+GRUBEXT = "xen-pvh"

--- a/recipes-bsp/grub/grub-xen.inc
+++ b/recipes-bsp/grub/grub-xen.inc
@@ -1,0 +1,65 @@
+# Hack to work around grub2.inc settings SRC_URI
+# OE_CORE_PATH defaults to a bordel build layout
+OE_CORE_PATH ?= "${TOPDIR}/layers/openembedded-core"
+FILESEXTRAPATHS_prepend := "${OE_CORE_PATH}/meta/recipes-bsp/grub/files:"
+require recipes-bsp/grub/grub2.inc
+
+require conf/image-uefi.conf
+
+# Need to be disabled otherwise there are wint_t type not defined errors
+SECURITY_CFLAGS = ""
+
+DEPENDS_append_class-target = " grub-efi-native"
+RDEPENDS_${PN}_class-target = "grub-common virtual/grub-bootconf"
+
+SRC_URI += " \
+	file://grub-xen.cfg \
+"
+
+S = "${WORKDIR}/grub-${PV}"
+
+CACHED_CONFIGUREVARS += "ac_cv_path_HELP2MAN="
+EXTRA_OECONF += "--enable-efiemu=no"
+
+GRUBPLATFORM ?= "xen"
+GRUB_TARGET ?= "x86_64"
+GRUBEXT ?= "${GRUBPLATFORM}-pvh"
+GRUB_BINARY = "grub-${GRUBEXT}"
+
+PACKAGECONFIG="device-mapper"
+
+GRUB_BUILDIN ?= "linux ext2 fat part_msdos part_gpt normal \
+                 iso9660 configfile search loadenv test \
+                 echo legacycfg memdisk tar gzio"
+
+do_mkimage() {
+	cd ${B}
+	# The early.cfg is limited, so it loads a full config from memdisk
+	echo "normal (memdisk)/grub-xen.cfg" > grub-bootstrap.cfg
+	# The memdisk config searches for a grub.cfg on the local boot media,
+	# or falls back to loading bzImage
+	tar -c -C ${WORKDIR} -f ${B}/memdisk.tar grub-xen.cfg
+	tar tf memdisk.tar
+	grub-mkimage -c grub-bootstrap.cfg -p / -d ./grub-core/ \
+	               -O ${GRUB_TARGET}-${GRUBPLATFORM} \
+	               -o ./${GRUB_BINARY} \
+	               -m memdisk.tar \
+	               ${GRUB_BUILDIN}
+}
+
+addtask mkimage before do_install after do_compile
+
+do_mkimage_class-native() {
+	:
+}
+
+do_install_class-target() {
+    install -d "${D}${libdir}/xen/boot"
+    install -m 644 "${GRUB_BINARY}" "${D}${libdir}/xen/boot"
+    ln -s "${GRUB_BINARY}" "${D}${libdir}/xen/boot/${GRUB_BINARY}.bin"
+}
+
+FILES_${PN} = "${libdir}/xen/boot"
+
+# grub.xen_pvh is a 32bit binary, so it may not match.
+INSANE_SKIP_${PN} += "arch"

--- a/recipes-core/images/xenclient-ndvm-image.bb
+++ b/recipes-core/images/xenclient-ndvm-image.bb
@@ -66,6 +66,7 @@ IMAGE_INSTALL = " \
     iputils-ping \
     dbd-tools-vm \
     xen-vif-scripts-ndvm \
+    grub-xen-conf \
 "
 
 require xenclient-version.inc

--- a/recipes-core/images/xenclient-syncvm-image.bb
+++ b/recipes-core/images/xenclient-syncvm-image.bb
@@ -40,6 +40,7 @@ IMAGE_INSTALL = "\
     sync-client \
     xenclient-syncvm-tweaks \
     blktap3 \
+    grub-xen-conf \
 "
 
 require xenclient-version.inc

--- a/recipes-core/images/xenclient-uivm-image.bb
+++ b/recipes-core/images/xenclient-uivm-image.bb
@@ -97,6 +97,7 @@ IMAGE_INSTALL += "\
     matchbox-keyboard \
     matchbox-keyboard-im \
     kernel-module-openxtfb \
+    grub-xen-conf \
 "
 
 require xenclient-version.inc

--- a/recipes-openxt/manager/xenmgr_git.bb
+++ b/recipes-openxt/manager/xenmgr_git.bb
@@ -73,6 +73,8 @@ RDEPENDS_${PN} += " \
     heimdallr \
     bash \
     openssl-bin \
+    grub-xen-pv64 \
+    grub-xen-pvh \
 "
 
 INITSCRIPT_NAME = "xenmgr"


### PR DESCRIPTION
This switches to using grub as a PVH/PV64 boot loader for booting VMs.  It removes extracting kernels from disk images, though that functionality still remains.

grub2 doesn't support a 32bit version, and PV32 shouldn't be used these days, AFAIUI.

https://github.com/OpenXT/manager/pull/205 changes the templates to use grub-xen-pvh/pv64.  I think this could go in first without the templates change and things would keep working.