### PR TITLE
Fix installer efivarfs mounting and drop efivars from fstab

### DIFF
--- a/recipes-core/base-files/files/openxt-installer/fstab
+++ b/recipes-core/base-files/files/openxt-installer/fstab
@@ -8,5 +8,3 @@ rootfs      /                           auto        rw,defaults,noatime         
 
 securityfs  /sys/kernel/security        securityfs  defaults                                0 0
 xenfs       /proc/xen                   xenfs       defaults                                0 0
-
-efivarfs    /sys/firmware/efi/efivars   efivarfs    rw,nosuid,nodev,noexec,noatime,nofail   0 0

--- a/recipes-core/base-files/files/xenclient-dom0/fstab
+++ b/recipes-core/base-files/files/xenclient-dom0/fstab
@@ -40,8 +40,3 @@ cgroup                         /sys/fs/cgroup          cgroup      defaults     
 /dev/mapper/xenclient-boot     /boot/system            ext4        errors=remount-ro,noatime                                                       1 4
 /dev/mapper/xenclient-storage  /storage                ext4        errors=remount-ro,user_xattr,noatime                                            1 5
 /dev/mapper/swap               none                    swap        sw                                                                              0 0
-
-# OpenXT: The following mount will fail on non-UEFI installs.
-# For some reason, at boot time, that usually results in the rest of this file getting ignored.
-# Having it be the last one makes it a non-issue.
-efivarfs                       /sys/firmware/efi/efivars efivarfs  ro,nosuid,nodev,noexec,noatime                                                  0 0

--- a/recipes-core/initscripts/initscripts-1.0/mountefi.sh
+++ b/recipes-core/initscripts/initscripts-1.0/mountefi.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -d /sys/firmware/efi ] ; then
+    mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+fi

--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -11,6 +11,10 @@ SRC_URI += " \
     file://volatiles \
 "
 
+SRC_URI_append_openxt-installer += " \
+    file://mountefi.sh \
+"
+
 # Override to reduce the number of scripts installed
 do_install () {
 #
@@ -74,6 +78,11 @@ do_install () {
 	update-rc.d -r ${D} finish.sh start 99 S .
 	update-rc.d -r ${D} mountearly.sh start 01 S .
 	update-rc.d -r ${D} udev-volatiles.sh start 03 S .
+}
+
+do_install_append_openxt-installer() {
+	install -m 0755    ${WORKDIR}/mountefi.sh	${D}${sysconfdir}/init.d
+	update-rc.d -r ${D} mountefi.sh start 36 S .
 }
 
 pkg_postinst_${PN}_append() {


### PR DESCRIPTION
Installation is currently broken (after the Linux 6.1 uprev I believe) because efivarfs is not mounted, so efibootmgr fails to write the boot variables.

The first patch fixes the problem.  It manually mounts efivarfs for the installer.

The second patch removes efivarfs from /etc/fstab.  dom0's is mounted early in /init from the initramfs-framework.  With the first patch, the installer manually mounts it in the same fashion.  The fstab entries are therefore unnecessary.  They were always problematic on legacy boots, so just drop them from fstab.

If the second patch is deemed unnecessary, then only the first patch can be taken to fix the issue.