### PR TITLE
libxl/blktap integration

### DIFF
--- a/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
+++ b/recipes-core/packagegroups/packagegroup-xenclient-dom0.bb
@@ -105,6 +105,7 @@ RDEPENDS_${PN} = " \
     tpm2-tss \
     tpm2-tools \
     blktap3 \
+    tapback \
     pesign \
     ipxe \
     udev-extraconf-dom0 \

--- a/recipes-extended/qemu-dm/qemu-dm/block-remove-unused-block-format-support.patch
+++ b/recipes-extended/qemu-dm/qemu-dm/block-remove-unused-block-format-support.patch
@@ -76,11 +76,3 @@ PATCHES:
  block-obj-$(CONFIG_PARALLELS) += parallels.o
  block-obj-y += blklogwrites.o
  block-obj-y += block-backend.o snapshot.o qapi.o
-@@ -24,6 +29,6 @@ block-obj-y += throttle-groups.o
- block-obj-$(CONFIG_LINUX) += nvme.o
- 
--block-obj-y += nbd.o
-+block-obj-n += nbd.o
- block-obj-$(CONFIG_SHEEPDOG) += sheepdog.o
- block-obj-$(CONFIG_LIBISCSI) += iscsi.o
- block-obj-$(if $(CONFIG_LIBISCSI),y,n) += iscsi-opts.o

