### PR TITLE
[ndvm] Drop rules file for vif scripts

### DIFF
--- a/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm_1.0.bb
+++ b/recipes-openxt/xen-vif-scripts/xen-vif-scripts-ndvm_1.0.bb
@@ -4,7 +4,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1;md5=1a6d268fd218675ffe
 
 SRC_URI = " \
     file://vif \
-    file://xen-vif-backend.rules \
 "
 
 S = "${WORKDIR}"
@@ -14,7 +13,6 @@ inherit allarch
 do_install() {
     install -m 0755 -d ${D}${sysconfdir}/udev
     install -m 0755 -d ${D}${sysconfdir}/udev/rules.d
-    install -m 0644 ${S}/xen-vif-backend.rules ${D}${sysconfdir}/udev/rules.d/xen-vif-backend.rules
 
     install -m 0755 -d ${D}${sysconfdir}/xen/scripts
     install -m 0755 ${S}/vif ${D}${sysconfdir}/xen/scripts/vif


### PR DESCRIPTION
  Commit c3a29af664ff9b6359845038e123d39d914a434f removed
  xen-vif-backend.rules from xenclient-oe, it also needs to be
  removed from this recipe.