### PR TITLE
xen-vif-scripts-ndvm: Trim down the script

### DIFF
--- a/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm/vif
+++ b/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm/vif
@@ -17,95 +17,16 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-TYPE=`echo ${XENBUS_PATH} | cut -f 2 -d '/'`
-DOMID=`echo ${XENBUS_PATH} | cut -f 3 -d '/'`
-DEVID=`echo ${XENBUS_PATH} | cut -f 4 -d '/'`
-
-XAPI=/xapi/${DOMID}/hotplug/${TYPE}/${DEVID}
-
 case "$1" in
     online)
         if [ "x${vif}" = "x" ]; then
             exit
         fi
-        xenstore-write "${XAPI}/vif" "${vif}"
-        xenstore-write "${XAPI}/hotplug" "online"
-        UUID=
-        for i in `xenstore-list /xenmgr/vms`; do
-            if [ "x`xenstore-read /xenmgr/vms/$i/domid`" = "x${DOMID}" ]; then
-                UUID=$i
-                break;
-            fi
-        done
-        FW_CONFIG=
-        if [ ! -z $UUID ]; then
-            FW_CONFIG="/vm/${UUID}/config/nic/${DEVID}/firewall-rules"
-        fi
-
-        iptables -N INPUT_${vif}
-        iptables -N FORWARD_${vif}
-        iptables -A INPUT_vifs -m physdev --physdev-in ${vif} -j INPUT_${vif}
-        iptables -A FORWARD_vifs -m physdev --physdev-in ${vif} -j FORWARD_${vif}
-
-        treat_rule()
-        {
-            OCMD=`db-read-dom0 $1/cmd`
-            OTYPE=`db-read-dom0 $1/type`
-            RTYPE=INPUT_${vif}
-            RCMD=`echo $OCMD | tr '[:lower:]' '[:upper:]'`
-            PORT=`db-read-dom0 $1/port`
-            IP=`db-read-dom0 $1/ip`
-            PROTOCOL=`db-read-dom0 $1/protocol`
-            EXTRA=''
-
-            if [ ! -z $PROTOCOL ]; then
-                PROTOCOL=`echo $PROTOCOL | tr '[:lower:]' '[:upper:]'`
-                EXTRA="--protocol $PROTOCOL"
-            fi
-
-            case `echo $OTYPE | tr '[:upper:]' '[:lower:]'` in
-                input)
-                    RTYPE=INPUT_${vif}
-                    if [ ! -z $PORT ]; then
-                        EXTRA="$EXTRA --source-port $PORT"
-                    fi
-                    if [ ! -z $IP ]; then
-                        EXTRA="$EXTRA --source $IP"
-                    fi
-                    ;;
-                output)
-                    RTYPE=FORWARD_${vif}
-                    if [ ! -z $PORT ]; then
-                        EXTRA="$EXTRA --destination-port $PORT"
-                    fi
-                    if [ ! -z $IP ]; then
-                        EXTRA="$EXTRA --destination $IP"
-                    fi
-                    ;;
-            esac
-
-            iptables -A $RTYPE $EXTRA -j $RCMD
-        }
-
-        if [ ! -z $FW_CONFIG ]; then
-            for i in `db-nodes-dom0 $FW_CONFIG`; do
-                treat_rule $FW_CONFIG/$i
-            done
-        fi
-        #end firewall
 
         xenstore-write "${XENBUS_PATH}/hotplug-status" "connected"
         ;;
 
     offline)
-        xenstore-rm "${XAPI}/hotplug"
-
-        iptables -D INPUT_vifs -m physdev --physdev-in ${vif} -j INPUT_${vif}
-        iptables -D FORWARD_vifs -m physdev --physdev-in ${vif} -j FORWARD_${vif}
-        iptables -F INPUT_${vif}
-        iptables -F FORWARD_${vif}
-        iptables -X INPUT_${vif}
-        iptables -X FORWARD_${vif}
         ;;
 esac
 


### PR DESCRIPTION
When this vif script runs, it can race with network-slave with both executing iptables commands.  iptables tries to grab a lock to synchronize access, but by default it fails the command if the lock cannot be grabbed:
"Another app is currently holding the xtables lock." "Perhaps you want to use the -w option?"

The `-w` flag to iptables makes it wait for the lock.  This is important so we don't lose iptables commands that define chains used for other commands.  For instance, this was seen:
network-slave: exception: "cannot add rule -A FORWARD -i brbridged -o brbridged -m physdev --physdev-in eth0 -j FORWARD_brbridged : iptables v1.8.4 (legacy): Couldn't load target FORWARD_brbridged':No such file or directory\n\nTry iptables -h' or 'iptables --help' for more information.\n" while processing RPC "configure"

The vif script could gain `-w` for all of the iptables commands, but in fact it is basically unused.

The firewall stuff is actually handled by network-slave.  xenmgr writes to:
/vm/$UUID/firewall-rules/$num/
While ndvm tries to read from:
/vm/$UUID/config/nic/$devid/firewall-rules/$num

ndvm can't access that top-level path since it gets constrained to it's own subtree (/vm/$ndvm_uuid).

network-daemon will write from /vm/$UUID/firewall-rules/$num/ into the NDVM's /vm/$ndvm_uuid/firewall-rules/$guest_uuid/$devid and network-slave will pick those up.

INPUT_vifs and FORWARD_vifs don't exist, so the can never be appended to.

INPUT_${vif} and FORWARD_${vif} don't get used by anything else.

network-slave already create FORWARD_${vif}_{IN,OUT} for its own use.

So all the firewall and iptables stuff can be removed.

The XAPI stuff is legacy and not used by anymore.  Remove it as well.

Goes with https://github.com/OpenXT/network/pull/28