--- a/recipes-extended/xen/blktap3.bb
+++ b/recipes-extended/xen/blktap3.bb
@@ -26,6 +26,9 @@ SRC_URI = "git://github.com/xapi-project/blktap.git;protocol=https \
     file://gcc9-compilation.patch \
     file://openssl-1.1.x.patch \
     file://0001-tap-ctl-Default-to-read-only-opening.patch \
+    file://0001-tapback-Add-l-libxl-compatibility-mode.patch \
+    file://0002-tapback-Move-backend-to-InitWait-earlier.patch \
+    file://0003-tapback-Don-t-remove-xenstore-backend-in-libxl-mode.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/xen/blktap3/0001-tapback-Add-l-libxl-compatibility-mode.patch
+++ b/recipes-extended/xen/blktap3/0001-tapback-Add-l-libxl-compatibility-mode.patch
@@ -1,0 +1,125 @@
+From 63f3883abe1f94a85428e17e98fe0dbe15606b0b Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Thu, 25 Jan 2024 08:22:55 -0500
+Subject: [PATCH 1/3] tapback: Add -l/--libxl compatibility mode
+
+libxl and xapi/xenopsd have different ordering requirements, and the
+libxl required changes are not readily compatible with xapi.
+
+Add a flag to allow running in libxl compatibility mode to bodge around
+the issue.  The flag has to be passed from the parent tapback process
+into the per-domain ones to ensure it is respected.
+
+Some nearby hard tabs are converted to spaces.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tapback/backend.c |  8 +++++---
+ tapback/tapback.c | 17 ++++++++++++++---
+ tapback/tapback.h | 10 ++++++++++
+ 3 files changed, 29 insertions(+), 6 deletions(-)
+
+diff --git a/tapback/backend.c b/tapback/backend.c
+index facae9b..cb607b1 100644
+--- a/tapback/backend.c
++++ b/tapback/backend.c
+@@ -1197,7 +1197,7 @@ tapback_backend_handle_backend_watch(backend_t *backend,
+                  * FIXME Shall we watch the child process?
+                  */
+             } else { /* child */
+-                char *args[7];
++                char *args[8];
+                 int i = 0;
+ 
+                 args[i++] = (char*)tapback_name;
+@@ -1211,8 +1211,10 @@ tapback_backend_handle_backend_watch(backend_t *backend,
+                 }
+                 if (log_level == LOG_DEBUG)
+                     args[i++] = "-v";
+-				if (!backend->barrier)
+-					args[i++] = "-b";
++                if (!backend->barrier)
++                    args[i++] = "-b";
++                if (libxl_mode())
++                    args[i++] = "--libxl";
+                 args[i] = NULL;
+                 /*
+                  * TODO we're hard-coding the name of the binary, better let
+diff --git a/tapback/tapback.c b/tapback/tapback.c
+index fe04d17..6a3098f 100644
+--- a/tapback/tapback.c
++++ b/tapback/tapback.c
+@@ -58,6 +58,7 @@
+ const char tapback_name[] = "tapback";
+ unsigned log_level;
+ int tapdev_major;
++static bool opt_libxl_mode;
+ 
+ struct list_head backends = LIST_HEAD_INIT(backends);
+ 
+@@ -77,6 +78,12 @@ char *xenbus_strstate(const XenbusState xbs)
+     return str[xbs];
+ }
+ 
++bool
++libxl_mode(void)
++{
++    return opt_libxl_mode;
++}
++
+ /**
+  * Read changes that occurred on the "backend/<backend name>" XenStore path
+  * or one of the front-end paths and act accordingly.
+@@ -513,7 +520,8 @@ usage(FILE * const stream, const char * const prog)
+ 			"\t[-h|--help]\n"
+             "\t[-v|--verbose]\n"
+ 			"\t[-b]--nobarrier]\n"
+-            "\t[-n|--name]\n", prog);
++            "\t[-n|--name]\n"
++            "\t[-l|--libxl]\n", prog);
+ }
+ 
+ extern char *optarg;
+@@ -612,8 +620,8 @@ int main(int argc, char **argv)
+             {"name", 0, NULL, 'n'},
+             {"pidfile", 0, NULL, 'p'},
+             {"domain", 0, NULL, 'x'},
+-			{"nobarrier", 0, NULL, 'b'},
+-
++            {"nobarrier", 0, NULL, 'b'},
++            {"libxl", 0, NULL, 'l'},
+         };
+         int c;
+ 
+@@ -628,6 +636,9 @@ int main(int argc, char **argv)
+         case 'd':
+             opt_debug = true;
+             break;
++        case 'l':
++            opt_libxl_mode = true;
++            break;
+         case 'v':
+             opt_verbose = true;
+             break;
+diff --git a/tapback/tapback.h b/tapback/tapback.h
+index 9bde55d..f106f25 100644
+--- a/tapback/tapback.h
++++ b/tapback/tapback.h
+@@ -524,4 +524,14 @@ tapback_backend_destroy(backend_t *backend);
+ 
+ bool verbose(void);
+ 
++/**
++ * Indicates when tapback is running in libxl compatibility mode.  libxl needs
++ * backends to transition to InitWait earlier than xapi/xenopds.
++ *
++ * Returns true if tapback is running in libxl compatibility mode and false
++ * otherwise.
++ */
++bool
++libxl_mode(void);
++
+ #endif /* __TAPBACK_H__ */
+-- 
+2.43.0
+

--- a/recipes-extended/xen/blktap3/0002-tapback-Move-backend-to-InitWait-earlier.patch
+++ b/recipes-extended/xen/blktap3/0002-tapback-Move-backend-to-InitWait-earlier.patch
@@ -1,0 +1,86 @@
+From 726cdd1e45ed155af48b9b433492a0e427256b65 Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Fri, 8 Dec 2023 13:17:20 -0500
+Subject: [PATCH 2/3] tapback: Move backend to InitWait earlier
+
+This is needed for libxl integration.
+
+tapdisk waits to transition to InitWait until after "hotplug-status" is
+connected.  However libxl doesn't run its hotplug scripts, which write
+"hotplug-status", until the backend transitions to InitWait.  With both
+sides waiting, progress is not made and connecting the blktap device
+times out and fails.
+
+Make tapback transition to InitWait earlier to resolve this issue under
+libxl.  Place the transition to InitWait in
+tapback_backend_create_device() after the xenstore feature nodes have
+been written.  InitWait is a signal to the frontend that such nodes have
+been written.  This matches blkback's behaviour.  It should also be fine
+since tapback still won't advance to Connected without the other setup
+like physical-device-path and hotplug-status.
+
+VBDs can be reconnected.  When pv-grub is used, it connects the VBD,
+loads the kernel, disconnects the VBD.  It then re-sets the frontend
+state to XenbusStateInitialising so that the new kernel will find and
+connect the VBD.
+
+tapback and blkback handle this case differently.  When blkback observes
+the frontend transition to XenbusStateInitialising, and the backend is
+XenbusStateClosed, the backend transitions to XenbusStateInitWait.
+
+When tapback observes the frontend transition to
+XenbusStateInitialising, the backend checks for hotplug_status_connected
+to be true before switching XenbusStateInitWait.  For tapback, this
+serves a second purpose for setting XenbusStateInitWait initially as
+well.
+
+Use libxl_mode() to determine whether to transition to InitWait sooner.
+Leave the hotplug_status_connected check since that should work fine for
+either even through it may be an extra watch firing for libxl.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tapback/backend.c  | 11 +++++++++++
+ tapback/frontend.c |  4 ++--
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/tapback/backend.c b/tapback/backend.c
+index cb607b1..0494f15 100644
+--- a/tapback/backend.c
++++ b/tapback/backend.c
+@@ -259,6 +259,17 @@ tapback_backend_create_device(backend_t *backend,
+         goto out;
+     }
+ 
++    if (libxl_mode()) {
++        /* In libxl_mode, after tapback has written it's capabilities to
++         * XenStore, switch to InitWait. */
++        err = xenbus_switch_state(device, XenbusStateInitWait);
++        if (unlikely(err)) {
++            WARN(device, "failed to switch to XenbusStateInitWait: %s\n",
++                 strerror(-err));
++            goto out;
++        }
++    }
++
+ out:
+     if (err) {
+         WARN(NULL, "%s: error creating device: %s\n", name, strerror(-err));
+diff --git a/tapback/frontend.c b/tapback/frontend.c
+index e086813..1b68d88 100644
+--- a/tapback/frontend.c
++++ b/tapback/frontend.c
+@@ -439,8 +439,8 @@ frontend_changed(vbd_t * const device, const XenbusState state)
+ 
+     switch (state) {
+         case XenbusStateInitialising:
+-			if (device->hotplug_status_connected)
+-				err = xenbus_switch_state(device, XenbusStateInitWait);
++            if (device->hotplug_status_connected)
++                err = xenbus_switch_state(device, XenbusStateInitWait);
+             break;
+         case XenbusStateInitialised:
+     	case XenbusStateConnected:
+-- 
+2.43.0
+

--- a/recipes-extended/xen/blktap3/0003-tapback-Don-t-remove-xenstore-backend-in-libxl-mode.patch
+++ b/recipes-extended/xen/blktap3/0003-tapback-Don-t-remove-xenstore-backend-in-libxl-mode.patch
@@ -1,0 +1,52 @@
+From adaffa0a7dab4984570e72c49366a08474bc6f2e Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Thu, 25 Jan 2024 08:31:57 -0500
+Subject: [PATCH 3/3] tapback: Don't remove xenstore backend in libxl mode
+
+libxl doesn't clean up tapdisks because it doesn't call the hotplug
+cleanup scripts:
+libxl: debug: libxl_event.c:1043:devstate_callback: backend /local/domain/0/backend/vbd3/5/2048/state wanted state 6 but it was removed
+libxl: debug: libxl_event.c:849:libxl__ev_xswatch_deregister: watch w=0xf82ba0 wpath=/local/domain/0/backend/vbd3/5/2048/state token=1/2: deregister slotnum=1
+libxl: debug: libxl_device.c:1156:device_backend_callback: Domain 5:calling device_backend_cleanup
+libxl: debug: libxl_event.c:863:libxl__ev_xswatch_deregister: watch w=0xf82ba0: deregister unregistered
+libxl: error: libxl_device.c:1169:device_backend_callback: Domain 5:unable to remove device with path /local/domain/0/backend/vbd3/5/2048 - rc -6
+
+The backend state cannot be found because tapback deleted the entire
+backend subtree.
+
+In libxl mode, tapback shouldn't remove the backend nodes when the
+frontend is removed, because the nodes contain the information on how to
+clean up.  Leave the nodes and allowed them to be removed by the
+toolstack.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tapback/frontend.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/tapback/frontend.c b/tapback/frontend.c
+index 1b68d88..d5db62b 100644
+--- a/tapback/frontend.c
++++ b/tapback/frontend.c
+@@ -508,7 +508,7 @@ tapback_backend_handle_otherend_watch(backend_t *backend,
+      */
+ 	s = tapback_xs_read(device->backend->xs, XBT_NULL, "%s",
+ 			device->frontend_state_path);
+-    if (!s) {
++    if (!s && !libxl_mode()) {
+         err = errno;
+ 		/*
+          * If the front-end XenBus node is missing, the XenBus device has been
+@@ -531,6 +531,9 @@ tapback_backend_handle_otherend_watch(backend_t *backend,
+                 }
+             }
+ 		}
++    } else if (!s && libxl_mode()) {
++        WARN(device, "frontend disappeared!");
++        err = ENOENT;
+     } else {
+         state = strtol(s, &end, 0);
+         if (*end != 0 || end == s) {
+-- 
+2.43.0
+

--- a/recipes-extended/xen/blktap3/fix-run-time-errors-and-memory-leaks.patch
+++ b/recipes-extended/xen/blktap3/fix-run-time-errors-and-memory-leaks.patch
@@ -83,28 +83,6 @@ PATCHES
  			if (ret <= 0) {
  				err = errno;
  				break;
---- a/include/blktap.h
-+++ b/include/blktap.h
-@@ -32,7 +32,7 @@
- #define _TD_BLKTAP_H_
- 
- #define BLKTAP2_SYSFS_DIR              "/sys/class/blktap2"
--#define BLKTAP2_CONTROL_NAME           "blktap/control"
-+#define BLKTAP2_CONTROL_NAME           "blktap-control"
- #define BLKTAP2_CONTROL_DIR            "/var/run/blktap-control"
- #define BLKTAP2_CONTROL_SOCKET         "ctl"
- #define BLKTAP2_DIRECTORY              "/dev/xen/blktap-2"
---- a/include/blktap2.h
-+++ b/include/blktap2.h
-@@ -50,7 +50,7 @@
- #define BLKTAP2_IOCTL_REMOVE_DEVICE    207
- 
- #define BLKTAP2_SYSFS_DIR              "/sys/class/blktap2"
--#define BLKTAP2_CONTROL_NAME           "blktap/control"
-+#define BLKTAP2_CONTROL_NAME           "blktap-control"
- #define BLKTAP2_CONTROL_DIR            "/var/run/blktap-control"
- #define BLKTAP2_CONTROL_SOCKET         "ctl"
- #define BLKTAP2_DIRECTORY              "/dev/xen/blktap-2"
 --- a/tapback/frontend.c
 +++ b/tapback/frontend.c
 @@ -477,7 +477,7 @@ tapback_backend_handle_otherend_watch(ba

--- a/recipes-extended/xen/blktap3/fix-run-time-errors-and-memory-leaks.patch
+++ b/recipes-extended/xen/blktap3/fix-run-time-errors-and-memory-leaks.patch
@@ -83,59 +83,6 @@ PATCHES
  			if (ret <= 0) {
  				err = errno;
  				break;
---- a/tapback/frontend.c
-+++ b/tapback/frontend.c
-@@ -477,7 +477,7 @@ tapback_backend_handle_otherend_watch(ba
- {
-     vbd_t *device = NULL;
-     int err = 0, state = 0;
--    char *s = NULL, *end = NULL, *_path = NULL;
-+    char *s = NULL, *end = NULL;
- 
- 	ASSERT(backend);
-     ASSERT(path);
-@@ -508,30 +508,7 @@ tapback_backend_handle_otherend_watch(ba
-      */
- 	s = tapback_xs_read(device->backend->xs, XBT_NULL, "%s",
- 			device->frontend_state_path);
--    if (!s) {
--        err = errno;
--		/*
--         * If the front-end XenBus node is missing, the XenBus device has been
--         * removed: remove the XenBus back-end node.
--		 */
--		if (err == ENOENT) {
--            err = asprintf(&_path, "%s/%s/%d/%d", XENSTORE_BACKEND,
--                    device->backend->name, device->domid, device->devid);
--            if (err == -1) {
--                err = errno;
--                WARN(device, "failed to asprintf: %s\n", strerror(err));
--                goto out;
--            }
--            err = 0;
--            if (!xs_rm(device->backend->xs, XBT_NULL, _path)) {
--                if (errno != ENOENT) {
--                    err = errno;
--                    WARN(device, "failed to remove %s: %s\n", path,
--                            strerror(err));
--                }
--            }
--		}
--    } else {
-+    if(s) {
-         state = strtol(s, &end, 0);
-         if (*end != 0 || end == s) {
-             WARN(device, "invalid XenBus state '%s'\n", s);
-@@ -540,9 +517,7 @@ tapback_backend_handle_otherend_watch(ba
-             err = frontend_changed(device, state);
-     }
- 
--out:
-     free(s);
--    free(_path);
-     return err;
- }
- 
 --- a/tapback/tapback.c
 +++ b/tapback/tapback.c
 @@ -171,6 +171,7 @@ tapback_backend_destroy(backend_t *backe

--- a/recipes-extended/xen/blktap3/tapback.initscript
+++ b/recipes-extended/xen/blktap3/tapback.initscript
@@ -29,7 +29,7 @@
 DESC="Tapback"
 EXEC=/usr/bin/tapback
 PIDFILE="/var/run/tapback.pid"
-OPTS="-p $PIDFILE"
+OPTS="-p $PIDFILE --libxl"
 
 do_start() {
     start-stop-daemon --start --quiet --oknodo --pidfile "$PIDFILE" \

--- a/recipes-extended/xen/files/0001-block-common-Fix-same_vm-for-no-targets.patch
+++ b/recipes-extended/xen/files/0001-block-common-Fix-same_vm-for-no-targets.patch
@@ -1,0 +1,56 @@
+From 1eb266d3ac6df915a0fa2fb6e86d8f8cd1328ec9 Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Thu, 21 Dec 2023 15:42:57 -0500
+Subject: [PATCH 1/5] block-common: Fix same_vm for no targets
+
+same_vm is broken when the two main domains do not have targets.  otvm
+and targetvm are both missing, which means they get set to -1 and then
+converted to empty strings:
+
+++10697+ local targetvm=-1
+++10697+ local otvm=-1
+++10697+ otvm=
+++10697+ othervm=/vm/cc97bc2f-3a91-43f7-8fbc-4cb92f90b4e4
+++10697+ targetvm=
+++10697+ local frontend_uuid=/vm/844dea4e-44f8-4e3e-8145-325132a31ca5
+
+The final comparison returns true since the two empty strings match:
+
+++10697+ '[' /vm/844dea4e-44f8-4e3e-8145-325132a31ca5 = /vm/cc97bc2f-3a91-43f7-8fbc-4cb92f90b4e4 -o '' = /vm/cc97bc2f-3a91-43f7-8fbc-4cb92f90b4e4 -o /vm/844dea4e-44f8-4e3e-8145-325132a31ca5 = '' -o '' = '' ']'
+
+Replace -1 with distinct strings indicating the lack of a value and
+remove the collescing to empty stings.  The strings themselves will no
+longer match, and that is correct.
+
+++12364+ '[' /vm/844dea4e-44f8-4e3e-8145-325132a31ca5 = /vm/cc97bc2f-3a91-43f7-8fbc-4cb92f90b4e4 -o 'No target' = /vm/cc97bc2f-3a91-43f7-8fbc-4cb92f90b4e4 -o /vm/844dea4e-44f8-4e3e-8145-325132a31ca5 = 'No other target' -o 'No target' = 'No other target' ']'
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tools/hotplug/Linux/block-common.sh | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/tools/hotplug/Linux/block-common.sh b/tools/hotplug/Linux/block-common.sh
+index f86a88c4eb..5c80237d99 100644
+--- a/tools/hotplug/Linux/block-common.sh
++++ b/tools/hotplug/Linux/block-common.sh
+@@ -112,14 +112,12 @@ same_vm()
+                   "$FRONTEND_UUID")
+   local target=$(xenstore_read_default  "/local/domain/$FRONTEND_ID/target"   \
+                  "-1")
+-  local targetvm=$(xenstore_read_default "/local/domain/$target/vm" "-1")
++  local targetvm=$(xenstore_read_default "/local/domain/$target/vm" "No Target")
+   local otarget=$(xenstore_read_default  "/local/domain/$otherdom/target"   \
+                  "-1")
+   local otvm=$(xenstore_read_default  "/local/domain/$otarget/vm"   \
+-                 "-1")
+-  otvm=${otvm%-1}
+-  othervm=${othervm%-1}
+-  targetvm=${targetvm%-1}
++                 "No Other Target")
++
+   local frontend_uuid=${FRONTEND_UUID%-1}
+   
+   [ "$frontend_uuid" = "$othervm" -o "$targetvm" = "$othervm" -o \
+-- 
+2.43.0
+

--- a/recipes-extended/xen/files/0002-libxl-Add-support-for-blktap-vbd3.patch
+++ b/recipes-extended/xen/files/0002-libxl-Add-support-for-blktap-vbd3.patch
@@ -1,0 +1,189 @@
+From ab11447309a175fbad3c38930e145a63001c8c9c Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Fri, 21 Apr 2023 12:41:09 -0400
+Subject: [PATCH 2/5] libxl: Add support for blktap vbd3
+
+This patch re-introduces blktap support to libxl.  Unlike earlier
+versions, it does not link against any blktap library.  libxl changes
+are needed to write to the vbd3 backend XenStore nodes.
+
+blktap has three components.  tapdisk is a daemon implementing the disk
+IO, NBD (Network Block Device), and Xen PV interfaces.  tap-ctl is a
+tool to control tapdisks - creating, starting, stopping and freeing.
+tapback manages the XenStore operations and instructs tapdisk to
+connect.
+
+It is notable that tapdisk performs the grant and event channel ops, but
+doesn't interact with XenStore.  tapback performs XenStore operations
+and notifies tapdisks of values and changes.
+
+The flow is: libxl writes to the "vbd3" XenStore nodes and runs the
+block-tap script.  The block-tap script runs tap-ctl to create a tapdisk
+instance as the physical device.  tapback then sees the tapdisk and
+instructs the tapdisk to connect up the PV blkif interface.
+
+This is expected to work without the kernel blktap driver, so the
+block-tap script is modified accordingly to write the UNIX NBD path.
+
+backendtype=tap was not fully removed previously, but it would never
+succeed since it would hit the hardcoded error in disk_try_backend().
+It is reused now.
+
+An example command to attach a vhd:
+xl block-attach vm 'vdev=xvdf,backendtype=tap,format=vhd,target=/srv/target.vhd'
+
+Format raw also works to run an "aio:" tapdisk.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+VHD support is important for OpenXT since there are lots of existing
+VHDs which still need supporting.  tapdisk also supports encrypting VHDs
+which is not available in QEMU.
+---
+ docs/man/xl-disk-configuration.5.pod.in   |  4 +++-
+ tools/libs/light/libxl_device.c           | 14 ++++++++++----
+ tools/libs/light/libxl_disk.c             | 20 +++++++++++++++-----
+ tools/libs/light/libxl_linux.c            |  1 +
+ tools/libs/light/libxl_types_internal.idl |  1 +
+ tools/libs/light/libxl_utils.c            |  2 ++
+ 6 files changed, 32 insertions(+), 10 deletions(-)
+
+diff --git a/docs/man/xl-disk-configuration.5.pod.in b/docs/man/xl-disk-configuration.5.pod.in
+index bc945cc517..cb442bd5b4 100644
+--- a/docs/man/xl-disk-configuration.5.pod.in
++++ b/docs/man/xl-disk-configuration.5.pod.in
+@@ -232,7 +232,7 @@ Specifies the backend implementation to use
+ 
+ =item Supported values
+ 
+-phy, qdisk, standalone
++phy, qdisk, standalone, tap
+ 
+ =item Mandatory
+ 
+@@ -254,6 +254,8 @@ and "standalone" does not support specifications other than "virtio".
+ Normally this option should not be specified, in which case libxl will
+ automatically determine the most suitable backend.
+ 
++"tap" needs blktap's tapback to be running.
++
+ 
+ =item B<script>=I<SCRIPT>
+ 
+diff --git a/tools/libs/light/libxl_device.c b/tools/libs/light/libxl_device.c
+index 13da6e0573..ae2b71b0bf 100644
+--- a/tools/libs/light/libxl_device.c
++++ b/tools/libs/light/libxl_device.c
+@@ -328,9 +328,15 @@ static int disk_try_backend(disk_try_backend_args *a,
+         return 0;
+ 
+     case LIBXL_DISK_BACKEND_TAP:
+-        LOG(DEBUG, "Disk vdev=%s, backend tap unsuitable because blktap "
+-                   "not available", a->disk->vdev);
+-        return 0;
++        if (a->disk->format != LIBXL_DISK_FORMAT_RAW &&
++            a->disk->format != LIBXL_DISK_FORMAT_VHD)
++            goto bad_format;
++
++        if (libxl_defbool_val(a->disk->colo_enable))
++            goto bad_colo;
++
++        LOG(DEBUG, "Disk vdev=%s, returning blktap", a->disk->vdev);
++        return backend;
+ 
+     case LIBXL_DISK_BACKEND_QDISK:
+         if (a->disk->script) goto bad_script;
+@@ -478,7 +484,7 @@ char *libxl__device_disk_string_of_backend(libxl_disk_backend backend)
+ {
+     switch (backend) {
+         case LIBXL_DISK_BACKEND_QDISK: return "qdisk";
+-        case LIBXL_DISK_BACKEND_TAP: return "phy";
++        case LIBXL_DISK_BACKEND_TAP: return "vbd3";
+         case LIBXL_DISK_BACKEND_PHY: return "phy";
+         case LIBXL_DISK_BACKEND_STANDALONE: return "standalone";
+         default: return NULL;
+diff --git a/tools/libs/light/libxl_disk.c b/tools/libs/light/libxl_disk.c
+index ea3623dd6f..59ff996837 100644
+--- a/tools/libs/light/libxl_disk.c
++++ b/tools/libs/light/libxl_disk.c
+@@ -56,7 +56,9 @@ static void disk_eject_xswatch_callback(libxl__egc *egc, libxl__ev_xswatch *w,
+             "/local/domain/%d/backend/%" TOSTRING(BACKEND_STRING_SIZE)
+            "[a-z]/%*d/%*d",
+            &disk->backend_domid, backend_type);
+-    if (!strcmp(backend_type, "tap") || !strcmp(backend_type, "vbd")) {
++    if (!strcmp(backend_type, "tap") ||
++        !strcmp(backend_type, "vbd") ||
++        !strcmp(backend_type, "vbd3")) {
+         disk->backend = LIBXL_DISK_BACKEND_TAP;
+     } else if (!strcmp(backend_type, "qdisk")) {
+         disk->backend = LIBXL_DISK_BACKEND_QDISK;
+@@ -224,7 +226,7 @@ static int libxl__device_from_disk(libxl__gc *gc, uint32_t domid,
+             device->backend_kind = LIBXL__DEVICE_KIND_VBD;
+             break;
+         case LIBXL_DISK_BACKEND_TAP:
+-            device->backend_kind = LIBXL__DEVICE_KIND_VBD;
++            device->backend_kind = LIBXL__DEVICE_KIND_VBD3;
+             break;
+         case LIBXL_DISK_BACKEND_QDISK:
+             device->backend_kind = LIBXL__DEVICE_KIND_QDISK;
+@@ -368,9 +370,17 @@ static void device_disk_add(libxl__egc *egc, uint32_t domid,
+                 assert(device->backend_kind == LIBXL__DEVICE_KIND_VIRTIO_DISK);
+                 break;
+             case LIBXL_DISK_BACKEND_TAP:
+-                LOG(ERROR, "blktap is not supported");
+-                rc = ERROR_FAIL;
+-                goto out;
++                flexarray_append(back, "params");
++                flexarray_append(back, GCSPRINTF("%s:%s",
++                              libxl__device_disk_string_of_format(disk->format),
++                              disk->pdev_path ? : ""));
++
++                script = libxl__abs_path(gc, disk->script?: "block-tap",
++                                         libxl__xen_script_dir_path());
++                flexarray_append_pair(back, "script", script);
++
++                assert(device->backend_kind == LIBXL__DEVICE_KIND_VBD3);
++                break;
+             case LIBXL_DISK_BACKEND_QDISK:
+                 flexarray_append(back, "params");
+                 flexarray_append(back, GCSPRINTF("%s:%s",
+diff --git a/tools/libs/light/libxl_linux.c b/tools/libs/light/libxl_linux.c
+index f7c92ba562..0b4c8bd045 100644
+--- a/tools/libs/light/libxl_linux.c
++++ b/tools/libs/light/libxl_linux.c
+@@ -207,6 +207,7 @@ int libxl__get_hotplug_script_info(libxl__gc *gc, libxl__device *dev,
+ 
+     switch (dev->backend_kind) {
+     case LIBXL__DEVICE_KIND_VBD:
++    case LIBXL__DEVICE_KIND_VBD3:
+         if (num_exec != 0) {
+             LOGD(DEBUG, dev->domid,
+                  "num_exec %d, not running hotplug scripts", num_exec);
+diff --git a/tools/libs/light/libxl_types_internal.idl b/tools/libs/light/libxl_types_internal.idl
+index e24288f1a5..56dccac153 100644
+--- a/tools/libs/light/libxl_types_internal.idl
++++ b/tools/libs/light/libxl_types_internal.idl
+@@ -34,6 +34,7 @@ libxl__device_kind = Enumeration("device_kind", [
+     (16, "VINPUT"),
+     (17, "VIRTIO_DISK"),
+     (18, "VIRTIO"),
++    (19, "VBD3"),
+     ])
+ 
+ libxl__console_backend = Enumeration("console_backend", [
+diff --git a/tools/libs/light/libxl_utils.c b/tools/libs/light/libxl_utils.c
+index e403bd9bcf..10398a6c86 100644
+--- a/tools/libs/light/libxl_utils.c
++++ b/tools/libs/light/libxl_utils.c
+@@ -295,6 +295,8 @@ int libxl_string_to_backend(libxl_ctx *ctx, char *s, libxl_disk_backend *backend
+         *backend = LIBXL_DISK_BACKEND_PHY;
+     } else if (!strcmp(s, "file")) {
+         *backend = LIBXL_DISK_BACKEND_TAP;
++    } else if (!strcmp(s, "vbd3")) {
++        *backend = LIBXL_DISK_BACKEND_TAP;
+     } else if (!strcmp(s, "qdisk")) {
+         *backend = LIBXL_DISK_BACKEND_QDISK;
+     } else if (!strcmp(s, "standalone")) {
+-- 
+2.43.0
+

--- a/recipes-extended/xen/files/0003-hotplug-Update-block-tap.patch
+++ b/recipes-extended/xen/files/0003-hotplug-Update-block-tap.patch
@@ -1,0 +1,224 @@
+From 8bb2ec9d9f0dcabde7084b4a505ab68e6ff19bd3 Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Fri, 5 Jan 2024 14:39:04 -0500
+Subject: [PATCH 3/5] hotplug: Update block-tap
+
+Implement a sharing check like the regular block script.
+
+Checking tapback inside block-tap is too late since it needs to be
+running to transition the backend to InitWait before block-tap is run.
+
+tap-ctl check will be removed when the requirement for the blktap kernel
+driver is removed.  Remove it now as it is of limited use.
+
+find_device() needs to be non-fatal allow a sharing check.
+
+Only write physical-device-path because that is all that tapback needs.
+Also write_dev doesn't handled files and would incorrectly store
+physical-device as 0:0 which would confuse the minor inside tapback
+---
+ tools/hotplug/Linux/block-tap | 162 ++++++++++++++++++++++++++++++++--
+ 1 file changed, 153 insertions(+), 9 deletions(-)
+
+diff --git a/tools/hotplug/Linux/block-tap b/tools/hotplug/Linux/block-tap
+index 89247921b9..5eca09f0f6 100755
+--- a/tools/hotplug/Linux/block-tap
++++ b/tools/hotplug/Linux/block-tap
+@@ -37,10 +37,6 @@ check_tools()
+     if ! command -v tap-ctl > /dev/null 2>&1; then
+         fatal "Unable to find tap-ctl tool"
+     fi
+-    modprobe blktap
+-    if ! tap-ctl check >& /dev/null ; then
+-	fatal "Blocktap kernel module not available"
+-    fi
+ }
+ 
+ # Sets the following global variables based on the params field passed in as
+@@ -81,7 +77,105 @@ find_device()
+     done
+ 
+     if [ -z "$pid" ] || [ -z "$minor" ]; then
+-        fatal "cannot find required parameters"
++        return 1
++    fi
++
++    return 0
++}
++
++count_using()
++{
++  local file="$1"
++  local f
++
++  local i=0
++  local base_path="$XENBUS_BASE_PATH/$XENBUS_TYPE"
++  for dom in $(xenstore-list "$base_path")
++  do
++    for dev in $(xenstore-list "$base_path/$dom")
++    do
++      f=$(xenstore_read_default "$base_path/$dom/$dev/params" "")
++      f=$(echo "$f" | cut -d ":" -f 2)
++
++      if [ -n "$f" ] && [ "$file" = $f ] ; then
++          i=$(( i + 1 ))
++      fi
++    done
++  done
++
++  echo "$i"
++}
++
++# tap_shared is used to determine if a shared tap can be closed
++# Since a stubdom and a guest both use the same tap, it can only
++# be freed when there is a single one left.
++tap_shared() {
++    [ $( count_using "$file" ) -gt 1 ]
++}
++
++check_tap_sharing()
++{
++  local file="$1"
++  local mode="$2"
++  local dev
++
++  local base_path="$XENBUS_BASE_PATH/$XENBUS_TYPE"
++  for dom in $(xenstore-list "$base_path") ; do
++    for dev in $(xenstore-list "$base_path/$dom") ; do
++      f=$(xenstore_read_default "$base_path/$dom/$dev/params" "")
++      f=$(echo "$f" | cut -d ":" -f 2)
++
++      if [ -n "$f" ] && [ "$file" = "$f" ] ; then
++        if [ "$mode" = 'w' ] ; then
++          if ! same_vm $dom ; then
++            echo "guest $f"
++            return
++          fi
++        else
++          local m=$(xenstore_read_default "$base_path/$dom/$dev/mode" "")
++          m=$(canonicalise_mode "$m")
++
++          if [ "$m" = 'w' ] ; then
++            if ! same_vm $dom ; then
++              echo "guest $f"
++              return
++            fi
++          fi
++        fi
++      fi
++    done
++  done
++
++  echo 'ok'
++}
++
++tap_create()
++{
++    if ! minor=$( tap-ctl allocate ) ; then
++        fatal "Could not allocate minor"
++    fi
++
++    # Handle with or without kernel blktap
++    minor=${minor#/run/blktap-control/tapdisk/tapdisk-}
++    minor=${minor#/dev/xen/blktap-2/tapdev}
++
++    # tap-ctl is spawning tapdisk which would hold the _lockfd open.
++    # Ensure it is closed before running tap-ctl spawn, which needs to be
++    # done in a subshell to continue holding the lock in the parent.
++    if ! pid=$( ( eval "exec $_lockfd>&-" ; tap-ctl spawn ) ) ; then
++        tap-ctl free -m "$minor"
++        fatal "Could not spawn tapdisk for $minor"
++    fi
++
++    if ! tap-ctl attach -p "$pid" -m "$minor" ; then
++        tap-ctl free -m "$minor"
++        fatal "Could not attach $pid and $minor"
++    fi
++
++    if ! tap-ctl open -p "$pid" -m "$minor" -a "$target" ; then
++        tap-ctl detach -p "$pid" -m "$minor"
++        tap-ctl free -m "$minor"
++        fatal "Could not open \"$target\""
+     fi
+ }
+ 
+@@ -89,15 +183,57 @@ find_device()
+ # the device
+ add()
+ {
+-    dev=$(tap-ctl create -a $target)
+-    write_dev $dev
++    local minor
++    local pid
++    local res
++
++    claim_lock "block"
++
++    if find_device; then
++        result=$( check_tap_sharing "$file" "$mode" )
++        if [ "$result" != "ok" ] ; then
++            do_ebusy "tap $type file $file in use " "$mode" "${result%% *}"
++        fi
++    else
++        tap_create
++    fi
++
++    # Create nbd unix path
++    dev=$( printf "/run/blktap-control/nbd%ld.%d" "$pid" "$minor" )
++
++    xenstore_write "$XENBUS_PATH/pid" "$pid"
++    xenstore_write "$XENBUS_PATH/minor" "$minor"
++    # dev, as a unix socket, would end up with major:minor 0:0 in
++    # physical-device if write_dev were used.  tapback would be thrown off by
++    # that incorrect minor, so just skip writing physical-device.
++    xenstore_write "$XENBUS_PATH/physical-device-path" "$dev"
++
++    success
++
++    release_lock "block"
+ }
+ 
+ # Disconnects the device
+ remove()
+ {
+-    find_device
+-    do_or_die tap-ctl destroy -p ${pid} -m ${minor} > /dev/null
++    local minor
++    local pid
++
++    claim_lock "block"
++
++    if tap_shared ; then
++        return
++    fi
++
++    minor=$( xenstore_read "$XENBUS_PATH/minor" )
++    pid=$( xenstore_read "$XENBUS_PATH/pid" )
++
++    [ -n "$minor" ] || fatal "minor missing"
++    [ -n "$pid" ] || fatal "pid missing"
++    do_or_die tap-ctl close -p "$pid" -m "$minor" > /dev/null
++    do_or_die tap-ctl detach -p "$pid" -m "$minor" > /dev/null
++
++    release_lock "block"
+ }
+ 
+ command=$1
+@@ -110,6 +246,14 @@ parse_target "$target"
+ 
+ check_tools || exit 1
+ 
++mode=$( xenstore_read $XENBUS_PATH/mode )
++mode=$( canonicalise_mode $mode )
++
++# needed for same_vm
++FRONTEND_ID=$(xenstore_read "$XENBUS_PATH/frontend-id")
++FRONTEND_UUID=$(xenstore_read_default \
++                    "/local/domain/$FRONTEND_ID/vm" 'unknown')
++
+ case $command in
+ add)
+     add
+-- 
+2.43.0
+

--- a/recipes-extended/xen/files/0004-libxl-Support-blktap-with-HVM-device-model.patch
+++ b/recipes-extended/xen/files/0004-libxl-Support-blktap-with-HVM-device-model.patch
@@ -1,0 +1,67 @@
+From 47a9f91205bfe2ec00212ef11994c4a17669ca59 Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Mon, 24 Apr 2023 08:19:40 -0400
+Subject: [PATCH 4/5] libxl: Support blktap with HVM device model
+
+blktap exposes disks over UNIX socket Network Block Device (NBD).
+Modify libxl__device_disk_find_local_path() to provide back the
+QEMU-formatted NBD path.  This allows tapdisk to be used for booting an
+HVM.
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tools/libs/light/libxl_disk.c | 17 +++++++++++++----
+ tools/libs/light/libxl_dm.c   |  1 -
+ 2 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/tools/libs/light/libxl_disk.c b/tools/libs/light/libxl_disk.c
+index 59ff996837..525ae0db97 100644
+--- a/tools/libs/light/libxl_disk.c
++++ b/tools/libs/light/libxl_disk.c
+@@ -1317,7 +1317,8 @@ char *libxl__device_disk_find_local_path(libxl__gc *gc,
+      * If the format isn't raw and / or we're using a script, then see
+      * if the script has written a path to the "cooked" node
+      */
+-    if (disk->script && guest_domid != INVALID_DOMID) {
++    if ((disk->script && guest_domid != INVALID_DOMID) ||
++        disk->backend == LIBXL_DISK_BACKEND_TAP) {
+         libxl__device device;
+         char *be_path, *pdpath;
+         int rc;
+@@ -1337,10 +1338,18 @@ char *libxl__device_disk_find_local_path(libxl__gc *gc,
+         LOGD(DEBUG, guest_domid, "Attempting to read node %s", pdpath);
+         path = libxl__xs_read(gc, XBT_NULL, pdpath);
+ 
+-        if (path)
++        if (path) {
+             LOGD(DEBUG, guest_domid, "Accessing cooked block device %s", path);
+-        else
+-            LOGD(DEBUG, guest_domid, "No physical-device-path, can't access locally.");
++
++            /* tapdisk exposes disks locally over UNIX socket NBD. */
++            if (disk->backend == LIBXL_DISK_BACKEND_TAP) {
++                path = libxl__sprintf(gc, "nbd:unix:%s", path);
++                LOGD(DEBUG, guest_domid,
++                     "Directly accessing local TAP target %s", path);
++            }
++        } else
++            LOGD(DEBUG, guest_domid,
++                "No physical-device-path, can't access locally.");
+ 
+         goto out;
+     }
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index 14b593110f..f7c796011d 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -1915,7 +1915,6 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
+                     continue;
+                 }
+ 
+-                assert(disks[i].backend != LIBXL_DISK_BACKEND_TAP);
+                 target_path = libxl__device_disk_find_local_path(gc,
+                                     guest_domid, &disks[i], true);
+ 
+-- 
+2.43.0
+

--- a/recipes-extended/xen/files/0005-libxl-Switch-to-ndb-unix-format.patch
+++ b/recipes-extended/xen/files/0005-libxl-Switch-to-ndb-unix-format.patch
@@ -1,0 +1,29 @@
+From 97ac5c34369525cc53f264238fd2fb870f4f5933 Mon Sep 17 00:00:00 2001
+From: Jason Andryuk <jandryuk@gmail.com>
+Date: Fri, 28 Apr 2023 13:29:45 -0400
+Subject: [PATCH 5/5] libxl: Switch to ndb+unix:/// format
+
+Switch to the URI format specified by the protocol at
+https://github.com/NetworkBlockDevice/nbd/blob/master/doc/uri.md
+
+Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
+---
+ tools/libs/light/libxl_disk.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_disk.c b/tools/libs/light/libxl_disk.c
+index 525ae0db97..b65cad33cc 100644
+--- a/tools/libs/light/libxl_disk.c
++++ b/tools/libs/light/libxl_disk.c
+@@ -1343,7 +1343,7 @@ char *libxl__device_disk_find_local_path(libxl__gc *gc,
+ 
+             /* tapdisk exposes disks locally over UNIX socket NBD. */
+             if (disk->backend == LIBXL_DISK_BACKEND_TAP) {
+-                path = libxl__sprintf(gc, "nbd:unix:%s", path);
++                path = libxl__sprintf(gc, "nbd+unix:///?socket=%s", path);
+                 LOGD(DEBUG, guest_domid,
+                      "Directly accessing local TAP target %s", path);
+             }
+-- 
+2.43.0
+

--- a/recipes-extended/xen/files/libxl-vwif-support.patch
+++ b/recipes-extended/xen/files/libxl-vwif-support.patch
@@ -57,7 +57,7 @@ PATCHES
 ################################################################################
 --- a/tools/libs/light/libxl_device.c
 +++ b/tools/libs/light/libxl_device.c
-@@ -825,7 +825,8 @@ int libxl__device_destroy(libxl__gc *gc,
+@@ -831,7 +831,8 @@ int libxl__device_destroy(libxl__gc *gc,
              libxl__xs_path_cleanup(gc, t, be_path);
          }
  
@@ -67,7 +67,7 @@ PATCHES
              libxl__xs_path_cleanup(gc, t, be_path);
          }
  
-@@ -1371,7 +1372,9 @@ static void device_destroy_be_watch_cb(l
+@@ -1377,7 +1378,9 @@ static void device_destroy_be_watch_cb(l
       * in xenstore. NDVM doesn't do that, so let's not wait forever
       * here. libxl will take care of the xenstore nodes later
       */
@@ -78,7 +78,7 @@ PATCHES
          /* backend path still exists, wait a little longer... */
          return;
      }
-@@ -1505,6 +1508,15 @@ int libxl__device_nextid(libxl__gc *gc,
+@@ -1511,6 +1514,15 @@ int libxl__device_nextid(libxl__gc *gc,
      else
          nextid = strtoul(l[nb - 1], NULL, 10) + 1;
  
@@ -112,7 +112,7 @@ PATCHES
                  flexarray_append(dm_args, "-netdev");
                  flexarray_append(dm_args,
                                   GCSPRINTF("type=tap,id=net%d,ifname=%s,"
-@@ -2102,6 +2105,9 @@ static void libxl__dm_vifs_from_hvm_gues
+@@ -2101,6 +2104,9 @@ static void libxl__dm_vifs_from_hvm_gues
      for (i=0; i<nr; i++) {
          dm_config->nics[i] = guest_config->nics[i];
          dm_config->nics[i].nictype = LIBXL_NIC_TYPE_VIF;
@@ -134,7 +134,7 @@ PATCHES
          libxl_nic_type nictype;
          char *gatewaydev;
  
-@@ -216,6 +217,7 @@ int libxl__get_hotplug_script_info(libxl
+@@ -217,6 +218,7 @@ int libxl__get_hotplug_script_info(libxl
          rc = libxl__hotplug_disk(gc, dev, args, env, action);
          break;
      case LIBXL__DEVICE_KIND_VIF:
@@ -281,11 +281,11 @@ PATCHES
      ("coloft_forwarddev", string),
 --- a/tools/libs/light/libxl_types_internal.idl
 +++ b/tools/libs/light/libxl_types_internal.idl
-@@ -34,6 +34,7 @@ libxl__device_kind = Enumeration("device
-     (16, "VINPUT"),
+@@ -35,6 +35,7 @@ libxl__device_kind = Enumeration("device
      (17, "VIRTIO_DISK"),
      (18, "VIRTIO"),
-+    (19, "VWIF"),
+     (19, "VBD3"),
++    (20, "VWIF"),
      ])
  
  libxl__console_backend = Enumeration("console_backend", [

--- a/recipes-extended/xen/xen-common.inc
+++ b/recipes-extended/xen/xen-common.inc
@@ -25,6 +25,13 @@ SRC_URI_append = " \
     file://acpi-slic-support.patch \
     file://tboot-xen-evtlog-support.patch \
     file://add-xc-hypercall-page.patch \
+    \
+    file://0001-block-common-Fix-same_vm-for-no-targets.patch \
+    file://0002-libxl-Add-support-for-blktap-vbd3.patch \
+    file://0003-hotplug-Update-block-tap.patch \
+    file://0004-libxl-Support-blktap-with-HVM-device-model.patch \
+    file://0005-libxl-Switch-to-ndb-unix-format.patch \
+    \
     file://libxl-syslog.patch \
     file://libxl-vif-cleanup.patch \
     file://libxl-vif-make-ioemu-and-stubdom-mac-addresses-configurable.patch \

--- a/recipes-kernel/linux/6.1/patches/blktap2.patch
+++ b/recipes-kernel/linux/6.1/patches/blktap2.patch
@@ -482,7 +482,7 @@ PATCHES
 +
 +static struct miscdevice blktap_control = {
 +	.minor    = MISC_DYNAMIC_MINOR,
-+	.name     = "blktap-control",
++	.name     = "blktap/control",
 +	.fops     = &blktap_control_file_operations,
 +};
 +

--- a/recipes-security/refpolicy/refpolicy-mcs/patches/blktap-interfaces.diff
+++ b/recipes-security/refpolicy/refpolicy-mcs/patches/blktap-interfaces.diff
@@ -1,12 +1,13 @@
 --- a/policy/modules/apps/qemu.te
 +++ b/policy/modules/apps/qemu.te
-@@ -133,6 +133,11 @@ optional_policy(`
+@@ -133,6 +133,12 @@ optional_policy(`
  # Unconfined local policy
  #
  
 +# qemu emulates disk for early boot code
 +optional_policy(`
 +	blktap_rw_blk_file(qemu_t)
++	tapdisk_stream_connect(qemu_t)
 +')
 +
  optional_policy(`

--- a/recipes-security/refpolicy/refpolicy-mcs/policy/modules/services/blktap.fc
+++ b/recipes-security/refpolicy/refpolicy-mcs/policy/modules/services/blktap.fc
@@ -24,6 +24,7 @@
 /usr/sbin/tap-ctl		--	gen_context(system_u:object_r:tapctl_exec_t,s0)
 /dev/xen/control		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/blktap-control		-c	gen_context(system_u:object_r:blktap_device_t,s0)
+/dev/blktap/control		-c	gen_context(system_u:object_r:blktap_device_t,s0)
 /dev/shm/metrics(/.*)?			gen_context(system_u:object_r:tapdisk_tmpfs_t,s0)
 /dev/shm/td3-[0-9]+-[0-9]+(/.*)?	gen_context(system_u:object_r:tapdisk_tmpfs_t,s0)
 /dev/shm/vbd3-[0-9]+-[0-9]+(/.*)?	gen_context(system_u:object_r:tapdisk_tmpfs_t,s0)


### PR DESCRIPTION
The Xen 4.14 uprev dropped libxl blktap integration.  The data path became:
blkfront <-> blkback <-> /dev/xen/blktap-2/tapdevX <-> tapdisk <-> vhd

This PR introduces upstream-able libxl patches to switch to:
blkfront <-> tapdisk <-> .vhd

Goes with https://github.com/OpenXT/manager/pull/209