### PR TITLE
varstored/refpolicy: Fix auth files location

### DIFF
--- a/recipes-core/varstored/varstored_git.bb
+++ b/recipes-core/varstored/varstored_git.bb
@@ -82,7 +82,7 @@ do_install() {
     install -d ${D}/usr/bin
     install -m 0755 ${S}/tools/varstore-{get,set,ls,rm,sb-state} ${D}/usr/bin
 
-    install -d ${D}/usr/share/varstored
-    install -m 0755 ${S}/{PK.auth,KEK.auth,db.auth} ${D}/usr/share/varstored
-    install -m 0755 ${WORKDIR}/dbx.auth ${D}/usr/share/varstored
+    install -d ${D}/var/lib/varstored
+    install -m 0755 ${S}/{PK.auth,KEK.auth,db.auth} ${D}/var/lib/varstored
+    install -m 0755 ${WORKDIR}/dbx.auth ${D}/var/lib/varstored
 }

--- a/recipes-security/refpolicy/refpolicy-mcs/policy/modules/system/stubdom-helpers.fc
+++ b/recipes-security/refpolicy/refpolicy-mcs/policy/modules/system/stubdom-helpers.fc
@@ -24,4 +24,4 @@
 
 /usr/sbin/varstored            --      gen_context(system_u:object_r:varstored_exec_t,s0)
 /usr/sbin/varstored-watch      --      gen_context(system_u:object_r:varstored_watch_exec_t,s0)
-/usr/share/varstored(/.*)?             gen_context(system_u:object_r:varstored_auth_t,s0)
+/var/lib/varstored(/.*)?               gen_context(system_u:object_r:varstored_auth_t,s0)

--- a/recipes-security/refpolicy/refpolicy-mcs/policy/modules/system/stubdom-helpers.te
+++ b/recipes-security/refpolicy/refpolicy-mcs/policy/modules/system/stubdom-helpers.te
@@ -171,7 +171,8 @@ xen_stream_connect_xenstore(varstored_watch_t)
 logging_send_syslog_msg(varstored_t)
 logging_send_syslog_msg(varstored_watch_t)
 
-# accessing EFI auth files (/usr/share/varstored)
+# accessing EFI auth files (/var/lib/varstored)
+files_search_var_lib(varstored_t)
 allow varstored_t varstored_auth_t:dir search_dir_perms;
 allow varstored_t varstored_auth_t:file read_file_perms;
 


### PR DESCRIPTION
With the uprev of varstored, the location of the auth files moved to /var/lib/varstored.  Update the installation and refpolicy to accomodate.

Without this, varstored logs:
Auth file '/var/lib/varstored/dbx.auth' is missing! Auth file '/var/lib/varstored/db.auth' is missing! Auth file '/var/lib/varstored/KEK.auth' is missing! Auth file '/var/lib/varstored/PK.auth' is missing!