### PR TITLE
grub-xen: Fix binary layout to avoid faulting

### DIFF
--- a/recipes-bsp/grub/grub-xen.inc
+++ b/recipes-bsp/grub/grub-xen.inc
@@ -9,6 +9,11 @@ require conf/image-uefi.conf
 # Need to be disabled otherwise there are wint_t type not defined errors
 SECURITY_CFLAGS = ""
 
+# Prevent generation of .text.unlikely which would be placed ahead of the
+# expected _start at the beginning of the .text section.  .text.unlikely
+# would then get executed and fault.
+CFLAGS_append = "-fno-reorder-functions"
+
 DEPENDS_append_class-target = " grub-efi-native"
 RDEPENDS_${PN}_class-target = "grub-common virtual/grub-bootconf"
 


### PR DESCRIPTION
After the recent grub updates in oe-core, we have faults on startup in the two pv-grubs.

grub-xen-pv64:
(XEN) d17v0 Unhandled invalid opcode fault/trap [#6, ec=ffffffff] (XEN) domain_crash_sync called from entry.S: fault at ffff82d0402fdfc8 x86_64/entry.S#create_bounce_frame+0x14f/0x167

grub-xen-pvh:
(XEN) MMIO emulation failed (1): d13v0 32bit @ 0000:ffffffff ->
(XEN) d13v0 Triple fault - invoking HVM shutdown action 1

GCC is generating a .text.unlikely section with terminate_arg.cold(), and that is placed ahead of the normal _start code in the text segment. The entry points still point at the beginning of the text segment, which faults as it is terminate_arg.cold().

Passing -fno-reorder-functions inhibits use of .text.unlikely, so terminate_arg.cold() is left in the main .text section.  This leaves _start at the beginning of the text segment and things work as expected.